### PR TITLE
[CBRD-26921] Extend remote DELETE with a local uncorrelated subquery to comparison ANY/ALL and remote-only AND

### DIFF
--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -728,6 +728,9 @@ extern "C"
   extern int pt_check_dblink_column_alias (PARSER_CONTEXT * parser, PT_NODE * dblink);
   extern int pt_dblink_get_remote_col_charset (void *remote_col_list, const char *col_name);
   extern PT_NODE *pt_count_name_nodes (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk);
+
+  extern bool pt_dblink_delete_is_driving_pred (PT_NODE * cond);
+  extern PT_NODE *pt_dblink_delete_and_tree_find_driving (PT_NODE * node);
 #ifdef __cplusplus
 }
 #endif

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -730,6 +730,7 @@ extern "C"
   extern PT_NODE *pt_count_name_nodes (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk);
 
   extern bool pt_dblink_delete_is_driving_pred (PT_NODE * cond);
+  extern bool pt_dblink_delete_is_remote_only_conjunct (PT_NODE * conjunct);
   extern PT_NODE *pt_dblink_delete_and_tree_find_driving (PT_NODE * node);
 #ifdef __cplusplus
 }

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -11944,10 +11944,10 @@ pt_dblink_delete_is_driving_pred (PT_NODE * cond)
  * pt_dblink_find_remote_spec () - parser_walk_tree pre-function: set *arg to true when the subtree still holds a
  *   spec carrying a remote server name (tbl@srv).
  *
- *   Only the INSERT SELECT sink rewrites such specs into dblink derived tables (pt_check_sub_query_spec); the
- *   remote DELETE sink does not.  Name resolution deliberately leaves flat_entity_list / spec.id unset on a
- *   remote spec because it expects that rewrite to happen, so a remote spec left inside a DELETE WHERE subquery
- *   reaches the optimizer half-built and crashes there.  Used below to keep the DELETE carve-out off that shape.
+ *   pt_check_sub_query_spec (both INSERT SELECT and, below, DELETE) rewrites such a spec into a dblink derived
+ *   table when it's on the same server as the DML target; a cross-server spec is never handed to it. Name
+ *   resolution leaves flat_entity_list / spec.id unset on a remote spec expecting that rewrite, so any spec this
+ *   walk still finds would reach the optimizer half-built and crash. Used below to keep the carve-out off that.
  */
 static PT_NODE *
 pt_dblink_find_remote_spec (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk)
@@ -12396,7 +12396,7 @@ pt_convert_dblink_dml_query (PARSER_CONTEXT * parser, PT_NODE * node,
 {
   int i;
   int tmp_server_cnt = snl->server_cnt;
-  int sub_sel_server_cnt = 0;	/* remote server count found in INSERT SELECT subquery */
+  int sub_sel_server_cnt = 0;	/* remote server count found in the INSERT SELECT or DELETE WHERE subquery */
   unsigned int save_custom_print;
 
   PT_NODE *sub_sel = NULL;	/* for select sub-query */
@@ -12426,6 +12426,20 @@ pt_convert_dblink_dml_query (PARSER_CONTEXT * parser, PT_NODE * node,
       break;
     case PT_DELETE:
       upd_spec = node->info.delete_.spec;
+      if (snl->sink_kind == DBLINK_REMOTE_SINK_DELETE_LOCAL_SUBQ)
+	{
+	  /* Detect a remote spec in the WHERE subquery, mirroring INSERT's sub_sel_server_cnt; the actual
+	   * same-server-mixed conversion is further down, mirroring the INSERT_SELECT post-switch block.
+	   * Scoped to driving->arg2 so the delta reflects the subquery alone; the broader upd_spec walk
+	   * below re-walks the whole statement and adds to the same counters, harmlessly (those are never
+	   * relied on for an exact count). */
+	  PT_NODE *driving = pt_dblink_delete_and_tree_find_driving (node->info.delete_.search_cond);
+	  if (driving != NULL)
+	    {
+	      parser_walk_tree (parser, driving->info.expr.arg2, pt_get_server_name_list, snl, NULL, NULL);
+	      sub_sel_server_cnt = snl->server_cnt - tmp_server_cnt;
+	    }
+	}
       break;
     case PT_UPDATE:
       upd_spec = node->info.update.spec;
@@ -12490,18 +12504,44 @@ pt_convert_dblink_dml_query (PARSER_CONTEXT * parser, PT_NODE * node,
 	}
     }
 
-  /* remote DELETE + local subquery: keep the carve-out only when the WHERE subquery is purely local
-   * (references local tables, no second/other remote server, no dblink() function). Otherwise clear it so
-   * the existing guards below apply: same-server all-remote subquery falls through to full pushdown, while
-   * multi-remote (distinct_cnt >= 2) and dblink() forms are rejected.
+  /* Same-server mixed WHERE subquery (local + remote, all on the target server) -- mirrors the
+   * INSERT_SELECT block above. Convert the embedded remote spec(s) into dblink derived-table scans so
+   * the subquery compiles as an ordinary local-side query (join against a derived table); this needs no
+   * runtime change since the DELETE sink's aptr already compiles/executes whatever subquery
+   * pt_to_delete_xasl_remote_subquery is handed, generically. */
+  if (snl->sink_kind == DBLINK_REMOTE_SINK_DELETE_LOCAL_SUBQ && sub_sel_server_cnt > 0)
+    {
+      if (snl->local_cnt > 0 && snl->distinct_cnt == 1)
+	{
+	  PT_NODE *driving = pt_dblink_delete_and_tree_find_driving (node->info.delete_.search_cond);
+	  bool had_dblink_before = snl->has_dblink_query;
+
+	  if (driving != NULL)
+	    {
+	      parser_walk_tree (parser, driving->info.expr.arg2, pt_check_sub_query_spec, snl, NULL, NULL);
+	    }
+	  /* The rewrite marks the spec PT_DERIVED_DBLINK_TABLE, which pt_get_server_name_list treats like a
+	   * real dblink() call, flipping has_dblink_query. INSERT SELECT is exempt from the has_dblink_query
+	   * rejection below ("!= DBLINK_REMOTE_SINK_INSERT_SELECT"); DELETE isn't, so snapshot/restore instead
+	   * -- only a dblink() already present before this call still trips that rejection. */
+	  if (!had_dblink_before)
+	    {
+	      snl->has_dblink_query = false;
+	    }
+	}
+      else
+	{
+	  snl->sink_kind = DBLINK_REMOTE_SINK_NONE;
+	}
+    }
+
+  /* remote DELETE + local subquery: keep the carve-out only when no remote spec is left unconverted (the
+   * block above only converts same-server ones). Otherwise clear it: same-server all-remote falls through to
+   * full pushdown, multi-remote/dblink() forms are rejected.
    *
-   * The counters alone do not establish "purely local": local_cnt > 0 holds as soon as one local table is
-   * referenced and distinct_cnt == 1 holds when the only remote server is the target's, so a subquery mixing a
-   * local table with a same-server remote one satisfies both. Walk the WHERE clause for a surviving remote spec
-   * to exclude that shape -- the sink evaluates the subquery locally but nothing rewrites a remote spec inside it
-   * into a dblink derived table (pt_check_sub_query_spec runs for the INSERT SELECT sink only), so it would reach
-   * the optimizer half-built. Supporting the mixed shape is a separate change; here it keeps the pre-existing
-   * "local mixed remote DML is not allowed" rejection. */
+   * local_cnt > 0 and distinct_cnt == 1 don't establish this alone -- both hold whether or not the same-server
+   * remote spec got converted. Walk the WHERE for a surviving (cross-server) spec instead: nothing rewrites
+   * those, and left in place they'd reach the optimizer half-built. */
   if (snl->sink_kind == DBLINK_REMOTE_SINK_DELETE_LOCAL_SUBQ)
     {
       bool cond_has_remote_spec = false;

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -11891,52 +11891,40 @@ pt_convert_dblink_insert_query (PARSER_CONTEXT * parser, PT_NODE * node, SERVER_
   return;
 }
 
-/* true iff the DELETE WHERE clause is a single positive predicate over a subquery whose shape is a
- * sink candidate: col IN (subquery), col {= | <> | < | > | <= | >=} ANY (subquery), a scalar comparison
- * col {= | <> | < | > | <= | >=} (subquery), or col {= | < | > | <= | >=} ALL (subquery). This only
- * gates the predicate *shape*; how each shape is executed (per-row push vs. a reduced single value) is
- * decided downstream in XASL generation. Forms excluded here fall through to the existing "local mixed
- * remote DML is not allowed" rejection: OR / multiple predicates (op PT_OR/PT_AND or a CNF list, caught
- * by op or cond->next), col <> ALL (PT_NE_ALL is excluded: whole-set semantics equivalent to NOT IN, not
- * value-push), negation of IN (PT_IS_NOT_IN), EXISTS, and a value-list IN (arg2 is not a query).
- *
- * Correlation and row/multi-column subqueries are NOT decided here. query.correlation_level is 0 for a DELETE
- * WHERE subquery (a DELETE target is not a query scope), so it cannot flag a target-correlated subquery at this
- * point. A correlated or row subquery that passes this shape gate is routed to the sink and rejected later, where
- * the reference to the outer target (or the multi-column shape) is resolvable: pt_dblink_delete_corr_ref()
- * (semantic_check.c) rejects correlated subqueries, and pt_to_delete_xasl_remote_subquery() (xasl_generation.c)
- * rejects row/multi-column subqueries. */
+/* true iff cond is a driving predicate over a subquery: col IN (subquery), col {= | <> | < | > | <= |
+ * >=} ANY (subquery), a scalar comparison, or col {= | < | > | <= | >=} ALL (subquery). PT_NE_ALL is
+ * excluded: whole-set (NOT IN) semantics, not value-push. This only gates predicate *shape*; how each
+ * shape executes is decided in XASL generation. */
 static bool
-pt_dblink_delete_where_is_inscope (PT_NODE * node)
+pt_dblink_delete_is_driving_pred (PT_NODE * cond)
 {
-  PT_NODE *cond = node->info.delete_.search_cond;
   PT_NODE *arg2;
 
-  if (cond == NULL || cond->next != NULL || cond->node_type != PT_EXPR)
+  if (cond == NULL || cond->node_type != PT_EXPR)
     {
       return false;
     }
 
   switch (cond->info.expr.op)
     {
-    case PT_IS_IN:		/* col IN (subquery) */
-    case PT_EQ_SOME:		/* col = ANY (subquery) */
-    case PT_NE_SOME:		/* col <> ANY (subquery) */
-    case PT_LT_SOME:		/* col < ANY (subquery) */
-    case PT_GT_SOME:		/* col > ANY (subquery) */
-    case PT_LE_SOME:		/* col <= ANY (subquery) */
-    case PT_GE_SOME:		/* col >= ANY (subquery) */
-    case PT_EQ:		/* scalar: col {= | <> | < | > | <= | >=} (subquery) */
+    case PT_IS_IN:
+    case PT_EQ_SOME:
+    case PT_NE_SOME:
+    case PT_LT_SOME:
+    case PT_GT_SOME:
+    case PT_LE_SOME:
+    case PT_GE_SOME:
+    case PT_EQ:
     case PT_NE:
     case PT_LT:
     case PT_GT:
     case PT_LE:
     case PT_GE:
-    case PT_EQ_ALL:		/* col = ALL (subquery) */
-    case PT_LT_ALL:		/* col < ALL (subquery) */
-    case PT_GT_ALL:		/* col > ALL (subquery) */
-    case PT_LE_ALL:		/* col <= ALL (subquery) */
-    case PT_GE_ALL:		/* col >= ALL (subquery) */
+    case PT_EQ_ALL:
+    case PT_LT_ALL:
+    case PT_GT_ALL:
+    case PT_LE_ALL:
+    case PT_GE_ALL:
       break;
     default:
       return false;
@@ -11945,7 +11933,7 @@ pt_dblink_delete_where_is_inscope (PT_NODE * node)
   arg2 = cond->info.expr.arg2;
   if (arg2 == NULL || !PT_IS_QUERY (arg2))
     {
-      return false;		/* RHS must be a subquery, not a value list or column */
+      return false;
     }
 
   return true;
@@ -12049,6 +12037,92 @@ pt_dblink_delete_qualifier_names_target (PT_NODE * node, const char **bad_qualif
     }
 
   return false;
+}
+
+/* true iff conjunct is a "remote-only" AND arm: col {= | <> | < | > | <= | >=} literal, nothing else
+ * (no subquery/dblink()/function/cast on either side). Single-target scope means a bare column can
+ * only resolve to the remote target, so this shape doubles as the local-reference guard. */
+static bool
+pt_dblink_delete_is_remote_only_conjunct (PT_NODE * conjunct)
+{
+  PT_NODE *arg1, *arg2;
+
+  if (conjunct == NULL || conjunct->node_type != PT_EXPR)
+    {
+      return false;
+    }
+
+  switch (conjunct->info.expr.op)
+    {
+    case PT_EQ:
+    case PT_NE:
+    case PT_LT:
+    case PT_GT:
+    case PT_LE:
+    case PT_GE:
+      break;
+    default:
+      return false;
+    }
+
+  arg1 = conjunct->info.expr.arg1;
+  arg2 = conjunct->info.expr.arg2;
+
+  return arg1 != NULL && arg1->node_type == PT_NAME && arg2 != NULL && arg2->node_type == PT_VALUE;
+}
+
+/* Walks the pre-CNF PT_AND tree rooted at node (carve-out runs before CNF, so multiple conjuncts are
+ * still one PT_AND tree, not a cond->next list): every leaf must be the one driving predicate or a
+ * remote-only conjunct. *driving_seen counts driving leaves found so far; a second one, an OR, or any
+ * other shape fails the gate. Recursion is manual, not parser_walk_tree(), so the driving predicate's
+ * own subquery arm is never descended into. */
+static bool
+pt_dblink_delete_and_tree_is_inscope (PT_NODE * node, int *driving_seen)
+{
+  if (node == NULL || node->node_type != PT_EXPR)
+    {
+      return false;
+    }
+
+  if (node->info.expr.op == PT_AND)
+    {
+      return (pt_dblink_delete_and_tree_is_inscope (node->info.expr.arg1, driving_seen)
+	      && pt_dblink_delete_and_tree_is_inscope (node->info.expr.arg2, driving_seen));
+    }
+
+  if (pt_dblink_delete_is_driving_pred (node))
+    {
+      (*driving_seen)++;
+      return *driving_seen == 1;
+    }
+
+  return pt_dblink_delete_is_remote_only_conjunct (node);
+}
+
+/* true iff the DELETE WHERE clause is in scope for the remote-sink-with-local-subquery carve-out:
+ * exactly one driving predicate (see pt_dblink_delete_is_driving_pred) plus zero or more remote-only AND
+ * arms (see pt_dblink_delete_is_remote_only_conjunct). A WHERE with no AND is just the driving predicate
+ * by itself, so this subsumes the single-predicate case.
+ *
+ * Correlation and row/multi-column subqueries are NOT decided here. query.correlation_level is 0 for a DELETE
+ * WHERE subquery (a DELETE target is not a query scope), so it cannot flag a target-correlated subquery at this
+ * point. A correlated or row subquery that passes this shape gate is routed to the sink and rejected later, where
+ * the reference to the outer target (or the multi-column shape) is resolvable: pt_dblink_delete_corr_ref()
+ * (semantic_check.c) rejects correlated subqueries, and pt_to_delete_xasl_remote_subquery() (xasl_generation.c)
+ * rejects row/multi-column subqueries. (semantic_check.c's PT_DELETE branch notes a gap this AND-tree widening
+ * creates in that correlation check.) */
+static bool
+pt_dblink_delete_where_is_inscope (PT_NODE * node)
+{
+  PT_NODE *cond = node->info.delete_.search_cond;
+  int driving_seen = 0;
+
+  if (cond == NULL || cond->next != NULL)
+    {
+      return false;		/* defensive: carve-out runs pre-CNF, so a cond->next list is unexpected here */
+    }
+
+  return pt_dblink_delete_and_tree_is_inscope (cond, &driving_seen) && driving_seen == 1;
 }
 
 static void

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -12042,8 +12042,10 @@ pt_dblink_delete_qualifier_names_target (PT_NODE * node, const char **bad_qualif
 
 /* true iff conjunct is a "remote-only" AND arm: col {= | <> | < | > | <= | >=} literal, nothing else
  * (no subquery/dblink()/function/cast on either side). Single-target scope means a bare column can
- * only resolve to the remote target, so this shape doubles as the local-reference guard. */
-static bool
+ * only resolve to the remote target, so this shape doubles as the local-reference guard. Shared
+ * (non-static) with xasl_generation.c, which re-checks this shape before deparsing a non-driving leaf
+ * -- if the gate and the deparse walk ever drift apart, the leaf is rejected instead of shipped as-is. */
+bool
 pt_dblink_delete_is_remote_only_conjunct (PT_NODE * conjunct)
 {
   PT_NODE *arg1, *arg2;

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -11891,12 +11891,12 @@ pt_convert_dblink_insert_query (PARSER_CONTEXT * parser, PT_NODE * node, SERVER_
   return;
 }
 
-/* true iff the DELETE WHERE clause is a single positive predicate over a subquery that the phase-1
- * value-push sink supports by shape: col IN (subquery), col = ANY (subquery), or a scalar comparison
- * col {= | < | > | <= | >=} (subquery). Forms excluded here fall through to the existing "local mixed remote
- * DML is not allowed" rejection: OR / multiple predicates (op PT_OR/PT_AND or a CNF list, caught by op or
- * cond->next), comparison ANY/ALL (PT_*_SOME except PT_EQ_SOME, PT_*_ALL), negation (PT_IS_NOT_IN, PT_NE),
- * EXISTS, and a value-list IN (arg2 is not a query).
+/* true iff the DELETE WHERE clause is a single positive predicate over a subquery that the value-push
+ * sink supports by shape: col IN (subquery), col {= | <> | < | > | <= | >=} ANY (subquery), or a scalar
+ * comparison col {= | <> | < | > | <= | >=} (subquery). Forms excluded here fall through to the existing
+ * "local mixed remote DML is not allowed" rejection: OR / multiple predicates (op PT_OR/PT_AND or a CNF
+ * list, caught by op or cond->next), comparison ALL (PT_*_ALL), negation of IN (PT_IS_NOT_IN), EXISTS, and
+ * a value-list IN (arg2 is not a query).
  *
  * Correlation and row/multi-column subqueries are NOT decided here. query.correlation_level is 0 for a DELETE
  * WHERE subquery (a DELETE target is not a query scope), so it cannot flag a target-correlated subquery at this
@@ -11919,7 +11919,13 @@ pt_dblink_delete_where_is_inscope (PT_NODE * node)
     {
     case PT_IS_IN:		/* col IN (subquery) */
     case PT_EQ_SOME:		/* col = ANY (subquery) */
-    case PT_EQ:		/* scalar: col {= | < | > | <= | >=} (subquery) */
+    case PT_NE_SOME:		/* col <> ANY (subquery) */
+    case PT_LT_SOME:		/* col < ANY (subquery) */
+    case PT_GT_SOME:		/* col > ANY (subquery) */
+    case PT_LE_SOME:		/* col <= ANY (subquery) */
+    case PT_GE_SOME:		/* col >= ANY (subquery) */
+    case PT_EQ:		/* scalar: col {= | <> | < | > | <= | >=} (subquery) */
+    case PT_NE:
     case PT_LT:
     case PT_GT:
     case PT_LE:

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -11894,8 +11894,9 @@ pt_convert_dblink_insert_query (PARSER_CONTEXT * parser, PT_NODE * node, SERVER_
 /* true iff cond is a driving predicate over a subquery: col IN (subquery), col {= | <> | < | > | <= |
  * >=} ANY (subquery), a scalar comparison, or col {= | < | > | <= | >=} ALL (subquery). PT_NE_ALL is
  * excluded: whole-set (NOT IN) semantics, not value-push. This only gates predicate *shape*; how each
- * shape executes is decided in XASL generation. */
-static bool
+ * shape executes is decided in XASL generation. Shared (non-static) with semantic_check.c and
+ * xasl_generation.c via pt_dblink_delete_and_tree_find_driving() below and parser.h. */
+bool
 pt_dblink_delete_is_driving_pred (PT_NODE * cond)
 {
   PT_NODE *arg2;
@@ -12109,8 +12110,9 @@ pt_dblink_delete_and_tree_is_inscope (PT_NODE * node, int *driving_seen)
  * point. A correlated or row subquery that passes this shape gate is routed to the sink and rejected later, where
  * the reference to the outer target (or the multi-column shape) is resolvable: pt_dblink_delete_corr_ref()
  * (semantic_check.c) rejects correlated subqueries, and pt_to_delete_xasl_remote_subquery() (xasl_generation.c)
- * rejects row/multi-column subqueries. (semantic_check.c's PT_DELETE branch notes a gap this AND-tree widening
- * creates in that correlation check.) */
+ * rejects row/multi-column subqueries. Both locate the driving predicate via
+ * pt_dblink_delete_and_tree_find_driving() below, so they see the same node regardless of whether it's
+ * combined with remote-only AND arms. */
 static bool
 pt_dblink_delete_where_is_inscope (PT_NODE * node)
 {
@@ -12123,6 +12125,31 @@ pt_dblink_delete_where_is_inscope (PT_NODE * node)
     }
 
   return pt_dblink_delete_and_tree_is_inscope (cond, &driving_seen) && driving_seen == 1;
+}
+
+/* Returns the sole driving predicate node within node's pre-CNF WHERE tree (node itself, if node isn't
+ * PT_AND), or NULL if none is found. Callers rely on pt_dblink_delete_where_is_inscope() having already
+ * validated the shape (exactly one driving predicate); this just locates it, e.g. so semantic_check.c
+ * can bind/correlation-check its subquery and xasl_generation.c can read its op/columns -- both must
+ * locate the *same* node the gate validated, which is why this traversal lives here and is shared
+ * rather than reimplemented per caller. */
+PT_NODE *
+pt_dblink_delete_and_tree_find_driving (PT_NODE * node)
+{
+  PT_NODE *found;
+
+  if (node == NULL || node->node_type != PT_EXPR)
+    {
+      return NULL;
+    }
+
+  if (node->info.expr.op == PT_AND)
+    {
+      found = pt_dblink_delete_and_tree_find_driving (node->info.expr.arg1);
+      return (found != NULL) ? found : pt_dblink_delete_and_tree_find_driving (node->info.expr.arg2);
+    }
+
+  return pt_dblink_delete_is_driving_pred (node) ? node : NULL;
 }
 
 static void

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -12080,14 +12080,24 @@ pt_dblink_delete_is_remote_only_conjunct (PT_NODE * conjunct)
   return arg1 != NULL && arg1->node_type == PT_NAME && arg2 != NULL && arg2->node_type == PT_VALUE;
 }
 
-/* Walks the pre-CNF PT_AND tree rooted at node (carve-out runs before CNF, so multiple conjuncts are
- * still one PT_AND tree, not a cond->next list): every leaf must be the one driving predicate or a
- * remote-only conjunct. *driving_seen counts driving leaves found so far; a second one, an OR, or any
- * other shape fails the gate. Recursion is manual, not parser_walk_tree(), so the driving predicate's
- * own subquery arm is never descended into. */
+/* The one traversal of a DELETE WHERE tree, answering both questions the carve-out asks: is the shape in
+ * scope (return value), and which leaf is the driving predicate (*driving). Both callers below are thin
+ * wrappers, so the gate and every later phase classify leaves the same way by construction.
+ *
+ * The tree is pre-CNF (the carve-out runs before CNF), so multiple conjuncts are still one PT_AND tree
+ * rather than a cond->next list. In scope means: every leaf is either the single driving predicate
+ * (pt_dblink_delete_is_driving_pred) or a remote-only conjunct (pt_dblink_delete_is_remote_only_conjunct);
+ * a second driving predicate, an OR, or any other shape fails. Recursion is manual, not
+ * parser_walk_tree(), so the driving predicate's own subquery arm is never descended into.
+ *
+ * Both AND arms are walked even after one fails, so *driving is found wherever it sits. Later phases rely
+ * on that: they locate the node the gate validated, and by then a rewrite may have left an arm in a shape
+ * this walk no longer accepts. */
 static bool
-pt_dblink_delete_and_tree_is_inscope (PT_NODE * node, int *driving_seen)
+pt_dblink_delete_and_tree_walk (PT_NODE * node, PT_NODE ** driving)
 {
+  bool arg1_ok, arg2_ok;
+
   if (node == NULL || node->node_type != PT_EXPR)
     {
       return false;
@@ -12095,14 +12105,19 @@ pt_dblink_delete_and_tree_is_inscope (PT_NODE * node, int *driving_seen)
 
   if (node->info.expr.op == PT_AND)
     {
-      return (pt_dblink_delete_and_tree_is_inscope (node->info.expr.arg1, driving_seen)
-	      && pt_dblink_delete_and_tree_is_inscope (node->info.expr.arg2, driving_seen));
+      arg1_ok = pt_dblink_delete_and_tree_walk (node->info.expr.arg1, driving);
+      arg2_ok = pt_dblink_delete_and_tree_walk (node->info.expr.arg2, driving);
+      return arg1_ok && arg2_ok;
     }
 
   if (pt_dblink_delete_is_driving_pred (node))
     {
-      (*driving_seen)++;
-      return *driving_seen == 1;
+      if (*driving != NULL)
+	{
+	  return false;		/* a second driving predicate: out of scope */
+	}
+      *driving = node;
+      return true;
     }
 
   return pt_dblink_delete_is_remote_only_conjunct (node);
@@ -12125,39 +12140,29 @@ static bool
 pt_dblink_delete_where_is_inscope (PT_NODE * node)
 {
   PT_NODE *cond = node->info.delete_.search_cond;
-  int driving_seen = 0;
+  PT_NODE *driving = NULL;
 
   if (cond == NULL || cond->next != NULL)
     {
       return false;		/* defensive: carve-out runs pre-CNF, so a cond->next list is unexpected here */
     }
 
-  return pt_dblink_delete_and_tree_is_inscope (cond, &driving_seen) && driving_seen == 1;
+  return pt_dblink_delete_and_tree_walk (cond, &driving) && driving != NULL;
 }
 
-/* Returns the sole driving predicate node within node's pre-CNF WHERE tree (node itself, if node isn't
- * PT_AND), or NULL if none is found. Callers rely on pt_dblink_delete_where_is_inscope() having already
- * validated the shape (exactly one driving predicate); this just locates it, e.g. so semantic_check.c
- * can bind/correlation-check its subquery and xasl_generation.c can read its op/columns -- both must
- * locate the *same* node the gate validated, which is why this traversal lives here and is shared
- * rather than reimplemented per caller. */
+/* Returns the driving predicate node within node's pre-CNF WHERE tree, or NULL if there is none. Shared
+ * (non-static) so semantic_check.c can bind/correlation-check its subquery and xasl_generation.c can read
+ * its op/columns -- both must land on the *same* node the gate validated, which is why they call this
+ * rather than re-deriving it. Shape validity is not re-checked here: the gate established it, and a
+ * rewrite since then may have left an AND arm in a shape the walk no longer accepts. */
 PT_NODE *
 pt_dblink_delete_and_tree_find_driving (PT_NODE * node)
 {
-  PT_NODE *found;
+  PT_NODE *driving = NULL;
 
-  if (node == NULL || node->node_type != PT_EXPR)
-    {
-      return NULL;
-    }
+  (void) pt_dblink_delete_and_tree_walk (node, &driving);
 
-  if (node->info.expr.op == PT_AND)
-    {
-      found = pt_dblink_delete_and_tree_find_driving (node->info.expr.arg1);
-      return (found != NULL) ? found : pt_dblink_delete_and_tree_find_driving (node->info.expr.arg2);
-    }
-
-  return pt_dblink_delete_is_driving_pred (node) ? node : NULL;
+  return driving;
 }
 
 static void

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -12541,11 +12541,15 @@ pt_convert_dblink_dml_query (PARSER_CONTEXT * parser, PT_NODE * node,
    *
    * local_cnt > 0 and distinct_cnt == 1 don't establish this alone -- both hold whether or not the same-server
    * remote spec got converted. Walk the WHERE for a surviving (cross-server) spec instead: nothing rewrites
-   * those, and left in place they'd reach the optimizer half-built. */
+   * those, and left in place they'd reach the optimizer half-built.
+   *
+   * cond_has_remote_spec/remote_spec_known are scoped to cover the diagnostic block below too, so a statement
+   * that lands in both (e.g. a same-server mixed subquery, converted or not) only pays for the walk once. */
+  bool cond_has_remote_spec = false;
+  bool remote_spec_known = false;
+
   if (snl->sink_kind == DBLINK_REMOTE_SINK_DELETE_LOCAL_SUBQ)
     {
-      bool cond_has_remote_spec = false;
-
       /* Single FROM spec is a precondition of this sink, established at the only site that sets the flag
        * (pt_convert_dblink_delete_query). Asserted rather than re-checked so a future second set site -- the
        * UPDATE extension this enum leaves room for -- fails loudly here instead of silently dropping a spec. */
@@ -12553,6 +12557,7 @@ pt_convert_dblink_dml_query (PARSER_CONTEXT * parser, PT_NODE * node,
 
       parser_walk_tree (parser, node->info.delete_.search_cond, pt_dblink_find_remote_spec, &cond_has_remote_spec,
 			NULL, NULL);
+      remote_spec_known = true;
 
       if (cond_has_remote_spec || !(snl->local_cnt > 0 && snl->distinct_cnt == 1 && !snl->has_dblink_query))
 	{
@@ -12596,9 +12601,39 @@ pt_convert_dblink_dml_query (PARSER_CONTEXT * parser, PT_NODE * node,
 	}
     }
 
+  /* Diagnose two specific reasons the DELETE carve-out declined this statement, ahead of the generic
+   * catch-all below -- local_cnt > 0 is required on both so a fully-remote statement that already works
+   * through full pushdown is never misdiagnosed here. */
+  if (node->node_type == PT_DELETE && remote_upd == 1 && local_upd == 0 && snl->local_cnt > 0
+      && pt_dblink_delete_where_is_inscope (node))
+    {
+      if (node->info.delete_.spec->next != NULL)
+	{
+	  PT_ERROR (parser, upd_spec, "dblink: remote DELETE with a local subquery supports only a single "
+		    "FROM table");
+	  return;
+	}
+
+      if (!remote_spec_known)
+	{
+	  parser_walk_tree (parser, node->info.delete_.search_cond, pt_dblink_find_remote_spec, &cond_has_remote_spec,
+			    NULL, NULL);
+	}
+
+      if (cond_has_remote_spec)
+	{
+	  PT_ERROR (parser, upd_spec, "dblink: remote DELETE with a local subquery only supports a WHERE "
+		    "subquery that mixes local tables with a remote table on the delete target's own server");
+	  return;
+	}
+    }
+
   if (snl->local_cnt > 0 && remote_upd > 0 && snl->sink_kind == DBLINK_REMOTE_SINK_NONE)
     {
-      PT_ERROR (parser, upd_spec ? upd_spec : into_spec, "dblink: local mixed remote DML is not allowed");
+      PT_ERROR (parser, upd_spec ? upd_spec : into_spec,
+		"dblink: this combination of local and remote references is not supported (some forms are, such "
+		"as INSERT ... SELECT into a remote table from local data, or a remote DELETE with a local "
+		"WHERE subquery)");
       return;
     }
 

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -11891,12 +11891,14 @@ pt_convert_dblink_insert_query (PARSER_CONTEXT * parser, PT_NODE * node, SERVER_
   return;
 }
 
-/* true iff the DELETE WHERE clause is a single positive predicate over a subquery that the value-push
- * sink supports by shape: col IN (subquery), col {= | <> | < | > | <= | >=} ANY (subquery), or a scalar
- * comparison col {= | <> | < | > | <= | >=} (subquery). Forms excluded here fall through to the existing
- * "local mixed remote DML is not allowed" rejection: OR / multiple predicates (op PT_OR/PT_AND or a CNF
- * list, caught by op or cond->next), comparison ALL (PT_*_ALL), negation of IN (PT_IS_NOT_IN), EXISTS, and
- * a value-list IN (arg2 is not a query).
+/* true iff the DELETE WHERE clause is a single positive predicate over a subquery whose shape is a
+ * sink candidate: col IN (subquery), col {= | <> | < | > | <= | >=} ANY (subquery), a scalar comparison
+ * col {= | <> | < | > | <= | >=} (subquery), or col {= | < | > | <= | >=} ALL (subquery). This only
+ * gates the predicate *shape*; how each shape is executed (per-row push vs. a reduced single value) is
+ * decided downstream in XASL generation. Forms excluded here fall through to the existing "local mixed
+ * remote DML is not allowed" rejection: OR / multiple predicates (op PT_OR/PT_AND or a CNF list, caught
+ * by op or cond->next), col <> ALL (PT_NE_ALL is excluded: whole-set semantics equivalent to NOT IN, not
+ * value-push), negation of IN (PT_IS_NOT_IN), EXISTS, and a value-list IN (arg2 is not a query).
  *
  * Correlation and row/multi-column subqueries are NOT decided here. query.correlation_level is 0 for a DELETE
  * WHERE subquery (a DELETE target is not a query scope), so it cannot flag a target-correlated subquery at this
@@ -11930,6 +11932,11 @@ pt_dblink_delete_where_is_inscope (PT_NODE * node)
     case PT_GT:
     case PT_LE:
     case PT_GE:
+    case PT_EQ_ALL:		/* col = ALL (subquery) */
+    case PT_LT_ALL:		/* col < ALL (subquery) */
+    case PT_GT_ALL:		/* col > ALL (subquery) */
+    case PT_LE_ALL:		/* col <= ALL (subquery) */
+    case PT_GE_ALL:		/* col >= ALL (subquery) */
       break;
     default:
       return false;

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -12565,15 +12565,15 @@ pt_convert_dblink_dml_query (PARSER_CONTEXT * parser, PT_NODE * node,
 			NULL, NULL);
       remote_spec_known = true;
 
-      if (cond_has_remote_spec || !(snl->local_cnt > 0 && snl->distinct_cnt == 1 && !snl->has_dblink_query))
+      /* the sink form holds only when the WHERE has no remote spec left unconverted, the subquery really is
+       * local-mixed on the one target server, and it carries no dblink() call of its own */
+      bool sink_form_confirmed = (!cond_has_remote_spec && snl->local_cnt > 0 && snl->distinct_cnt == 1
+				  && !snl->has_dblink_query);
+
+      if (sink_form_confirmed)
 	{
-	  snl->sink_kind = DBLINK_REMOTE_SINK_NONE;
-	}
-      else
-	{
-	  /* Confirmed sink form. Two shapes are diagnosed only now, because a same-server all-remote statement
-	   * reaches this block too and keeps working through full pushdown -- rejecting them at the gate above
-	   * would break it. */
+	  /* Two shapes are diagnosed only now, because a same-server all-remote statement reaches this block
+	   * too and keeps working through full pushdown -- rejecting them at the gate above would break it. */
 	  const char *bad_qualifier;
 
 	  if (node->info.delete_.limit != NULL)
@@ -12604,6 +12604,10 @@ pt_convert_dblink_dml_query (PARSER_CONTEXT * parser, PT_NODE * node,
 	      PT_ERROR (parser, upd_spec, errmsg);
 	      return;
 	    }
+	}
+      else
+	{
+	  snl->sink_kind = DBLINK_REMOTE_SINK_NONE;
 	}
     }
 

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -12165,6 +12165,147 @@ pt_dblink_delete_and_tree_find_driving (PT_NODE * node)
   return driving;
 }
 
+/* true when the DELETE WHERE tree still holds a spec carrying a remote server name that nothing rewrote
+ * into a dblink derived table. Cheap enough to call at each decision point rather than caching the answer
+ * across them. */
+static bool
+pt_dblink_delete_where_has_remote_spec (PARSER_CONTEXT * parser, PT_NODE * node)
+{
+  bool found = false;
+
+  parser_walk_tree (parser, node->info.delete_.search_cond, pt_dblink_find_remote_spec, &found, NULL, NULL);
+
+  return found;
+}
+
+/* Counts the remote servers named inside the WHERE subquery alone, as a delta on snl->server_cnt, feeding
+ * the same sub_sel_server_cnt the INSERT SELECT branch uses. Scoped to the driving predicate's subquery arm;
+ * the broader upd_spec walk in the caller re-walks the whole statement and adds to the same counters,
+ * harmlessly (they are never relied on for an exact count). */
+static int
+pt_dblink_delete_subquery_server_delta (PARSER_CONTEXT * parser, PT_NODE * node, SERVER_NAME_LIST * snl,
+					int server_cnt_before)
+{
+  PT_NODE *driving = pt_dblink_delete_and_tree_find_driving (node->info.delete_.search_cond);
+
+  if (driving == NULL)
+    {
+      return 0;
+    }
+
+  parser_walk_tree (parser, driving->info.expr.arg2, pt_get_server_name_list, snl, NULL, NULL);
+
+  return snl->server_cnt - server_cnt_before;
+}
+
+/* defined below, next to the INSERT SELECT conversion that shares it */
+static PT_NODE *pt_check_sub_query_spec (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk);
+
+/* Same-server mixed WHERE subquery (local + remote, all on the target server): convert the embedded remote
+ * spec(s) into dblink derived-table scans so the subquery compiles as an ordinary local-side query (a join
+ * against a derived table). No runtime change is needed -- the DELETE sink's aptr already compiles and
+ * executes whatever subquery pt_to_delete_xasl_remote_subquery is handed, generically.
+ *
+ * The same-server-only guard and the spec rewrite itself match what the INSERT SELECT branch in the caller
+ * does; what is walked differs (INSERT loops over every value clause, this walks the driving predicate's
+ * subquery arm alone), so the two are not interchangeable beyond that conversion step.
+ *
+ * Clears sink_kind when the subquery is not local-mixed on the one target server, leaving the statement to
+ * the existing guards. */
+static void
+pt_dblink_delete_convert_same_server_specs (PARSER_CONTEXT * parser, PT_NODE * node, SERVER_NAME_LIST * snl)
+{
+  PT_NODE *driving;
+  bool had_dblink_before;
+
+  if (!(snl->local_cnt > 0 && snl->distinct_cnt == 1))
+    {
+      snl->sink_kind = DBLINK_REMOTE_SINK_NONE;
+      return;
+    }
+
+  driving = pt_dblink_delete_and_tree_find_driving (node->info.delete_.search_cond);
+  had_dblink_before = snl->has_dblink_query;
+
+  if (driving != NULL)
+    {
+      parser_walk_tree (parser, driving->info.expr.arg2, pt_check_sub_query_spec, snl, NULL, NULL);
+    }
+
+  /* The rewrite marks the spec PT_DERIVED_DBLINK_TABLE, which pt_get_server_name_list treats like a real
+   * dblink() call, flipping has_dblink_query. INSERT SELECT is exempt from the has_dblink_query rejection in
+   * the caller ("!= DBLINK_REMOTE_SINK_INSERT_SELECT"); DELETE isn't, so restore the flag instead -- only a
+   * dblink() already present before this call should still trip that rejection. */
+  if (!had_dblink_before)
+    {
+      snl->has_dblink_query = false;
+    }
+}
+
+/* Two shapes that can only be diagnosed once the sink form is confirmed: a same-server all-remote statement
+ * reaches the same place and keeps working through full pushdown, so rejecting these at the shape gate would
+ * break it.
+ *   return: true when an error was raised (caller returns immediately) */
+static bool
+pt_dblink_delete_diagnose_confirmed_sink (PARSER_CONTEXT * parser, PT_NODE * node, PT_NODE * upd_spec)
+{
+  const char *bad_qualifier;
+  char errmsg[256];
+
+  if (node->info.delete_.limit != NULL)
+    {
+      /* One statement becomes one remote DELETE per local value, so there is no single statement to cap and
+       * the local side cannot tell how many remote rows a value removes. LIMIT would also be invisible to the
+       * shape gate, which runs before semantic check turns it into an inst_num() predicate. */
+      PT_ERROR (parser, upd_spec, "dblink: remote DELETE with a local subquery does not support LIMIT");
+      return true;
+    }
+
+  if (!pt_dblink_delete_qualifier_names_target (node, &bad_qualifier))
+    {
+      if (bad_qualifier != NULL)
+	{
+	  snprintf (errmsg, sizeof (errmsg),
+		    "dblink: remote DELETE with a local subquery requires the WHERE qualifier to name the "
+		    "delete target, but \"%s\" does not", bad_qualifier);
+	}
+      else
+	{
+	  snprintf (errmsg, sizeof (errmsg),
+		    "dblink: remote DELETE with a local subquery does not support a multi-part qualifier "
+		    "on the WHERE predicate");
+	}
+      PT_ERROR (parser, upd_spec, errmsg);
+      return true;
+    }
+
+  return false;
+}
+
+/* Two specific reasons the carve-out declined a statement it otherwise recognises, diagnosed ahead of the
+ * generic catch-all. local_cnt > 0 is required by the caller on both, so a fully-remote statement that
+ * already works through full pushdown is never misdiagnosed here.
+ *   return: true when an error was raised (caller returns immediately) */
+static bool
+pt_dblink_delete_diagnose_declined (PARSER_CONTEXT * parser, PT_NODE * node, PT_NODE * upd_spec)
+{
+  if (node->info.delete_.spec->next != NULL)
+    {
+      PT_ERROR (parser, upd_spec, "dblink: remote DELETE with a local subquery supports only a single "
+		"FROM table");
+      return true;
+    }
+
+  if (pt_dblink_delete_where_has_remote_spec (parser, node))
+    {
+      PT_ERROR (parser, upd_spec, "dblink: remote DELETE with a local subquery only supports a WHERE "
+		"subquery that mixes local tables with a remote table on the delete target's own server");
+      return true;
+    }
+
+  return false;
+}
+
 static void
 pt_convert_dblink_delete_query (PARSER_CONTEXT * parser, PT_NODE * node, SERVER_NAME_LIST * snl)
 {
@@ -12439,17 +12580,7 @@ pt_convert_dblink_dml_query (PARSER_CONTEXT * parser, PT_NODE * node,
       upd_spec = node->info.delete_.spec;
       if (snl->sink_kind == DBLINK_REMOTE_SINK_DELETE_LOCAL_SUBQ)
 	{
-	  /* Detect a remote spec in the WHERE subquery, mirroring INSERT's sub_sel_server_cnt; the actual
-	   * same-server-mixed conversion is further down, mirroring the INSERT_SELECT post-switch block.
-	   * Scoped to driving->arg2 so the delta reflects the subquery alone; the broader upd_spec walk
-	   * below re-walks the whole statement and adds to the same counters, harmlessly (those are never
-	   * relied on for an exact count). */
-	  PT_NODE *driving = pt_dblink_delete_and_tree_find_driving (node->info.delete_.search_cond);
-	  if (driving != NULL)
-	    {
-	      parser_walk_tree (parser, driving->info.expr.arg2, pt_get_server_name_list, snl, NULL, NULL);
-	      sub_sel_server_cnt = snl->server_cnt - tmp_server_cnt;
-	    }
+	  sub_sel_server_cnt = pt_dblink_delete_subquery_server_delta (parser, node, snl, tmp_server_cnt);
 	}
       break;
     case PT_UPDATE:
@@ -12515,35 +12646,10 @@ pt_convert_dblink_dml_query (PARSER_CONTEXT * parser, PT_NODE * node,
 	}
     }
 
-  /* Same-server mixed WHERE subquery (local + remote, all on the target server) -- mirrors the
-   * INSERT_SELECT block above. Convert the embedded remote spec(s) into dblink derived-table scans so
-   * the subquery compiles as an ordinary local-side query (join against a derived table); this needs no
-   * runtime change since the DELETE sink's aptr already compiles/executes whatever subquery
-   * pt_to_delete_xasl_remote_subquery is handed, generically. */
+  /* Same-server mixed WHERE subquery: the DELETE counterpart of the conversion just above. */
   if (snl->sink_kind == DBLINK_REMOTE_SINK_DELETE_LOCAL_SUBQ && sub_sel_server_cnt > 0)
     {
-      if (snl->local_cnt > 0 && snl->distinct_cnt == 1)
-	{
-	  PT_NODE *driving = pt_dblink_delete_and_tree_find_driving (node->info.delete_.search_cond);
-	  bool had_dblink_before = snl->has_dblink_query;
-
-	  if (driving != NULL)
-	    {
-	      parser_walk_tree (parser, driving->info.expr.arg2, pt_check_sub_query_spec, snl, NULL, NULL);
-	    }
-	  /* The rewrite marks the spec PT_DERIVED_DBLINK_TABLE, which pt_get_server_name_list treats like a
-	   * real dblink() call, flipping has_dblink_query. INSERT SELECT is exempt from the has_dblink_query
-	   * rejection below ("!= DBLINK_REMOTE_SINK_INSERT_SELECT"); DELETE isn't, so snapshot/restore instead
-	   * -- only a dblink() already present before this call still trips that rejection. */
-	  if (!had_dblink_before)
-	    {
-	      snl->has_dblink_query = false;
-	    }
-	}
-      else
-	{
-	  snl->sink_kind = DBLINK_REMOTE_SINK_NONE;
-	}
+      pt_dblink_delete_convert_same_server_specs (parser, node, snl);
     }
 
   /* remote DELETE + local subquery: keep the carve-out only when no remote spec is left unconverted (the
@@ -12552,13 +12658,7 @@ pt_convert_dblink_dml_query (PARSER_CONTEXT * parser, PT_NODE * node,
    *
    * local_cnt > 0 and distinct_cnt == 1 don't establish this alone -- both hold whether or not the same-server
    * remote spec got converted. Walk the WHERE for a surviving (cross-server) spec instead: nothing rewrites
-   * those, and left in place they'd reach the optimizer half-built.
-   *
-   * cond_has_remote_spec/remote_spec_known are scoped to cover the diagnostic block below too, so a statement
-   * that lands in both (e.g. a same-server mixed subquery, converted or not) only pays for the walk once. */
-  bool cond_has_remote_spec = false;
-  bool remote_spec_known = false;
-
+   * those, and left in place they'd reach the optimizer half-built. */
   if (snl->sink_kind == DBLINK_REMOTE_SINK_DELETE_LOCAL_SUBQ)
     {
       /* Single FROM spec is a precondition of this sink, established at the only site that sets the flag
@@ -12566,47 +12666,11 @@ pt_convert_dblink_dml_query (PARSER_CONTEXT * parser, PT_NODE * node,
        * UPDATE extension this enum leaves room for -- fails loudly here instead of silently dropping a spec. */
       assert (node->info.delete_.spec->next == NULL);
 
-      parser_walk_tree (parser, node->info.delete_.search_cond, pt_dblink_find_remote_spec, &cond_has_remote_spec,
-			NULL, NULL);
-      remote_spec_known = true;
-
-      /* the sink form holds only when the WHERE has no remote spec left unconverted, the subquery really is
-       * local-mixed on the one target server, and it carries no dblink() call of its own */
-      bool sink_form_confirmed = (!cond_has_remote_spec && snl->local_cnt > 0 && snl->distinct_cnt == 1
-				  && !snl->has_dblink_query);
-
-      if (sink_form_confirmed)
+      if (!pt_dblink_delete_where_has_remote_spec (parser, node) && snl->local_cnt > 0 && snl->distinct_cnt == 1
+	  && !snl->has_dblink_query)
 	{
-	  /* Two shapes are diagnosed only now, because a same-server all-remote statement reaches this block
-	   * too and keeps working through full pushdown -- rejecting them at the gate above would break it. */
-	  const char *bad_qualifier;
-
-	  if (node->info.delete_.limit != NULL)
+	  if (pt_dblink_delete_diagnose_confirmed_sink (parser, node, upd_spec))
 	    {
-	      /* One statement becomes one remote DELETE per local value, so there is no single statement to cap
-	       * and the local side cannot tell how many remote rows a value removes. LIMIT would also be invisible
-	       * to the shape gate, which runs before semantic check turns it into an inst_num() predicate. */
-	      PT_ERROR (parser, upd_spec, "dblink: remote DELETE with a local subquery does not support LIMIT");
-	      return;
-	    }
-
-	  if (!pt_dblink_delete_qualifier_names_target (node, &bad_qualifier))
-	    {
-	      char errmsg[256];
-
-	      if (bad_qualifier != NULL)
-		{
-		  snprintf (errmsg, sizeof (errmsg),
-			    "dblink: remote DELETE with a local subquery requires the WHERE qualifier to name the "
-			    "delete target, but \"%s\" does not", bad_qualifier);
-		}
-	      else
-		{
-		  snprintf (errmsg, sizeof (errmsg),
-			    "dblink: remote DELETE with a local subquery does not support a multi-part qualifier "
-			    "on the WHERE predicate");
-		}
-	      PT_ERROR (parser, upd_spec, errmsg);
 	      return;
 	    }
 	}
@@ -12617,30 +12681,12 @@ pt_convert_dblink_dml_query (PARSER_CONTEXT * parser, PT_NODE * node,
     }
 
   /* Diagnose two specific reasons the DELETE carve-out declined this statement, ahead of the generic
-   * catch-all below -- local_cnt > 0 is required on both so a fully-remote statement that already works
-   * through full pushdown is never misdiagnosed here. */
+   * catch-all below -- local_cnt > 0 is required so a fully-remote statement that already works through full
+   * pushdown is never misdiagnosed here. */
   if (node->node_type == PT_DELETE && remote_upd == 1 && local_upd == 0 && snl->local_cnt > 0
-      && pt_dblink_delete_where_is_inscope (node))
+      && pt_dblink_delete_where_is_inscope (node) && pt_dblink_delete_diagnose_declined (parser, node, upd_spec))
     {
-      if (node->info.delete_.spec->next != NULL)
-	{
-	  PT_ERROR (parser, upd_spec, "dblink: remote DELETE with a local subquery supports only a single "
-		    "FROM table");
-	  return;
-	}
-
-      if (!remote_spec_known)
-	{
-	  parser_walk_tree (parser, node->info.delete_.search_cond, pt_dblink_find_remote_spec, &cond_has_remote_spec,
-			    NULL, NULL);
-	}
-
-      if (cond_has_remote_spec)
-	{
-	  PT_ERROR (parser, upd_spec, "dblink: remote DELETE with a local subquery only supports a WHERE "
-		    "subquery that mixes local tables with a remote table on the delete target's own server");
-	  return;
-	}
+      return;
     }
 
   if (snl->local_cnt > 0 && remote_upd > 0 && snl->sink_kind == DBLINK_REMOTE_SINK_NONE)

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -11991,29 +11991,35 @@ pt_dblink_delete_target_range_name (PT_NODE * spec)
 }
 
 /*
- * pt_dblink_delete_qualifier_names_target () - true when the WHERE left-hand side is either unqualified or
- *   qualified with the DELETE target's own correlation name. *bad_qualifier is set to the offending name when it
- *   can be named, NULL when the shape itself is the problem.
+ * pt_dblink_delete_qualifier_names_target () - true when the driving predicate's left-hand side is either
+ *   unqualified or qualified with the DELETE target's own correlation name. *bad_qualifier names the offending
+ *   qualifier, or is NULL when the shape itself (a nested a.b.c) is the problem.
  *
- *   pt_to_delete_xasl_remote_subquery keeps only the trailing attribute of a dotted name, so anything this
- *   function cannot verify must be kept away from the sink. A local target gets the equivalent check from name
- *   resolution; a remote spec does not, because pt_find_name_in_spec() reports every name as found there -- the
- *   local server holds no schema for the remote table. Nested qualifiers (a.b.c) therefore return false rather
- *   than being skipped: the qualifier is not a plain name, so it cannot be compared, and letting it through
- *   deletes against whatever the trailing attribute happens to name.
+ *   Name resolution cannot do this for a remote spec -- pt_find_name_in_spec() reports every name as found
+ *   there, the local server holding no schema for the remote table -- while pt_to_delete_xasl_remote_subquery
+ *   keeps only the trailing attribute of a dotted name, so an unverifiable qualifier would delete against
+ *   whatever that attribute happens to name. Read the driving predicate rather than search_cond: with a
+ *   remote-only AND arm the root is PT_AND, whose arg1 is a conjunct rather than a PT_DOT_, and the qualifier
+ *   would never be compared.
  */
 static bool
 pt_dblink_delete_qualifier_names_target (PT_NODE * node, const char **bad_qualifier)
 {
-  PT_NODE *cond = node->info.delete_.search_cond;
+  PT_NODE *cond = pt_dblink_delete_and_tree_find_driving (node->info.delete_.search_cond);
   PT_NODE *arg1, *qual;
   const char *range_name;
 
   *bad_qualifier = NULL;
 
-  if (cond == NULL || cond->node_type != PT_EXPR)
+  /* The gate (pt_dblink_delete_where_is_inscope) established exactly one driving predicate before the sink was
+   * confirmed, and a driving predicate is always a PT_EXPR, so this lookup cannot come back empty here; a NULL
+   * means the gate and this lookup have drifted -- DBLINK_REMOTE_SINK_* leaves room for an UPDATE extension
+   * that would add a second site setting the flag. Fail closed rather than skipping the comparison: an
+   * unverified qualifier deletes remote rows the statement never named. */
+  assert (cond != NULL);
+  if (cond == NULL)
     {
-      return true;
+      return false;
     }
 
   arg1 = cond->info.expr.arg1;

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -12345,24 +12345,24 @@ pt_check_with_info (PARSER_CONTEXT * parser, PT_NODE * node, SEMANTIC_CHK_INFO *
 		  /* mirrors the remote INSERT SELECT handling above (same reason -- see that comment): the WHERE
 		   * subquery's specs would lack range_var / spec id and XASL generation would crash without this.
 		   * qstr == NULL confirms pt_rewrite_for_dblink (db_vdb.c) chose the value-push sink over a full
-		   * qstr pushdown; requiring cond to be a single EXPR (no AND) below further narrows this to the
-		   * single-predicate shape.
-		   *
-		   * KNOWN GAP: pt_dblink_delete_where_is_inscope (parser_support.c) also accepts the driving
-		   * predicate combined with remote-only AND arms, which the single-EXPR check below does not cover
-		   * -- subq stays NULL and that subquery is neither correlation-checked nor bound. Harmless only
-		   * because pt_to_delete_xasl_remote_subquery() (xasl_generation.c) doesn't walk an AND tree either
-		   * and rejects it first; extend both together if that changes. */
+		   * qstr pushdown. The WHERE may now be the driving predicate alone or that predicate combined
+		   * with remote-only AND arms (pt_dblink_delete_where_is_inscope, parser_support.c);
+		   * pt_dblink_delete_and_tree_find_driving() locates the same driving node that gate validated,
+		   * in either shape, so the AND arms (if any) are left untouched here and only the driving
+		   * predicate's own subquery is bound below. */
 		  PT_NODE *remote = node->info.delete_.spec->info.spec.remote_server_name;
 		  PT_NODE *cond = node->info.delete_.search_cond;
+		  PT_NODE *driving = NULL;
 		  PT_NODE *subq = NULL;
 
 		  if (remote != NULL && remote->node_type == PT_DBLINK_TABLE_DML
-		      && remote->info.dblink_table.qstr == NULL && cond != NULL && cond->next == NULL
-		      && cond->node_type == PT_EXPR && cond->info.expr.arg2 != NULL
-		      && PT_IS_QUERY (cond->info.expr.arg2))
+		      && remote->info.dblink_table.qstr == NULL && cond != NULL && cond->next == NULL)
 		    {
-		      subq = cond->info.expr.arg2;
+		      driving = pt_dblink_delete_and_tree_find_driving (cond);
+		    }
+		  if (driving != NULL)
+		    {
+		      subq = driving->info.expr.arg2;
 		    }
 		  if (subq != NULL)
 		    {
@@ -12397,7 +12397,7 @@ pt_check_with_info (PARSER_CONTEXT * parser, PT_NODE * node, SEMANTIC_CHK_INFO *
 						      "remote DELETE: failed to translate the WHERE subquery");
 		      if (subq != NULL)
 			{
-			  cond->info.expr.arg2 = subq;
+			  driving->info.expr.arg2 = subq;
 			}
 		    }
 		}

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -12342,20 +12342,21 @@ pt_check_with_info (PARSER_CONTEXT * parser, PT_NODE * node, SEMANTIC_CHK_INFO *
 		}
 	      else if (node->node_type == PT_DELETE)
 		{
-		  /* mirrors the remote INSERT SELECT handling above (same reason -- see that comment); here
-		   * the WHERE subquery's specs would lack range_var / spec id and XASL generation would
-		   * crash. Only the single-predicate "<col> <op> (subquery)" shape is touched; other remote
-		   * DELETEs have no subquery (or a value list) and use the qstr pushdown. */
+		  /* mirrors the remote INSERT SELECT handling above (same reason -- see that comment): the WHERE
+		   * subquery's specs would lack range_var / spec id and XASL generation would crash without this.
+		   * qstr == NULL confirms pt_rewrite_for_dblink (db_vdb.c) chose the value-push sink over a full
+		   * qstr pushdown; requiring cond to be a single EXPR (no AND) below further narrows this to the
+		   * single-predicate shape.
+		   *
+		   * KNOWN GAP: pt_dblink_delete_where_is_inscope (parser_support.c) also accepts the driving
+		   * predicate combined with remote-only AND arms, which the single-EXPR check below does not cover
+		   * -- subq stays NULL and that subquery is neither correlation-checked nor bound. Harmless only
+		   * because pt_to_delete_xasl_remote_subquery() (xasl_generation.c) doesn't walk an AND tree either
+		   * and rejects it first; extend both together if that changes. */
 		  PT_NODE *remote = node->info.delete_.spec->info.spec.remote_server_name;
 		  PT_NODE *cond = node->info.delete_.search_cond;
 		  PT_NODE *subq = NULL;
 
-		  /* Only the value-push sink. pt_rewrite_for_dblink (db_vdb.c, before this semantic check) already
-		   * converted the target to PT_DBLINK_TABLE_DML: the sink leaves qstr == NULL, while a full qstr
-		   * pushdown (e.g. same-server all-remote IN (SELECT ... FROM t@srv)) sets qstr and ships the whole
-		   * DELETE as text -- its subquery must NOT be translated locally. qstr == NULL is only produced when
-		   * the parser shape gate (pt_dblink_delete_where_is_inscope) accepted the form, so this also confines
-		   * resolution to the parser-approved single-predicate shapes. */
 		  if (remote != NULL && remote->node_type == PT_DBLINK_TABLE_DML
 		      && remote->info.dblink_table.qstr == NULL && cond != NULL && cond->next == NULL
 		      && cond->node_type == PT_EXPR && cond->info.expr.arg2 != NULL

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -19727,12 +19727,82 @@ pt_to_insert_xasl_remote_select (PARSER_CONTEXT * parser, PT_NODE * statement)
   return xasl;
 }
 
+/* Deparses every remote-only AND arm in node's WHERE tree into a single "arm1 AND arm2 ..." SQL
+ * fragment (NULL if there are none); the driving predicate (pt_dblink_delete_is_driving_pred) is
+ * skipped since it's handled separately via remote_key_col/remote_op. custom_print flags match the
+ * existing same-server qstr pushdown (pt_convert_dblink_dml_query) since this text also ships to a
+ * remote server as-is.
+ *
+ * *error distinguishes "no extra arms" (return value NULL, *error untouched) from a print or
+ * allocation failure (*error set true) -- a NULL return alone would be ambiguous between the two,
+ * and silently dropping/misassembling an arm on failure is worse than the caller aborting
+ * explicitly. Once *error is set, the recursion stops doing further print work and just unwinds. */
+static char *
+pt_dblink_delete_deparse_extra_where (PARSER_CONTEXT * parser, PT_NODE * node, char *extra_where, bool * error)
+{
+  unsigned int save_custom_print;
+  char *piece;
+
+  if (*error || node == NULL || node->node_type != PT_EXPR)
+    {
+      return extra_where;
+    }
+
+  if (node->info.expr.op == PT_AND)
+    {
+      extra_where = pt_dblink_delete_deparse_extra_where (parser, node->info.expr.arg1, extra_where, error);
+      return pt_dblink_delete_deparse_extra_where (parser, node->info.expr.arg2, extra_where, error);
+    }
+
+  if (pt_dblink_delete_is_driving_pred (node))
+    {
+      return extra_where;
+    }
+
+  save_custom_print = parser->custom_print;
+  parser->custom_print |=
+    PT_PRINT_SUPPRESS_SERVER_NAME | PT_PRINT_SUPPRESS_SERIAL_CONV | PT_PRINT_NO_HOST_VAR_INDEX |
+    PT_PRINT_SUPPRESS_FOR_DBLINK;
+  piece = parser_print_tree (parser, node);
+  parser->custom_print = save_custom_print;
+
+  if (piece == NULL)
+    {
+      *error = true;
+      return extra_where;
+    }
+
+  if (extra_where != NULL)
+    {
+      char *joined = pt_append_string (parser, extra_where, " AND ");
+
+      if (joined == NULL)
+	{
+	  *error = true;
+	  return extra_where;
+	}
+      extra_where = joined;
+    }
+
+  {
+    char *result = pt_append_string (parser, extra_where, piece);
+
+    if (result == NULL)
+      {
+	*error = true;
+	return extra_where;
+      }
+    return result;
+  }
+}
+
 /*
  * pt_to_delete_xasl_remote_subquery () - Builds DELETE_PROC XASL for a remote DELETE whose WHERE references a
- *   pure-local subquery. Mirrors pt_to_insert_xasl_remote_select: the local subquery is compiled as the aptr
- *   (produces a single-column list-file), and the DELETE_PROC carries the remote connection, target table,
- *   WHERE key column, and comparison operator. The runtime reads each list-file value and pushes
- *   "DELETE FROM <table> WHERE <key> <op> ?" via CCI bind.
+ *   pure-local subquery, optionally combined with remote-only AND arms. The local subquery is compiled as the
+ *   aptr (produces a single-column list-file, as in pt_to_insert_xasl_remote_select), and the DELETE_PROC
+ *   carries the remote connection, target table, WHERE key column, comparison operator, and -- if any
+ *   remote-only AND arms are present -- their deparsed SQL text in remote_extra_where, for the runtime SQL
+ *   builder (dblink_dml_build_delete_sql) to fold into the pushed WHERE clause.
  *
  * return        : XASL node, or NULL on error.
  * parser (in)   : Parser context.
@@ -19746,7 +19816,7 @@ pt_to_delete_xasl_remote_subquery (PARSER_CONTEXT * parser, PT_NODE * statement)
   PT_NODE *aptr_statement = NULL;
   PT_NODE *from = NULL, *server_node = NULL, *entity_name = NULL;
   PT_DBLINK_INFO *pdblink = NULL;
-  PT_NODE *cond, *arg1, *arg2;
+  PT_NODE *cond, *driving, *arg1, *arg2;
   const char *op_sql = NULL;
   const char *key_col = NULL;
   DBLINK_REMOTE_SINK_MODE sink_mode = DBLINK_SINK_MODE_PER_ROW;
@@ -19758,9 +19828,9 @@ pt_to_delete_xasl_remote_subquery (PARSER_CONTEXT * parser, PT_NODE * statement)
 
   assert (cond != NULL && cond->node_type == PT_EXPR);
 
-  /* Only the first predicate is translated below, so a second one would be dropped without a diagnostic. The
-   * parser gate admits a single predicate, but rewrites between there and here can append to the list -- LIMIT
-   * becomes inst_num() <= n during semantic check, for one. Those forms are excluded at the gate; reject here
+  /* A second top-level predicate (cond->next) is a different hazard than the AND arms below: the parser gate
+   * admits a single predicate/AND-tree, but a rewrite between there and here could still append to the list --
+   * LIMIT becomes inst_num() <= n during semantic check, for one. That form is excluded at the gate; reject here
    * too so any future appender surfaces as an error instead of a silently unenforced condition. */
   if (cond->next != NULL)
     {
@@ -19769,12 +19839,22 @@ pt_to_delete_xasl_remote_subquery (PARSER_CONTEXT * parser, PT_NODE * statement)
       return NULL;
     }
 
+  /* locate the driving predicate within cond (which may be that predicate alone, or combined with
+   * remote-only AND arms) -- pt_dblink_delete_where_is_inscope (parser_support.c) already validated
+   * this shape, so a miss here would mean that gate and this builder have drifted apart. */
+  driving = pt_dblink_delete_and_tree_find_driving (cond);
+  if (driving == NULL)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, "remote DELETE subquery: unexpected operator");
+      return NULL;
+    }
+
   /* operator -> remote WHERE SQL text (fixed safe set) + sink mode. IN/=ANY/scalar-=/comparison ANY
    * push one remote predicate per list-file value (PER_ROW, ANY semantics fall out of the per-row
    * OR-union the runtime already does); comparison ALL instead reduces the whole local subquery result
    * to a single value pushed once (REDUCE_MIN/REDUCE_MAX/EQ_ALL) -- the reduction itself is done at
    * runtime, not here (see qexec_execute_remote_dml_sink). */
-  switch (cond->info.expr.op)
+  switch (driving->info.expr.op)
     {
     case PT_IS_IN:
     case PT_EQ_SOME:
@@ -19827,7 +19907,7 @@ pt_to_delete_xasl_remote_subquery (PARSER_CONTEXT * parser, PT_NODE * statement)
     }
 
   /* single-column WHERE left-hand side (reject row / multi-column predicates) */
-  arg1 = cond->info.expr.arg1;
+  arg1 = driving->info.expr.arg1;
   if (arg1 != NULL && arg1->node_type == PT_NAME)
     {
       key_col = arg1->info.name.original;
@@ -19849,7 +19929,7 @@ pt_to_delete_xasl_remote_subquery (PARSER_CONTEXT * parser, PT_NODE * statement)
     }
 
   /* the local subquery feeds the value list */
-  arg2 = cond->info.expr.arg2;
+  arg2 = driving->info.expr.arg2;
   if (arg2 == NULL || !PT_IS_QUERY (arg2))
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1,
@@ -19906,6 +19986,19 @@ pt_to_delete_xasl_remote_subquery (PARSER_CONTEXT * parser, PT_NODE * statement)
   del->remote_key_col = pt_append_string (parser, NULL, key_col);
   del->remote_op = pt_append_string (parser, NULL, op_sql);
   del->remote_sink_mode = sink_mode;
+
+  {
+    bool extra_where_error = false;
+
+    del->remote_extra_where = pt_dblink_delete_deparse_extra_where (parser, cond, NULL, &extra_where_error);
+    if (extra_where_error)
+      {
+	er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1,
+		"remote DELETE: failed to deparse a remote-only AND arm");
+	return NULL;
+      }
+  }
+
   if (del->sink.table_name == NULL || del->remote_key_col == NULL || del->remote_op == NULL || pt_has_error (parser))
     {
       return NULL;

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -19768,7 +19768,9 @@ pt_to_delete_xasl_remote_subquery (PARSER_CONTEXT * parser, PT_NODE * statement)
       return NULL;
     }
 
-  /* operator -> remote WHERE SQL text (fixed safe set; IN / = ANY push per-row equality) */
+  /* operator -> remote WHERE SQL text (fixed safe set; each op pushes one remote predicate per
+   * list-file value -- IN/=ANY/scalar-= as equality, <>(_SOME) as inequality, the rest as their
+   * own comparison; ANY semantics fall out of the per-row OR-union the runtime already does) */
   switch (cond->info.expr.op)
     {
     case PT_IS_IN:
@@ -19777,16 +19779,24 @@ pt_to_delete_xasl_remote_subquery (PARSER_CONTEXT * parser, PT_NODE * statement)
       op_sql = "=";
       break;
     case PT_LT:
+    case PT_LT_SOME:
       op_sql = "<";
       break;
     case PT_GT:
+    case PT_GT_SOME:
       op_sql = ">";
       break;
     case PT_LE:
+    case PT_LE_SOME:
       op_sql = "<=";
       break;
     case PT_GE:
+    case PT_GE_SOME:
       op_sql = ">=";
+      break;
+    case PT_NE:
+    case PT_NE_SOME:
+      op_sql = "<>";
       break;
     default:
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, "remote DELETE subquery: unexpected operator");

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -19729,14 +19729,17 @@ pt_to_insert_xasl_remote_select (PARSER_CONTEXT * parser, PT_NODE * statement)
 
 /* Deparses every remote-only AND arm in node's WHERE tree into a single "arm1 AND arm2 ..." SQL
  * fragment (NULL if there are none); the driving predicate (pt_dblink_delete_is_driving_pred) is
- * skipped since it's handled separately via remote_key_col/remote_op. custom_print flags match the
- * existing same-server qstr pushdown (pt_convert_dblink_dml_query) since this text also ships to a
- * remote server as-is.
+ * skipped since it's handled separately via remote_key_col/remote_op. Every other leaf is
+ * re-validated against pt_dblink_delete_is_remote_only_conjunct() before printing -- if this walk
+ * and the parser gate (pt_dblink_delete_where_is_inscope) ever drift apart, a leaf the gate would
+ * not have accepted is rejected here instead of being shipped to the remote server as-is.
+ * custom_print flags match the existing same-server qstr pushdown (pt_convert_dblink_dml_query)
+ * since this text also ships to a remote server as-is.
  *
- * *error distinguishes "no extra arms" (return value NULL, *error untouched) from a print or
- * allocation failure (*error set true) -- a NULL return alone would be ambiguous between the two,
- * and silently dropping/misassembling an arm on failure is worse than the caller aborting
- * explicitly. Once *error is set, the recursion stops doing further print work and just unwinds. */
+ * *error distinguishes "no extra arms" (return value NULL, *error untouched) from a shape mismatch,
+ * print, or allocation failure (*error set true) -- a NULL return alone would be ambiguous between
+ * the two, and silently dropping/misassembling an arm on failure is worse than the caller aborting
+ * explicitly. Once *error is set, the recursion stops doing further work and just unwinds. */
 static char *
 pt_dblink_delete_deparse_extra_where (PARSER_CONTEXT * parser, PT_NODE * node, char *extra_where, bool * error)
 {
@@ -19759,10 +19762,19 @@ pt_dblink_delete_deparse_extra_where (PARSER_CONTEXT * parser, PT_NODE * node, c
       return extra_where;
     }
 
+  /* re-validate the remote-only shape rather than trusting the gate blindly -- if
+   * pt_dblink_delete_where_is_inscope() (parser_support.c) and this walk ever drift apart, a leaf the
+   * gate would not have accepted must not be shipped to the remote server as-is. */
+  if (!pt_dblink_delete_is_remote_only_conjunct (node))
+    {
+      *error = true;
+      return extra_where;
+    }
+
   save_custom_print = parser->custom_print;
   parser->custom_print |=
     PT_PRINT_SUPPRESS_SERVER_NAME | PT_PRINT_SUPPRESS_SERIAL_CONV | PT_PRINT_NO_HOST_VAR_INDEX |
-    PT_PRINT_SUPPRESS_FOR_DBLINK;
+    PT_PRINT_SUPPRESS_FOR_DBLINK | PT_SUPPRESS_RESOLVED;
   piece = parser_print_tree (parser, node);
   parser->custom_print = save_custom_print;
 

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -19749,6 +19749,7 @@ pt_to_delete_xasl_remote_subquery (PARSER_CONTEXT * parser, PT_NODE * statement)
   PT_NODE *cond, *arg1, *arg2;
   const char *op_sql = NULL;
   const char *key_col = NULL;
+  DBLINK_REMOTE_SINK_MODE sink_mode = DBLINK_SINK_MODE_PER_ROW;
 
   assert (parser != NULL && statement != NULL);
 
@@ -19768,9 +19769,11 @@ pt_to_delete_xasl_remote_subquery (PARSER_CONTEXT * parser, PT_NODE * statement)
       return NULL;
     }
 
-  /* operator -> remote WHERE SQL text (fixed safe set; each op pushes one remote predicate per
-   * list-file value -- IN/=ANY/scalar-= as equality, <>(_SOME) as inequality, the rest as their
-   * own comparison; ANY semantics fall out of the per-row OR-union the runtime already does) */
+  /* operator -> remote WHERE SQL text (fixed safe set) + sink mode. IN/=ANY/scalar-=/comparison ANY
+   * push one remote predicate per list-file value (PER_ROW, ANY semantics fall out of the per-row
+   * OR-union the runtime already does); comparison ALL instead reduces the whole local subquery result
+   * to a single value pushed once (REDUCE_MIN/REDUCE_MAX/EQ_ALL) -- the reduction itself is done at
+   * runtime, not here (see qexec_execute_remote_dml_sink). */
   switch (cond->info.expr.op)
     {
     case PT_IS_IN:
@@ -19797,6 +19800,26 @@ pt_to_delete_xasl_remote_subquery (PARSER_CONTEXT * parser, PT_NODE * statement)
     case PT_NE:
     case PT_NE_SOME:
       op_sql = "<>";
+      break;
+    case PT_EQ_ALL:
+      op_sql = "=";
+      sink_mode = DBLINK_SINK_MODE_EQ_ALL;
+      break;
+    case PT_LT_ALL:
+      op_sql = "<";
+      sink_mode = DBLINK_SINK_MODE_REDUCE_MIN;
+      break;
+    case PT_LE_ALL:
+      op_sql = "<=";
+      sink_mode = DBLINK_SINK_MODE_REDUCE_MIN;
+      break;
+    case PT_GT_ALL:
+      op_sql = ">";
+      sink_mode = DBLINK_SINK_MODE_REDUCE_MAX;
+      break;
+    case PT_GE_ALL:
+      op_sql = ">=";
+      sink_mode = DBLINK_SINK_MODE_REDUCE_MAX;
       break;
     default:
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, "remote DELETE subquery: unexpected operator");
@@ -19882,6 +19905,7 @@ pt_to_delete_xasl_remote_subquery (PARSER_CONTEXT * parser, PT_NODE * statement)
 
   del->remote_key_col = pt_append_string (parser, NULL, key_col);
   del->remote_op = pt_append_string (parser, NULL, op_sql);
+  del->remote_sink_mode = sink_mode;
   if (del->sink.table_name == NULL || del->remote_key_col == NULL || del->remote_op == NULL || pt_has_error (parser))
     {
       return NULL;

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -19744,7 +19744,7 @@ static char *
 pt_dblink_delete_deparse_extra_where (PARSER_CONTEXT * parser, PT_NODE * node, char *extra_where, bool * error)
 {
   unsigned int save_custom_print;
-  char *piece;
+  char *piece, *joined;
 
   if (*error || node == NULL || node->node_type != PT_EXPR)
     {
@@ -19786,8 +19786,7 @@ pt_dblink_delete_deparse_extra_where (PARSER_CONTEXT * parser, PT_NODE * node, c
 
   if (extra_where != NULL)
     {
-      char *joined = pt_append_string (parser, extra_where, " AND ");
-
+      joined = pt_append_string (parser, extra_where, " AND ");
       if (joined == NULL)
 	{
 	  *error = true;
@@ -19796,16 +19795,14 @@ pt_dblink_delete_deparse_extra_where (PARSER_CONTEXT * parser, PT_NODE * node, c
       extra_where = joined;
     }
 
-  {
-    char *result = pt_append_string (parser, extra_where, piece);
+  joined = pt_append_string (parser, extra_where, piece);
+  if (joined == NULL)
+    {
+      *error = true;
+      return extra_where;
+    }
 
-    if (result == NULL)
-      {
-	*error = true;
-	return extra_where;
-      }
-    return result;
-  }
+  return joined;
 }
 
 /*
@@ -19832,6 +19829,7 @@ pt_to_delete_xasl_remote_subquery (PARSER_CONTEXT * parser, PT_NODE * statement)
   const char *op_sql = NULL;
   const char *key_col = NULL;
   DBLINK_REMOTE_SINK_MODE sink_mode = DBLINK_SINK_MODE_PER_ROW;
+  bool extra_where_error = false;
 
   assert (parser != NULL && statement != NULL);
 
@@ -19999,17 +19997,12 @@ pt_to_delete_xasl_remote_subquery (PARSER_CONTEXT * parser, PT_NODE * statement)
   del->remote_op = pt_append_string (parser, NULL, op_sql);
   del->remote_sink_mode = sink_mode;
 
-  {
-    bool extra_where_error = false;
-
-    del->remote_extra_where = pt_dblink_delete_deparse_extra_where (parser, cond, NULL, &extra_where_error);
-    if (extra_where_error)
-      {
-	er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1,
-		"remote DELETE: failed to deparse a remote-only AND arm");
-	return NULL;
-      }
-  }
+  del->remote_extra_where = pt_dblink_delete_deparse_extra_where (parser, cond, NULL, &extra_where_error);
+  if (extra_where_error)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, "remote DELETE: failed to deparse a remote-only AND arm");
+      return NULL;
+    }
 
   if (del->sink.table_name == NULL || del->remote_key_col == NULL || del->remote_op == NULL || pt_has_error (parser))
     {

--- a/src/query/dblink_scan.c
+++ b/src/query/dblink_scan.c
@@ -1488,6 +1488,14 @@ sql_build_error:
  *                      is NULL
  *   extra_where(in)  : deparsed remote-only AND arm(s), or NULL/empty if there are none
  *   sql_out(out)     : set to the built SQL text on success
+ *
+ * TODO: key_col and the identifiers inside extra_where are appended unquoted, matching the parser-side
+ *       push-down paths (pt_copypush_terms, and mq_dblink_append_corr_pred_sql -- see the TODO there).  A
+ *       reserved-word or space-bearing column therefore fails the remote prepare instead of deleting the
+ *       wrong rows.  One thing differs here: this text is assembled at execution time, where
+ *       cci_get_dbms_type() identifies the remote, so vendor-aware quoting is feasible in this path even
+ *       though it is not at XASL generation.  Deferred until the quoting semantics are settled per vendor
+ *       (quoting makes identifiers case-sensitive on Oracle, and MySQL's default quote is the backtick).
  */
 static int
 dblink_dml_build_delete_sql (THREAD_ENTRY * thread_p, const char *table_name, const char *key_col, const char *op,

--- a/src/query/dblink_scan.c
+++ b/src/query/dblink_scan.c
@@ -1496,55 +1496,26 @@ dblink_dml_build_delete_sql (THREAD_ENTRY * thread_p, const char *table_name, co
   int ret, remaining;
   char *sql;
   size_t sql_len;
+  bool has_key = key_col != NULL;
   bool has_extra;
 
   *sql_out = NULL;
 
-  if (key_col != NULL && key_col[0] == '\0')
+  if (has_key && key_col[0] == '\0')
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, "remote DELETE: key_col is empty");
       return ER_DBLINK;
     }
-
-  has_extra = (extra_where != NULL && extra_where[0] != '\0');
-
-  if (key_col == NULL)
-    {
-      sql_len = strlen (table_name) + (has_extra ? strlen (extra_where) : 0) + 64;
-      sql = (char *) db_private_alloc (thread_p, sql_len);
-      if (sql == NULL)
-	{
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sql_len);
-	  return ER_OUT_OF_VIRTUAL_MEMORY;
-	}
-
-      remaining = (int) sql_len;
-      if (has_extra)
-	{
-	  ret = snprintf (sql, remaining, "/* DBLINK DELETE */ DELETE FROM %s WHERE (%s)", table_name, extra_where);
-	}
-      else
-	{
-	  ret = snprintf (sql, remaining, "/* DBLINK DELETE */ DELETE FROM %s", table_name);
-	}
-      if (ret < 0 || ret >= remaining)
-	{
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, "remote DELETE: SQL assembly truncated");
-	  db_private_free (thread_p, sql);
-	  return ER_DBLINK;
-	}
-
-      *sql_out = sql;
-      return NO_ERROR;
-    }
-
-  if (op == NULL || op[0] == '\0')
+  if (has_key && (op == NULL || op[0] == '\0'))
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, "remote DELETE: op is NULL or empty");
       return ER_DBLINK;
     }
 
-  sql_len = strlen (table_name) + strlen (key_col) + strlen (op) + (has_extra ? strlen (extra_where) : 0) + 80;
+  has_extra = (extra_where != NULL && extra_where[0] != '\0');
+
+  sql_len = strlen (table_name) + (has_key ? strlen (key_col) + strlen (op) : 0)
+    + (has_extra ? strlen (extra_where) : 0) + 80;
   sql = (char *) db_private_alloc (thread_p, sql_len);
   if (sql == NULL)
     {
@@ -1553,14 +1524,22 @@ dblink_dml_build_delete_sql (THREAD_ENTRY * thread_p, const char *table_name, co
     }
 
   remaining = (int) sql_len;
-  if (has_extra)
+  if (has_key && has_extra)
     {
       ret = snprintf (sql, remaining, "/* DBLINK DELETE */ DELETE FROM %s WHERE %s %s ? AND (%s)", table_name,
 		      key_col, op, extra_where);
     }
-  else
+  else if (has_key)
     {
       ret = snprintf (sql, remaining, "/* DBLINK DELETE */ DELETE FROM %s WHERE %s %s ?", table_name, key_col, op);
+    }
+  else if (has_extra)
+    {
+      ret = snprintf (sql, remaining, "/* DBLINK DELETE */ DELETE FROM %s WHERE (%s)", table_name, extra_where);
+    }
+  else
+    {
+      ret = snprintf (sql, remaining, "/* DBLINK DELETE */ DELETE FROM %s", table_name);
     }
   if (ret < 0 || ret >= remaining)
     {

--- a/src/query/dblink_scan.c
+++ b/src/query/dblink_scan.c
@@ -1469,13 +1469,17 @@ sql_build_error:
 }
 
 /*
- * dblink_dml_build_delete_sql () - Build "DELETE FROM <table> WHERE <key_col> <op> ?" (one placeholder).
+ * dblink_dml_build_delete_sql () - Build "DELETE FROM <table> WHERE <key_col> <op> ?" (one placeholder),
+ *   or "DELETE FROM <table>" with no WHERE at all when key_col is NULL (comparison ALL over an empty
+ *   local subquery result is vacuously true, so every remote row is deleted -- DELETE rather than
+ *   TRUNCATE, to preserve 2PC/trigger/rollback semantics).
  *   return: NO_ERROR on success (sql_out set to a db_private_alloc'd string, caller frees with
  *           db_private_free), error code on failure.
  *   thread_p(in)   : thread entry
  *   table_name(in) : remote table name
- *   key_col(in)    : remote WHERE column (left-hand side, e.g. rc1)
- *   op(in)         : comparison operator SQL text ("=", "<", ">", "<=", ">=")
+ *   key_col(in)    : remote WHERE column (left-hand side, e.g. rc1); NULL builds a WHERE-less DELETE
+ *   op(in)         : comparison operator SQL text ("=", "<", ">", "<=", ">="); ignored when key_col
+ *                    is NULL
  *   sql_out(out)   : set to the built SQL text on success
  */
 static int
@@ -1488,9 +1492,38 @@ dblink_dml_build_delete_sql (THREAD_ENTRY * thread_p, const char *table_name, co
 
   *sql_out = NULL;
 
-  if (key_col == NULL || key_col[0] == '\0' || op == NULL || op[0] == '\0')
+  if (key_col != NULL && key_col[0] == '\0')
     {
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, "remote DELETE: key_col/op is NULL or empty");
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, "remote DELETE: key_col is empty");
+      return ER_DBLINK;
+    }
+
+  if (key_col == NULL)
+    {
+      sql_len = strlen (table_name) + 48;
+      sql = (char *) db_private_alloc (thread_p, sql_len);
+      if (sql == NULL)
+	{
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sql_len);
+	  return ER_OUT_OF_VIRTUAL_MEMORY;
+	}
+
+      remaining = (int) sql_len;
+      ret = snprintf (sql, remaining, "/* DBLINK DELETE */ DELETE FROM %s", table_name);
+      if (ret < 0 || ret >= remaining)
+	{
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, "remote DELETE: SQL assembly truncated");
+	  db_private_free (thread_p, sql);
+	  return ER_DBLINK;
+	}
+
+      *sql_out = sql;
+      return NO_ERROR;
+    }
+
+  if (op == NULL || op[0] == '\0')
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, "remote DELETE: op is NULL or empty");
       return ER_DBLINK;
     }
 
@@ -1528,8 +1561,10 @@ dblink_dml_build_delete_sql (THREAD_ENTRY * thread_p, const char *table_name, co
  *   attr_names(in)  : INSERT only -- explicit column names (NULL for positional INSERT)
  *   num_attrs(in)   : INSERT only -- length of attr_names (0 when positional)
  *   num_bind(in)    : INSERT only -- number of ? placeholders (= SELECT column count)
- *   key_col(in)     : DELETE only -- remote WHERE column (left-hand side, e.g. rc1)
- *   op(in)          : DELETE only -- comparison operator SQL text ("=", "<", ">", "<=", ">=")
+ *   key_col(in)     : DELETE only -- remote WHERE column (left-hand side, e.g. rc1); NULL builds a
+ *                     WHERE-less DELETE (deletes every remote row)
+ *   op(in)          : DELETE only -- comparison operator SQL text ("=", "<", ">", "<=", ">="); ignored
+ *                     when key_col is NULL
  *   state(out)      : filled with conn_handle and stmt_handle on success
  *
  * Note: To prevent partial writes, both kinds ALWAYS:

--- a/src/query/dblink_scan.c
+++ b/src/query/dblink_scan.c
@@ -1469,26 +1469,34 @@ sql_build_error:
 }
 
 /*
- * dblink_dml_build_delete_sql () - Build "DELETE FROM <table> WHERE <key_col> <op> ?" (one placeholder),
- *   or "DELETE FROM <table>" with no WHERE at all when key_col is NULL (comparison ALL over an empty
- *   local subquery result is vacuously true, so every remote row is deleted -- DELETE rather than
- *   TRUNCATE, to preserve 2PC/trigger/rollback semantics).
+ * dblink_dml_build_delete_sql () - Build the remote DELETE SQL text. key_col NULL builds a WHERE-less
+ *   DELETE (comparison ALL over an empty local subquery result is vacuously true, so every remote row
+ *   is deleted -- DELETE rather than TRUNCATE, to preserve 2PC/trigger/rollback semantics); extra_where
+ *   (a remote-only AND arm deparsed at XASL generation, e.g. "name <> 'x'") is folded in as an
+ *   additional AND'd condition in either case, since it stands for a real WHERE condition regardless of
+ *   whether the driving predicate contributed a placeholder:
+ *     key_col set,   extra_where set   -> "... WHERE <key_col> <op> ? AND (<extra_where>)"
+ *     key_col set,   extra_where NULL  -> "... WHERE <key_col> <op> ?"
+ *     key_col NULL,  extra_where set   -> "... WHERE (<extra_where>)"
+ *     key_col NULL,  extra_where NULL  -> "..." (no WHERE at all)
  *   return: NO_ERROR on success (sql_out set to a db_private_alloc'd string, caller frees with
  *           db_private_free), error code on failure.
- *   thread_p(in)   : thread entry
- *   table_name(in) : remote table name
- *   key_col(in)    : remote WHERE column (left-hand side, e.g. rc1); NULL builds a WHERE-less DELETE
- *   op(in)         : comparison operator SQL text ("=", "<", ">", "<=", ">="); ignored when key_col
- *                    is NULL
- *   sql_out(out)   : set to the built SQL text on success
+ *   thread_p(in)     : thread entry
+ *   table_name(in)   : remote table name
+ *   key_col(in)      : remote WHERE column (left-hand side, e.g. rc1); NULL builds a WHERE-less DELETE
+ *   op(in)           : comparison operator SQL text ("=", "<", ">", "<=", ">="); ignored when key_col
+ *                      is NULL
+ *   extra_where(in)  : deparsed remote-only AND arm(s), or NULL/empty if there are none
+ *   sql_out(out)     : set to the built SQL text on success
  */
 static int
 dblink_dml_build_delete_sql (THREAD_ENTRY * thread_p, const char *table_name, const char *key_col, const char *op,
-			     char **sql_out)
+			     const char *extra_where, char **sql_out)
 {
   int ret, remaining;
   char *sql;
   size_t sql_len;
+  bool has_extra;
 
   *sql_out = NULL;
 
@@ -1498,9 +1506,11 @@ dblink_dml_build_delete_sql (THREAD_ENTRY * thread_p, const char *table_name, co
       return ER_DBLINK;
     }
 
+  has_extra = (extra_where != NULL && extra_where[0] != '\0');
+
   if (key_col == NULL)
     {
-      sql_len = strlen (table_name) + 48;
+      sql_len = strlen (table_name) + (has_extra ? strlen (extra_where) : 0) + 64;
       sql = (char *) db_private_alloc (thread_p, sql_len);
       if (sql == NULL)
 	{
@@ -1509,7 +1519,14 @@ dblink_dml_build_delete_sql (THREAD_ENTRY * thread_p, const char *table_name, co
 	}
 
       remaining = (int) sql_len;
-      ret = snprintf (sql, remaining, "/* DBLINK DELETE */ DELETE FROM %s", table_name);
+      if (has_extra)
+	{
+	  ret = snprintf (sql, remaining, "/* DBLINK DELETE */ DELETE FROM %s WHERE (%s)", table_name, extra_where);
+	}
+      else
+	{
+	  ret = snprintf (sql, remaining, "/* DBLINK DELETE */ DELETE FROM %s", table_name);
+	}
       if (ret < 0 || ret >= remaining)
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, "remote DELETE: SQL assembly truncated");
@@ -1527,7 +1544,7 @@ dblink_dml_build_delete_sql (THREAD_ENTRY * thread_p, const char *table_name, co
       return ER_DBLINK;
     }
 
-  sql_len = strlen (table_name) + strlen (key_col) + strlen (op) + 64;
+  sql_len = strlen (table_name) + strlen (key_col) + strlen (op) + (has_extra ? strlen (extra_where) : 0) + 80;
   sql = (char *) db_private_alloc (thread_p, sql_len);
   if (sql == NULL)
     {
@@ -1536,7 +1553,15 @@ dblink_dml_build_delete_sql (THREAD_ENTRY * thread_p, const char *table_name, co
     }
 
   remaining = (int) sql_len;
-  ret = snprintf (sql, remaining, "/* DBLINK DELETE */ DELETE FROM %s WHERE %s %s ?", table_name, key_col, op);
+  if (has_extra)
+    {
+      ret = snprintf (sql, remaining, "/* DBLINK DELETE */ DELETE FROM %s WHERE %s %s ? AND (%s)", table_name,
+		      key_col, op, extra_where);
+    }
+  else
+    {
+      ret = snprintf (sql, remaining, "/* DBLINK DELETE */ DELETE FROM %s WHERE %s %s ?", table_name, key_col, op);
+    }
   if (ret < 0 || ret >= remaining)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, "remote DELETE: SQL assembly truncated");
@@ -1561,10 +1586,12 @@ dblink_dml_build_delete_sql (THREAD_ENTRY * thread_p, const char *table_name, co
  *   attr_names(in)  : INSERT only -- explicit column names (NULL for positional INSERT)
  *   num_attrs(in)   : INSERT only -- length of attr_names (0 when positional)
  *   num_bind(in)    : INSERT only -- number of ? placeholders (= SELECT column count)
- *   key_col(in)     : DELETE only -- remote WHERE column (left-hand side, e.g. rc1); NULL builds a
- *                     WHERE-less DELETE (deletes every remote row)
+ *   key_col(in)     : DELETE only -- remote WHERE column (left-hand side, e.g. rc1); NULL omits the
+ *                     placeholder condition (deletes every remote row, unless extra_where narrows it)
  *   op(in)          : DELETE only -- comparison operator SQL text ("=", "<", ">", "<=", ">="); ignored
  *                     when key_col is NULL
+ *   extra_where(in) : DELETE only -- deparsed remote-only AND arm(s), or NULL/empty if there are none;
+ *                     see dblink_dml_build_delete_sql for the four key_col/extra_where combinations
  *   state(out)      : filled with conn_handle and stmt_handle on success
  *
  * Note: To prevent partial writes, both kinds ALWAYS:
@@ -1580,7 +1607,7 @@ dblink_dml_build_delete_sql (THREAD_ENTRY * thread_p, const char *table_name, co
 int
 dblink_dml_open (THREAD_ENTRY * thread_p, DBLINK_DML_KIND kind, const char *url, const char *user, const char *pwd,
 		 const char *table_name, char **attr_names, int num_attrs, int num_bind, const char *key_col,
-		 const char *op, DBLINK_DML_STATE * state)
+		 const char *op, const char *extra_where, DBLINK_DML_STATE * state)
 {
   int ret;
   T_CCI_ERROR err_buf;
@@ -1632,7 +1659,7 @@ dblink_dml_open (THREAD_ENTRY * thread_p, DBLINK_DML_KIND kind, const char *url,
       ret = dblink_dml_build_insert_sql (thread_p, table_name, attr_names, num_attrs, num_bind, &sql);
       break;
     case DBLINK_DML_DELETE:
-      ret = dblink_dml_build_delete_sql (thread_p, table_name, key_col, op, &sql);
+      ret = dblink_dml_build_delete_sql (thread_p, table_name, key_col, op, extra_where, &sql);
       break;
     default:
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, "remote DML sink: unknown kind");

--- a/src/query/dblink_scan.c
+++ b/src/query/dblink_scan.c
@@ -1484,7 +1484,7 @@ sql_build_error:
  *   thread_p(in)     : thread entry
  *   table_name(in)   : remote table name
  *   key_col(in)      : remote WHERE column (left-hand side, e.g. rc1); NULL builds a WHERE-less DELETE
- *   op(in)           : comparison operator SQL text ("=", "<", ">", "<=", ">="); ignored when key_col
+ *   op(in)           : comparison operator SQL text ("=", "<>", "<", ">", "<=", ">="); ignored when key_col
  *                      is NULL
  *   extra_where(in)  : deparsed remote-only AND arm(s), or NULL/empty if there are none
  *   sql_out(out)     : set to the built SQL text on success
@@ -1588,7 +1588,7 @@ dblink_dml_build_delete_sql (THREAD_ENTRY * thread_p, const char *table_name, co
  *   num_bind(in)    : INSERT only -- number of ? placeholders (= SELECT column count)
  *   key_col(in)     : DELETE only -- remote WHERE column (left-hand side, e.g. rc1); NULL omits the
  *                     placeholder condition (deletes every remote row, unless extra_where narrows it)
- *   op(in)          : DELETE only -- comparison operator SQL text ("=", "<", ">", "<=", ">="); ignored
+ *   op(in)          : DELETE only -- comparison operator SQL text ("=", "<>", "<", ">", "<=", ">="); ignored
  *                     when key_col is NULL
  *   extra_where(in) : DELETE only -- deparsed remote-only AND arm(s), or NULL/empty if there are none;
  *                     see dblink_dml_build_delete_sql for the four key_col/extra_where combinations

--- a/src/query/dblink_scan.h
+++ b/src/query/dblink_scan.h
@@ -120,14 +120,14 @@ struct dblink_dml_state
 /* which statement dblink_dml_open() prepares; each kind reads only its own params below */
 typedef enum dblink_dml_kind
 {
-  DBLINK_DML_INSERT,		/* uses attr_names/num_attrs/num_bind; ignores key_col/op */
-  DBLINK_DML_DELETE		/* uses key_col/op; ignores attr_names/num_attrs/num_bind */
+  DBLINK_DML_INSERT,		/* uses attr_names/num_attrs/num_bind; ignores key_col/op/extra_where */
+  DBLINK_DML_DELETE		/* uses key_col/op/extra_where; ignores attr_names/num_attrs/num_bind */
     /* DBLINK_DML_UPDATE to follow */
 } DBLINK_DML_KIND;
 
 extern int dblink_dml_open (THREAD_ENTRY * thread_p, DBLINK_DML_KIND kind, const char *url, const char *user,
 			    const char *pwd, const char *table_name, char **attr_names, int num_attrs, int num_bind,
-			    const char *key_col, const char *op, DBLINK_DML_STATE * state);
+			    const char *key_col, const char *op, const char *extra_where, DBLINK_DML_STATE * state);
 extern int dblink_dml_execute_row (THREAD_ENTRY * thread_p, DBLINK_DML_STATE * state, DB_VALUE ** vals,
 				   int num_vals, int *affected_rows);
 extern void dblink_dml_rollback (THREAD_ENTRY * thread_p, DBLINK_DML_STATE * state);

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -12897,20 +12897,14 @@ qexec_execute_remote_delete_reduce (THREAD_ENTRY * thread_p, XASL_NODE * xasl, X
 		       &dblink_state) != NO_ERROR)
     {
       qexec_failure_line (__LINE__, xasl_state);
-      dblink_dml_close (&dblink_state);
-      dblink_dml_rollback (thread_p, &dblink_state);
-      pr_clear_value (&boundary);
-      return ER_FAILED;
+      goto dml_error;
     }
 
   bindv[0] = &boundary;
   if (dblink_dml_execute_row (thread_p, &dblink_state, bindv, (row_count == 0) ? 0 : 1, &row_affected) != NO_ERROR)
     {
       qexec_failure_line (__LINE__, xasl_state);
-      dblink_dml_close (&dblink_state);
-      dblink_dml_rollback (thread_p, &dblink_state);
-      pr_clear_value (&boundary);
-      return ER_FAILED;
+      goto dml_error;
     }
 
   xasl->list_id->tuple_cnt += row_affected;
@@ -12919,6 +12913,13 @@ qexec_execute_remote_delete_reduce (THREAD_ENTRY * thread_p, XASL_NODE * xasl, X
   pr_clear_value (&boundary);
 
   return NO_ERROR;
+
+dml_error:
+  dblink_dml_close (&dblink_state);
+  dblink_dml_rollback (thread_p, &dblink_state);
+  pr_clear_value (&boundary);
+
+  return ER_FAILED;
 
 exit_on_error:
   qexec_end_scan (thread_p, specp);

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -12897,6 +12897,8 @@ qexec_execute_remote_delete_reduce (THREAD_ENTRY * thread_p, XASL_NODE * xasl, X
 		       &dblink_state) != NO_ERROR)
     {
       qexec_failure_line (__LINE__, xasl_state);
+      dblink_dml_close (&dblink_state);
+      dblink_dml_rollback (thread_p, &dblink_state);
       pr_clear_value (&boundary);
       return ER_FAILED;
     }

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -561,6 +561,9 @@ static int qexec_collect_remote_delete_key (SCAN_ID * s_id, XASL_STATE * xasl_st
 					    bool * skip_row);
 static int qexec_execute_remote_dml_sink (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_state,
 					  DBLINK_DML_KIND kind);
+static int qexec_execute_remote_delete_reduce (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_state,
+					       REMOTE_DML_SINK * sink, const char *key_col, const char *op,
+					       DBLINK_REMOTE_SINK_MODE sink_mode);
 static int qexec_execute_remote_delete_subquery (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_state);
 static int qexec_execute_insert (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_state, bool skip_aptr);
 static int qexec_evaluate_row_default_exprs (THREAD_ENTRY * thread_p, INSERT_PROC_NODE * insert,
@@ -12567,6 +12570,7 @@ qexec_execute_remote_dml_sink (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_S
   int num_attrs = 0;
   const char *key_col = NULL, *op = NULL;
   DBLINK_DML_STATE dblink_state = { -1, -1 };
+  DBLINK_REMOTE_SINK_MODE sink_mode = DBLINK_SINK_MODE_PER_ROW;
 
   assert (specp != NULL);
 
@@ -12595,6 +12599,7 @@ qexec_execute_remote_dml_sink (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_S
 	sink = &del->sink;
 	key_col = del->remote_key_col;
 	op = del->remote_op;
+	sink_mode = del->remote_sink_mode;
 	break;
       }
     default:
@@ -12604,6 +12609,17 @@ qexec_execute_remote_dml_sink (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_S
     }
 
   assert (sink->is_remote);
+
+  /* comparison ALL (< ALL / <= ALL / > ALL / >= ALL) reduces to a single remote push instead of one
+   * per local subquery row -- handled by a dedicated path that scans the local subquery before opening
+   * the remote connection, since the bound value must be known before the DELETE can be prepared.
+   * EQ_ALL is not yet covered here (its "all rows share one value" check is a separate task) and falls
+   * through to the per-row loop below like PER_ROW. */
+  if (kind == DBLINK_DML_DELETE
+      && (sink_mode == DBLINK_SINK_MODE_REDUCE_MIN || sink_mode == DBLINK_SINK_MODE_REDUCE_MAX))
+    {
+      return qexec_execute_remote_delete_reduce (thread_p, xasl, xasl_state, sink, key_col, op, sink_mode);
+    }
 
   /* open remote connection and prepare the INSERT/DELETE statement */
   if (dblink_dml_open (thread_p, kind, sink->url, sink->user, sink->pwd, sink->table_name, attr_names, num_attrs,
@@ -12707,6 +12723,164 @@ exit_on_error:
   dblink_dml_rollback (thread_p, &dblink_state);
   qexec_end_scan (thread_p, specp);
   qexec_close_scan (thread_p, specp);
+
+  return ER_FAILED;
+}
+
+/*
+ * qexec_execute_remote_delete_reduce () - Reduce-mode variant of the remote DELETE sink for comparison
+ *   ALL: scan the local subquery fully first to find the single MIN/MAX bound, then push at most one
+ *   remote DELETE using that bound, instead of one push per local subquery row.
+ *   return: NO_ERROR or ER_FAILED
+ *   xasl(in)       : DELETE_PROC XASL with sink.is_remote set; specp scans the already-materialized
+ *                    local subquery list file (see qexec_execute_remote_dml_sink's Note)
+ *   xasl_state(in) : XASL state
+ *   sink(in)       : remote connection info (url/user/pwd/table_name)
+ *   key_col(in)    : remote WHERE column
+ *   op(in)         : comparison operator SQL text ("<", "<=", ">", ">=")
+ *   sink_mode(in)  : DBLINK_SINK_MODE_REDUCE_MIN or DBLINK_SINK_MODE_REDUCE_MAX
+ *
+ * Note: A NULL anywhere in the local subquery result makes the comparison unknown for every remote row
+ *   (ALL over a set containing NULL), so this leaves the remote table untouched -- no connection is
+ *   opened. An empty local subquery result is also left untouched here; turning that into "delete every
+ *   remote row" is a separate follow-up (empty set is vacuously true for ALL, the SQL builder needs a
+ *   WHERE-less DELETE for it).
+ */
+static int
+qexec_execute_remote_delete_reduce (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_state,
+				    REMOTE_DML_SINK * sink, const char *key_col, const char *op,
+				    DBLINK_REMOTE_SINK_MODE sink_mode)
+{
+  ACCESS_SPEC_TYPE *specp = xasl->spec_list;
+  SCAN_CODE xb_scan, ls_scan;
+  SCAN_ID *s_id = NULL;
+  DB_VALUE *bindv[1];
+  DB_VALUE boundary;
+  bool has_boundary = false;
+  bool null_seen = false;
+  int row_count = 0;
+  int row_affected;
+  DBLINK_DML_STATE dblink_state = { -1, -1 };
+
+  db_make_null (&boundary);
+
+  if (qexec_open_scan (thread_p, specp, xasl->val_list, &xasl_state->vd, false, specp->fixed_scan,
+		       specp->grouped_scan, true, &specp->s_id, xasl_state->query_id, S_SELECT, false,
+		       NULL, xasl) != NO_ERROR)
+    {
+      qexec_failure_line (__LINE__, xasl_state);
+      goto exit_on_error;
+    }
+
+  while ((xb_scan = qexec_next_scan_block_iterations (thread_p, xasl)) == S_SUCCESS)
+    {
+      s_id = &xasl->curr_spec->s_id;
+
+      while ((ls_scan = scan_next_scan (thread_p, s_id)) == S_SUCCESS)
+	{
+	  bool skip_row;
+
+	  if (qexec_collect_remote_delete_key (s_id, xasl_state, bindv, &skip_row) != NO_ERROR)
+	    {
+	      goto exit_on_error;
+	    }
+	  if (skip_row)
+	    {
+	      /* NULL in the set: the final answer (no-op) is already decided, but keep draining the
+	       * scan to completion rather than introducing an early-exit path for it. */
+	      null_seen = true;
+	      continue;
+	    }
+	  if (null_seen)
+	    {
+	      continue;
+	    }
+
+	  row_count++;
+	  if (!has_boundary)
+	    {
+	      if (pr_clone_value (bindv[0], &boundary) != NO_ERROR)
+		{
+		  qexec_failure_line (__LINE__, xasl_state);
+		  goto exit_on_error;
+		}
+	      has_boundary = true;
+	    }
+	  else
+	    {
+	      DB_VALUE_COMPARE_RESULT cmp = tp_value_compare (bindv[0], &boundary, 1, 1);
+
+	      if (cmp != DB_LT && cmp != DB_EQ && cmp != DB_GT)
+		{
+		  /* not cleanly comparable (e.g. DB_UNK) -- ALL's boundary becomes undecidable,
+		   * the same conservative call as a NULL in the set. */
+		  null_seen = true;
+		  continue;
+		}
+
+	      if ((sink_mode == DBLINK_SINK_MODE_REDUCE_MIN && cmp == DB_LT)
+		  || (sink_mode == DBLINK_SINK_MODE_REDUCE_MAX && cmp == DB_GT))
+		{
+		  pr_clear_value (&boundary);
+		  if (pr_clone_value (bindv[0], &boundary) != NO_ERROR)
+		    {
+		      qexec_failure_line (__LINE__, xasl_state);
+		      goto exit_on_error;
+		    }
+		}
+	    }
+	}
+
+      if (ls_scan != S_END)
+	{
+	  qexec_failure_line (__LINE__, xasl_state);
+	  goto exit_on_error;
+	}
+    }
+
+  if (xb_scan != S_END)
+    {
+      qexec_failure_line (__LINE__, xasl_state);
+      goto exit_on_error;
+    }
+
+  qexec_close_scan (thread_p, specp);
+
+  if (null_seen || row_count == 0)
+    {
+      pr_clear_value (&boundary);
+      return NO_ERROR;
+    }
+
+  if (dblink_dml_open (thread_p, DBLINK_DML_DELETE, sink->url, sink->user, sink->pwd, sink->table_name, NULL, 0, 0,
+		       key_col, op, &dblink_state) != NO_ERROR)
+    {
+      qexec_failure_line (__LINE__, xasl_state);
+      pr_clear_value (&boundary);
+      return ER_FAILED;
+    }
+
+  bindv[0] = &boundary;
+  if (dblink_dml_execute_row (thread_p, &dblink_state, bindv, 1, &row_affected) != NO_ERROR)
+    {
+      qexec_failure_line (__LINE__, xasl_state);
+      dblink_dml_close (&dblink_state);
+      dblink_dml_rollback (thread_p, &dblink_state);
+      pr_clear_value (&boundary);
+      return ER_FAILED;
+    }
+
+  xasl->list_id->tuple_cnt += row_affected;
+
+  dblink_dml_close (&dblink_state);
+  pr_clear_value (&boundary);
+
+  return NO_ERROR;
+
+exit_on_error:
+  qexec_end_scan (thread_p, specp);
+  qexec_close_scan (thread_p, specp);
+  pr_clear_value (&boundary);
 
   return ER_FAILED;
 }

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -563,7 +563,7 @@ static int qexec_execute_remote_dml_sink (THREAD_ENTRY * thread_p, XASL_NODE * x
 					  DBLINK_DML_KIND kind);
 static int qexec_execute_remote_delete_reduce (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_state,
 					       REMOTE_DML_SINK * sink, const char *key_col, const char *op,
-					       DBLINK_REMOTE_SINK_MODE sink_mode);
+					       const char *extra_where, DBLINK_REMOTE_SINK_MODE sink_mode);
 static int qexec_execute_remote_delete_subquery (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_state);
 static int qexec_execute_insert (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_state, bool skip_aptr);
 static int qexec_evaluate_row_default_exprs (THREAD_ENTRY * thread_p, INSERT_PROC_NODE * insert,
@@ -12568,7 +12568,7 @@ qexec_execute_remote_dml_sink (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_S
   int val_no = 0, row_affected;
   char **attr_names = NULL;
   int num_attrs = 0;
-  const char *key_col = NULL, *op = NULL;
+  const char *key_col = NULL, *op = NULL, *extra_where = NULL;
   DBLINK_DML_STATE dblink_state = { -1, -1 };
   DBLINK_REMOTE_SINK_MODE sink_mode = DBLINK_SINK_MODE_PER_ROW;
 
@@ -12599,6 +12599,7 @@ qexec_execute_remote_dml_sink (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_S
 	sink = &del->sink;
 	key_col = del->remote_key_col;
 	op = del->remote_op;
+	extra_where = del->remote_extra_where;
 	sink_mode = del->remote_sink_mode;
 	break;
       }
@@ -12618,12 +12619,12 @@ qexec_execute_remote_dml_sink (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_S
       && (sink_mode == DBLINK_SINK_MODE_REDUCE_MIN || sink_mode == DBLINK_SINK_MODE_REDUCE_MAX
 	  || sink_mode == DBLINK_SINK_MODE_EQ_ALL))
     {
-      return qexec_execute_remote_delete_reduce (thread_p, xasl, xasl_state, sink, key_col, op, sink_mode);
+      return qexec_execute_remote_delete_reduce (thread_p, xasl, xasl_state, sink, key_col, op, extra_where, sink_mode);
     }
 
   /* open remote connection and prepare the INSERT/DELETE statement */
   if (dblink_dml_open (thread_p, kind, sink->url, sink->user, sink->pwd, sink->table_name, attr_names, num_attrs,
-		       val_no, key_col, op, &dblink_state) != NO_ERROR)
+		       val_no, key_col, op, extra_where, &dblink_state) != NO_ERROR)
     {
       qexec_failure_line (__LINE__, xasl_state);
       goto exit_on_error;
@@ -12740,20 +12741,24 @@ exit_on_error:
  *   sink(in)       : remote connection info (url/user/pwd/table_name)
  *   key_col(in)    : remote WHERE column
  *   op(in)         : comparison operator SQL text ("<", "<=", ">", ">=", "=")
+ *   extra_where(in): deparsed remote-only AND arm(s), or NULL/empty if there are none -- folded in
+ *                    regardless of whether the reduce boundary ends up bound (see
+ *                    dblink_dml_build_delete_sql), since it's a real WHERE condition either way
  *   sink_mode(in)  : DBLINK_SINK_MODE_REDUCE_MIN, DBLINK_SINK_MODE_REDUCE_MAX, or
  *                    DBLINK_SINK_MODE_EQ_ALL
  *
  * Note: A NULL anywhere in the local subquery result makes the comparison unknown for every remote row
  *   (ALL over a set containing NULL), so this leaves the remote table untouched -- no connection is
  *   opened. An empty local subquery result is vacuously true for ALL, so every remote row is deleted
- *   instead (dblink_dml_open/dblink_dml_build_delete_sql with a NULL key_col builds a WHERE-less
- *   DELETE for this case). For EQ_ALL specifically, if the local subquery rows do not all share one
- *   value, "col = ALL (...)" is always false, so the remote table is also left untouched.
+ *   instead, or every row matching extra_where if a remote-only AND arm is present (dblink_dml_open/
+ *   dblink_dml_build_delete_sql with a NULL key_col builds a WHERE-less, or extra_where-only, DELETE
+ *   for this case). For EQ_ALL specifically, if the local subquery rows do not all share one value,
+ *   "col = ALL (...)" is always false, so the remote table is also left untouched.
  */
 static int
 qexec_execute_remote_delete_reduce (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_state,
 				    REMOTE_DML_SINK * sink, const char *key_col, const char *op,
-				    DBLINK_REMOTE_SINK_MODE sink_mode)
+				    const char *extra_where, DBLINK_REMOTE_SINK_MODE sink_mode)
 {
   ACCESS_SPEC_TYPE *specp = xasl->spec_list;
   SCAN_CODE xb_scan, ls_scan;
@@ -12881,11 +12886,15 @@ qexec_execute_remote_delete_reduce (THREAD_ENTRY * thread_p, XASL_NODE * xasl, X
       return NO_ERROR;
     }
 
-  /* row_count == 0: the local subquery is empty, so ALL is vacuously true -- delete every remote row.
-   * dblink_dml_build_delete_sql() builds a WHERE-less DELETE when key_col is NULL; bind_count 0 means
-   * dblink_dml_execute_row() skips binding (boundary is unset DB_NULL in this case, never read). */
+  /* row_count == 0: the local subquery is empty, so ALL is vacuously true -- delete every remote row
+   * (or every row matching extra_where, if a remote-only AND arm is present: TRUE AND extra_where is
+   * just extra_where). dblink_dml_build_delete_sql() builds a WHERE-less (or extra_where-only) DELETE
+   * when key_col is NULL; bind_count 0 means dblink_dml_execute_row() skips binding (boundary is unset
+   * DB_NULL in this case, never read). extra_where itself never needs a placeholder (gate-enforced
+   * literal-only shape), so it is passed through unconditionally either way. */
   if (dblink_dml_open (thread_p, DBLINK_DML_DELETE, sink->url, sink->user, sink->pwd, sink->table_name, NULL, 0, 0,
-		       (row_count == 0) ? NULL : key_col, (row_count == 0) ? NULL : op, &dblink_state) != NO_ERROR)
+		       (row_count == 0) ? NULL : key_col, (row_count == 0) ? NULL : op, extra_where,
+		       &dblink_state) != NO_ERROR)
     {
       qexec_failure_line (__LINE__, xasl_state);
       pr_clear_value (&boundary);

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -12747,13 +12747,19 @@ exit_on_error:
  *   sink_mode(in)  : DBLINK_SINK_MODE_REDUCE_MIN, DBLINK_SINK_MODE_REDUCE_MAX, or
  *                    DBLINK_SINK_MODE_EQ_ALL
  *
- * Note: A NULL anywhere in the local subquery result makes the comparison unknown for every remote row
- *   (ALL over a set containing NULL), so this leaves the remote table untouched -- no connection is
- *   opened. An empty local subquery result is vacuously true for ALL, so every remote row is deleted
- *   instead, or every row matching extra_where if a remote-only AND arm is present (dblink_dml_open/
- *   dblink_dml_build_delete_sql with a NULL key_col builds a WHERE-less, or extra_where-only, DELETE
- *   for this case). For EQ_ALL specifically, if the local subquery rows do not all share one value,
- *   "col = ALL (...)" is always false, so the remote table is also left untouched.
+ * What the scan decides, in one table (values_seen counts the rows that reached the reduction, so it is 0
+ * only when the local subquery returned nothing -- a NULL row returns early, before any row is counted):
+ *
+ *   scan outcome                       | remote effect
+ *   -----------------------------------+-------------------------------------------------------------
+ *   a NULL in the set                  | nothing: ALL over a set containing NULL is unknown for every
+ *                                      | remote row. No connection is opened
+ *   values_seen == 0 (empty subquery)  | delete every remote row: ALL over the empty set is vacuously
+ *                                      | true. A WHERE-less DELETE, or extra_where-only when a
+ *                                      | remote-only AND arm is present
+ *   EQ_ALL, values differ              | nothing: "col = ALL (...)" is then always false
+ *   otherwise                          | one DELETE bound to the reduced value (MIN, MAX, or the one
+ *                                      | value every row shares)
  */
 static int
 qexec_execute_remote_delete_reduce (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_state,
@@ -12768,7 +12774,8 @@ qexec_execute_remote_delete_reduce (THREAD_ENTRY * thread_p, XASL_NODE * xasl, X
   bool has_boundary = false;
   bool null_seen = false;
   bool all_equal = true;
-  int row_count = 0;
+  bool delete_all;
+  int values_seen = 0;
   int row_affected;
   DBLINK_DML_STATE dblink_state = { -1, -1 };
 
@@ -12812,7 +12819,7 @@ qexec_execute_remote_delete_reduce (THREAD_ENTRY * thread_p, XASL_NODE * xasl, X
 	      continue;
 	    }
 
-	  row_count++;
+	  values_seen++;
 	  if (!has_boundary)
 	    {
 	      if (pr_clone_value (bindv[0], &boundary) != NO_ERROR)
@@ -12879,21 +12886,21 @@ qexec_execute_remote_delete_reduce (THREAD_ENTRY * thread_p, XASL_NODE * xasl, X
       return NO_ERROR;
     }
 
-  if (sink_mode == DBLINK_SINK_MODE_EQ_ALL && row_count > 0 && !all_equal)
+  if (sink_mode == DBLINK_SINK_MODE_EQ_ALL && values_seen > 0 && !all_equal)
     {
       /* local subquery rows do not all share one value: "col = ALL (...)" is always false */
       pr_clear_value (&boundary);
       return NO_ERROR;
     }
 
-  /* row_count == 0: the local subquery is empty, so ALL is vacuously true -- delete every remote row
-   * (or every row matching extra_where, if a remote-only AND arm is present: TRUE AND extra_where is
-   * just extra_where). dblink_dml_build_delete_sql() builds a WHERE-less (or extra_where-only) DELETE
-   * when key_col is NULL; bind_count 0 means dblink_dml_execute_row() skips binding (boundary is unset
-   * DB_NULL in this case, never read). extra_where itself never needs a placeholder (gate-enforced
-   * literal-only shape), so it is passed through unconditionally either way. */
+  /* The empty-subquery row of the table above: a NULL key_col makes dblink_dml_build_delete_sql() build a
+   * WHERE-less (or extra_where-only) DELETE, and bind count 0 makes dblink_dml_execute_row() skip binding
+   * (boundary stays the unset DB_NULL and is never read). extra_where never needs a placeholder itself
+   * (gate-enforced literal-only shape), so it is passed through either way. */
+  delete_all = (values_seen == 0);
+
   if (dblink_dml_open (thread_p, DBLINK_DML_DELETE, sink->url, sink->user, sink->pwd, sink->table_name, NULL, 0, 0,
-		       (row_count == 0) ? NULL : key_col, (row_count == 0) ? NULL : op, extra_where,
+		       delete_all ? NULL : key_col, delete_all ? NULL : op, extra_where,
 		       &dblink_state) != NO_ERROR)
     {
       qexec_failure_line (__LINE__, xasl_state);
@@ -12901,7 +12908,7 @@ qexec_execute_remote_delete_reduce (THREAD_ENTRY * thread_p, XASL_NODE * xasl, X
     }
 
   bindv[0] = &boundary;
-  if (dblink_dml_execute_row (thread_p, &dblink_state, bindv, (row_count == 0) ? 0 : 1, &row_affected) != NO_ERROR)
+  if (dblink_dml_execute_row (thread_p, &dblink_state, bindv, delete_all ? 0 : 1, &row_affected) != NO_ERROR)
     {
       qexec_failure_line (__LINE__, xasl_state);
       goto dml_error;
@@ -12914,6 +12921,7 @@ qexec_execute_remote_delete_reduce (THREAD_ENTRY * thread_p, XASL_NODE * xasl, X
 
   return NO_ERROR;
 
+  /* failed after the scan was closed and the remote statement opened: undo the remote side */
 dml_error:
   dblink_dml_close (&dblink_state);
   dblink_dml_rollback (thread_p, &dblink_state);
@@ -12921,6 +12929,7 @@ dml_error:
 
   return ER_FAILED;
 
+  /* failed while scanning, before any remote connection existed */
 exit_on_error:
   qexec_end_scan (thread_p, specp);
   qexec_close_scan (thread_p, specp);

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -12742,9 +12742,9 @@ exit_on_error:
  *
  * Note: A NULL anywhere in the local subquery result makes the comparison unknown for every remote row
  *   (ALL over a set containing NULL), so this leaves the remote table untouched -- no connection is
- *   opened. An empty local subquery result is also left untouched here; turning that into "delete every
- *   remote row" is a separate follow-up (empty set is vacuously true for ALL, the SQL builder needs a
- *   WHERE-less DELETE for it).
+ *   opened. An empty local subquery result is vacuously true for ALL, so every remote row is deleted
+ *   instead (dblink_dml_open/dblink_dml_build_delete_sql with a NULL key_col builds a WHERE-less
+ *   DELETE for this case).
  */
 static int
 qexec_execute_remote_delete_reduce (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_state,
@@ -12846,14 +12846,17 @@ qexec_execute_remote_delete_reduce (THREAD_ENTRY * thread_p, XASL_NODE * xasl, X
 
   qexec_close_scan (thread_p, specp);
 
-  if (null_seen || row_count == 0)
+  if (null_seen)
     {
       pr_clear_value (&boundary);
       return NO_ERROR;
     }
 
+  /* row_count == 0: the local subquery is empty, so ALL is vacuously true -- delete every remote row.
+   * dblink_dml_build_delete_sql() builds a WHERE-less DELETE when key_col is NULL; bind_count 0 means
+   * dblink_dml_execute_row() skips binding (boundary is unset DB_NULL in this case, never read). */
   if (dblink_dml_open (thread_p, DBLINK_DML_DELETE, sink->url, sink->user, sink->pwd, sink->table_name, NULL, 0, 0,
-		       key_col, op, &dblink_state) != NO_ERROR)
+		       (row_count == 0) ? NULL : key_col, (row_count == 0) ? NULL : op, &dblink_state) != NO_ERROR)
     {
       qexec_failure_line (__LINE__, xasl_state);
       pr_clear_value (&boundary);
@@ -12861,7 +12864,7 @@ qexec_execute_remote_delete_reduce (THREAD_ENTRY * thread_p, XASL_NODE * xasl, X
     }
 
   bindv[0] = &boundary;
-  if (dblink_dml_execute_row (thread_p, &dblink_state, bindv, 1, &row_affected) != NO_ERROR)
+  if (dblink_dml_execute_row (thread_p, &dblink_state, bindv, (row_count == 0) ? 0 : 1, &row_affected) != NO_ERROR)
     {
       qexec_failure_line (__LINE__, xasl_state);
       dblink_dml_close (&dblink_state);

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -12610,13 +12610,13 @@ qexec_execute_remote_dml_sink (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_S
 
   assert (sink->is_remote);
 
-  /* comparison ALL (< ALL / <= ALL / > ALL / >= ALL) reduces to a single remote push instead of one
-   * per local subquery row -- handled by a dedicated path that scans the local subquery before opening
-   * the remote connection, since the bound value must be known before the DELETE can be prepared.
-   * EQ_ALL is not yet covered here (its "all rows share one value" check is a separate task) and falls
-   * through to the per-row loop below like PER_ROW. */
+  /* comparison ALL (< ALL / <= ALL / > ALL / >= ALL / = ALL) reduces to a single remote push instead
+   * of one per local subquery row -- handled by a dedicated path that scans the local subquery before
+   * opening the remote connection, since the bound value must be known before the DELETE can be
+   * prepared. */
   if (kind == DBLINK_DML_DELETE
-      && (sink_mode == DBLINK_SINK_MODE_REDUCE_MIN || sink_mode == DBLINK_SINK_MODE_REDUCE_MAX))
+      && (sink_mode == DBLINK_SINK_MODE_REDUCE_MIN || sink_mode == DBLINK_SINK_MODE_REDUCE_MAX
+	  || sink_mode == DBLINK_SINK_MODE_EQ_ALL))
     {
       return qexec_execute_remote_delete_reduce (thread_p, xasl, xasl_state, sink, key_col, op, sink_mode);
     }
@@ -12729,22 +12729,26 @@ exit_on_error:
 
 /*
  * qexec_execute_remote_delete_reduce () - Reduce-mode variant of the remote DELETE sink for comparison
- *   ALL: scan the local subquery fully first to find the single MIN/MAX bound, then push at most one
- *   remote DELETE using that bound, instead of one push per local subquery row.
+ *   ALL: scan the local subquery fully first to find the single value the remote DELETE needs, then
+ *   push at most one remote DELETE using it, instead of one push per local subquery row. REDUCE_MIN/
+ *   REDUCE_MAX reduce to the running MIN/MAX; EQ_ALL reduces to "the one value every row shares" (or
+ *   determines that no such value exists).
  *   return: NO_ERROR or ER_FAILED
  *   xasl(in)       : DELETE_PROC XASL with sink.is_remote set; specp scans the already-materialized
  *                    local subquery list file (see qexec_execute_remote_dml_sink's Note)
  *   xasl_state(in) : XASL state
  *   sink(in)       : remote connection info (url/user/pwd/table_name)
  *   key_col(in)    : remote WHERE column
- *   op(in)         : comparison operator SQL text ("<", "<=", ">", ">=")
- *   sink_mode(in)  : DBLINK_SINK_MODE_REDUCE_MIN or DBLINK_SINK_MODE_REDUCE_MAX
+ *   op(in)         : comparison operator SQL text ("<", "<=", ">", ">=", "=")
+ *   sink_mode(in)  : DBLINK_SINK_MODE_REDUCE_MIN, DBLINK_SINK_MODE_REDUCE_MAX, or
+ *                    DBLINK_SINK_MODE_EQ_ALL
  *
  * Note: A NULL anywhere in the local subquery result makes the comparison unknown for every remote row
  *   (ALL over a set containing NULL), so this leaves the remote table untouched -- no connection is
  *   opened. An empty local subquery result is vacuously true for ALL, so every remote row is deleted
  *   instead (dblink_dml_open/dblink_dml_build_delete_sql with a NULL key_col builds a WHERE-less
- *   DELETE for this case).
+ *   DELETE for this case). For EQ_ALL specifically, if the local subquery rows do not all share one
+ *   value, "col = ALL (...)" is always false, so the remote table is also left untouched.
  */
 static int
 qexec_execute_remote_delete_reduce (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_state,
@@ -12758,6 +12762,7 @@ qexec_execute_remote_delete_reduce (THREAD_ENTRY * thread_p, XASL_NODE * xasl, X
   DB_VALUE boundary;
   bool has_boundary = false;
   bool null_seen = false;
+  bool all_equal = true;
   int row_count = 0;
   int row_affected;
   DBLINK_DML_STATE dblink_state = { -1, -1 };
@@ -12795,6 +12800,12 @@ qexec_execute_remote_delete_reduce (THREAD_ENTRY * thread_p, XASL_NODE * xasl, X
 	    {
 	      continue;
 	    }
+	  if (sink_mode == DBLINK_SINK_MODE_EQ_ALL && !all_equal)
+	    {
+	      /* a differing value already proved "col = ALL (...)" is always false; the outcome
+	       * is decided, so stop paying for tp_value_compare on the remaining rows. */
+	      continue;
+	    }
 
 	  row_count++;
 	  if (!has_boundary)
@@ -12815,6 +12826,17 @@ qexec_execute_remote_delete_reduce (THREAD_ENTRY * thread_p, XASL_NODE * xasl, X
 		  /* not cleanly comparable (e.g. DB_UNK) -- ALL's boundary becomes undecidable,
 		   * the same conservative call as a NULL in the set. */
 		  null_seen = true;
+		  continue;
+		}
+
+	      if (sink_mode == DBLINK_SINK_MODE_EQ_ALL)
+		{
+		  if (cmp != DB_EQ)
+		    {
+		      /* a differing value proves "col = ALL (...)" is always false; boundary no
+		       * longer matters, but keep draining the scan like the NULL case above. */
+		      all_equal = false;
+		    }
 		  continue;
 		}
 
@@ -12848,6 +12870,13 @@ qexec_execute_remote_delete_reduce (THREAD_ENTRY * thread_p, XASL_NODE * xasl, X
 
   if (null_seen)
     {
+      pr_clear_value (&boundary);
+      return NO_ERROR;
+    }
+
+  if (sink_mode == DBLINK_SINK_MODE_EQ_ALL && row_count > 0 && !all_equal)
+    {
+      /* local subquery rows do not all share one value: "col = ALL (...)" is always false */
       pr_clear_value (&boundary);
       return NO_ERROR;
     }

--- a/src/query/stream_to_xasl.c
+++ b/src/query/stream_to_xasl.c
@@ -3929,6 +3929,8 @@ stx_build_delete_proc (THREAD_ENTRY * thread_p, char *ptr, DELETE_PROC_NODE * de
     delete_info->remote_sink_mode = (DBLINK_REMOTE_SINK_MODE) mode;
   }
 
+  delete_info->remote_extra_where = stx_restore_string (thread_p, ptr);
+
   return ptr;
 
 error:

--- a/src/query/stream_to_xasl.c
+++ b/src/query/stream_to_xasl.c
@@ -3922,6 +3922,13 @@ stx_build_delete_proc (THREAD_ENTRY * thread_p, char *ptr, DELETE_PROC_NODE * de
   delete_info->remote_key_col = stx_restore_string (thread_p, ptr);
   delete_info->remote_op = stx_restore_string (thread_p, ptr);
 
+  {
+    int mode;
+
+    ptr = or_unpack_int (ptr, &mode);
+    delete_info->remote_sink_mode = (DBLINK_REMOTE_SINK_MODE) mode;
+  }
+
   return ptr;
 
 error:

--- a/src/query/stream_to_xasl.c
+++ b/src/query/stream_to_xasl.c
@@ -3875,6 +3875,7 @@ static char *
 stx_build_delete_proc (THREAD_ENTRY * thread_p, char *ptr, DELETE_PROC_NODE * delete_info)
 {
   int offset;
+  int sink_mode;
   XASL_UNPACK_INFO *xasl_unpack_info = get_xasl_unpack_info_ptr (thread_p);
 
   ptr = or_unpack_int (ptr, &delete_info->num_classes);
@@ -3922,12 +3923,8 @@ stx_build_delete_proc (THREAD_ENTRY * thread_p, char *ptr, DELETE_PROC_NODE * de
   delete_info->remote_key_col = stx_restore_string (thread_p, ptr);
   delete_info->remote_op = stx_restore_string (thread_p, ptr);
 
-  {
-    int mode;
-
-    ptr = or_unpack_int (ptr, &mode);
-    delete_info->remote_sink_mode = (DBLINK_REMOTE_SINK_MODE) mode;
-  }
+  ptr = or_unpack_int (ptr, &sink_mode);
+  delete_info->remote_sink_mode = (DBLINK_REMOTE_SINK_MODE) sink_mode;
 
   delete_info->remote_extra_where = stx_restore_string (thread_p, ptr);
 

--- a/src/query/xasl.h
+++ b/src/query/xasl.h
@@ -453,7 +453,7 @@ struct delete_proc_node
   /* remote DELETE + local subquery sink fields (DELETE FROM remote WHERE col op (SELECT FROM local)) */
   REMOTE_DML_SINK sink;
   char *remote_key_col;		/* remote target column on the WHERE left-hand side (e.g. rc1) */
-  char *remote_op;		/* comparison operator pushed to the remote WHERE: "=", "<", ">", "<=", ">=" */
+  char *remote_op;		/* comparison operator pushed to the remote WHERE: "=", "<>", "<", ">", "<=", ">=" */
 };
 
 typedef struct connectby_proc_node CONNECTBY_PROC_NODE;

--- a/src/query/xasl.h
+++ b/src/query/xasl.h
@@ -439,6 +439,21 @@ struct insert_proc_node
   int remote_num_attrs;		/* length of remote_attr_names */
 };
 
+/* how the remote DELETE sink derives the value(s) it pushes for the WHERE predicate. PER_ROW pushes
+ * one remote statement per row of the local subquery's result (IN / ANY / scalar comparisons); the
+ * REDUCE_* / EQ_ALL modes instead push a single remote statement built from a value reduced locally
+ * over the whole subquery result (comparison ALL). Not yet wired into xts_process_delete_proc /
+ * xts_sizeof_delete_proc / stx_build_delete_proc -- a CS-mode pack/unpack round trip currently leaves
+ * this field as uninitialized memory, not PER_ROW. Nothing reads it yet, but any runtime code path
+ * that does must land the serialization wiring first. */
+typedef enum dblink_remote_sink_mode
+{
+  DBLINK_SINK_MODE_PER_ROW = 0,	/* col {= | <> | < | > | <= | >=} (subquery|ANY): one push per row */
+  DBLINK_SINK_MODE_REDUCE_MIN,	/* col {< | <=} ALL (subquery): push once using the local MIN */
+  DBLINK_SINK_MODE_REDUCE_MAX,	/* col {> | >=} ALL (subquery): push once using the local MAX */
+  DBLINK_SINK_MODE_EQ_ALL	/* col = ALL (subquery): push once if all rows share one value */
+} DBLINK_REMOTE_SINK_MODE;
+
 typedef struct delete_proc_node DELETE_PROC_NODE;
 struct delete_proc_node
 {
@@ -454,6 +469,7 @@ struct delete_proc_node
   REMOTE_DML_SINK sink;
   char *remote_key_col;		/* remote target column on the WHERE left-hand side (e.g. rc1) */
   char *remote_op;		/* comparison operator pushed to the remote WHERE: "=", "<>", "<", ">", "<=", ">=" */
+  DBLINK_REMOTE_SINK_MODE remote_sink_mode;	/* per-row push vs. locally-reduced single push */
 };
 
 typedef struct connectby_proc_node CONNECTBY_PROC_NODE;

--- a/src/query/xasl.h
+++ b/src/query/xasl.h
@@ -445,7 +445,7 @@ struct insert_proc_node
  * over the whole subquery result (comparison ALL). */
 typedef enum dblink_remote_sink_mode
 {
-  DBLINK_SINK_MODE_PER_ROW = 0,	/* col {= | <> | < | > | <= | >=} (subquery|ANY): one push per row */
+  DBLINK_SINK_MODE_PER_ROW = 0,	/* col {IN | = | <> | < | > | <= | >=} (subquery|ANY): one push per row */
   DBLINK_SINK_MODE_REDUCE_MIN,	/* col {< | <=} ALL (subquery): push once using the local MIN */
   DBLINK_SINK_MODE_REDUCE_MAX,	/* col {> | >=} ALL (subquery): push once using the local MAX */
   DBLINK_SINK_MODE_EQ_ALL	/* col = ALL (subquery): push once if all rows share one value */

--- a/src/query/xasl.h
+++ b/src/query/xasl.h
@@ -442,10 +442,7 @@ struct insert_proc_node
 /* how the remote DELETE sink derives the value(s) it pushes for the WHERE predicate. PER_ROW pushes
  * one remote statement per row of the local subquery's result (IN / ANY / scalar comparisons); the
  * REDUCE_* / EQ_ALL modes instead push a single remote statement built from a value reduced locally
- * over the whole subquery result (comparison ALL). Not yet wired into xts_process_delete_proc /
- * xts_sizeof_delete_proc / stx_build_delete_proc -- a CS-mode pack/unpack round trip currently leaves
- * this field as uninitialized memory, not PER_ROW. Nothing reads it yet, but any runtime code path
- * that does must land the serialization wiring first. */
+ * over the whole subquery result (comparison ALL). */
 typedef enum dblink_remote_sink_mode
 {
   DBLINK_SINK_MODE_PER_ROW = 0,	/* col {= | <> | < | > | <= | >=} (subquery|ANY): one push per row */

--- a/src/query/xasl.h
+++ b/src/query/xasl.h
@@ -467,6 +467,7 @@ struct delete_proc_node
   char *remote_key_col;		/* remote target column on the WHERE left-hand side (e.g. rc1) */
   char *remote_op;		/* comparison operator pushed to the remote WHERE: "=", "<>", "<", ">", "<=", ">=" */
   DBLINK_REMOTE_SINK_MODE remote_sink_mode;	/* per-row push vs. locally-reduced single push */
+  char *remote_extra_where;	/* deparsed remote-only AND arm(s), e.g. "name <> 'x'" (NULL if none) */
 };
 
 typedef struct connectby_proc_node CONNECTBY_PROC_NODE;

--- a/src/query/xasl_to_stream.c
+++ b/src/query/xasl_to_stream.c
@@ -4261,6 +4261,13 @@ xts_process_delete_proc (char *ptr, const DELETE_PROC_NODE * delete_info)
 
   ptr = or_pack_int (ptr, (int) delete_info->remote_sink_mode);
 
+  offset = xts_save_string (delete_info->remote_extra_where);
+  if (offset == ER_FAILED)
+    {
+      return NULL;
+    }
+  ptr = or_pack_int (ptr, offset);
+
   return ptr;
 }
 
@@ -6598,7 +6605,8 @@ xts_sizeof_delete_proc (const DELETE_PROC_NODE * delete_info)
 	   + xts_sizeof_remote_dml_sink ()	/* remote DELETE + local subquery sink fields */
 	   + PTR_SIZE		/* remote_key_col */
 	   + PTR_SIZE		/* remote_op */
-	   + OR_INT_SIZE);	/* remote_sink_mode */
+	   + OR_INT_SIZE	/* remote_sink_mode */
+	   + PTR_SIZE);		/* remote_extra_where */
 
   return size;
 }

--- a/src/query/xasl_to_stream.c
+++ b/src/query/xasl_to_stream.c
@@ -4259,6 +4259,8 @@ xts_process_delete_proc (char *ptr, const DELETE_PROC_NODE * delete_info)
     }
   ptr = or_pack_int (ptr, offset);
 
+  ptr = or_pack_int (ptr, (int) delete_info->remote_sink_mode);
+
   return ptr;
 }
 
@@ -6595,7 +6597,8 @@ xts_sizeof_delete_proc (const DELETE_PROC_NODE * delete_info)
 	   + PTR_SIZE		/* mvcc_cond_reev_classes */
 	   + xts_sizeof_remote_dml_sink ()	/* remote DELETE + local subquery sink fields */
 	   + PTR_SIZE		/* remote_key_col */
-	   + PTR_SIZE);		/* remote_op */
+	   + PTR_SIZE		/* remote_op */
+	   + OR_INT_SIZE);	/* remote_sink_mode */
 
   return size;
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26921

### Purpose
N/A

### Implementation
N/A

### Remarks
N/A