### PR TITLE
[CBRD-27172] rev: Complex static query error within SP (#7742)

### DIFF
--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -12512,6 +12512,16 @@ pt_print_function (PARSER_CONTEXT * parser, PT_NODE * p)
   FUNC_CODE code;
   PARSER_VARCHAR *q = 0, *r1;
   PT_NODE *order_by = NULL;
+  unsigned int save_custom = parser->custom_print;
+
+  /* a function argument is never followed by "AS alias" in SQL syntax; an arg_list member's own
+   * alias_print may be set for unrelated bookkeeping (e.g. carried over from view/subquery
+   * merging), so it must not leak into the printed text here -- restored below, right before
+   * this call's own alias (if any) is appended. */
+  if (parser->flag.is_parsing_static_sql)
+    {
+      parser->custom_print &= ~PT_PRINT_ALIAS;
+    }
 
   code = p->info.function.function_type;
   if (code == PT_GENERIC)
@@ -12745,6 +12755,11 @@ pt_print_function (PARSER_CONTEXT * parser, PT_NODE * p)
 	  q = pt_append_varchar (parser, q, r1);
 	}
       q = pt_append_nulstring (parser, q, ")");
+    }
+
+  if (parser->flag.is_parsing_static_sql)
+    {
+      parser->custom_print = save_custom;
     }
 
   if ((parser->custom_print & PT_PRINT_ALIAS) && p->alias_print != NULL)


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27172>

### Purpose

```
일반 SQL 클라이언트 (dbeaver등) 에서는 정상 구동되는 쿼리가, function 내부의 정적(static)으로 사용할때 내부 처리방식으로 인해 발생하는 문제 해결

CREATE TABLE t (name VARCHAR(40));
INSERT INTO t VALUES ('a'), ('b');

-- non-mergeable(집계) 뷰 본문 안에 derived table 이 있는 형태
CREATE VIEW v AS SELECT MAX(c) AS COL_1 FROM (SELECT name AS c FROM t);

CREATE OR REPLACE PROCEDURE p_view IS
  sr SYS_REFCURSOR;
BEGIN
  OPEN sr FOR SELECT V.COL_1 FROM v V;
  CLOSE sr;
END;

CALL p_view();

ERROR: Stored procedure execute error: 
  (line 4, column 3) Syntax: In line 1, column 42 before ' [c]) from [dba.t] V) V (COL_1)'
Syntax error: unexpected 'as', expecting ')'
```

위 쿼리 결과에서 에러 발생하는 문제 해결

### Implementation

backport from develop

### Remarks

N/A
