### PR TITLE
[CBRD-27257] [Backport] Keep the factor location when pt_cnf rebuilds an OR tree

### DIFF
--- a/src/parser/cnf.c
+++ b/src/parser/cnf.c
@@ -819,6 +819,11 @@ pt_transform_cnf_post (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *
 	    {			/* build OR-tree */
 	      list = pt_and (parser, arg1, arg2);
 	      list->info.expr.op = PT_OR;
+	      /* pt_and () builds a fresh node, so carry over what the factor being replaced held.
+	       * Losing 'location' turns a term that came from an outer join's ON condition into a
+	       * WHERE level (after join) term, which then rejects the null padded rows. */
+	      list->info.expr.location = node->info.expr.location;
+	      list->type_enum = PT_TYPE_LOGICAL;
 	    }
 	  else
 	    {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27257

## Purpose

develop 의 CBRD-27257 수정(#7729, `53226298b`)을 `release/11.3` 로 백포트합니다.
JIRA 의 Planned Version(s) 가 `10.2 Patch 19` / `11.0 Patch 17` / `11.3 Patch 6` / `11.4 Patch 6` / `guava` 라서 브랜치별로 같은 백포트 PR 을 하나씩 등록합니다.

OUTER JOIN 의 ON 절에 일정 크기를 넘는 OR 술어가 있으면 NULL 패딩 행이 사라져 **INNER JOIN 과 같은 결과**가 반환됩니다(오답). `release/11.3` 에서도 그대로 재현됩니다.

```sql
CREATE TABLE p (id INT);  INSERT INTO p VALUES (1),(2),(3);
CREATE TABLE q (id INT, v1 INT, v2 INT, v3 INT, v4 INT, v5 INT);
INSERT INTO q VALUES (1,1,1,1,1,1);

-- 3분기 x 4리프 = 64 (<=100)  -> (1,1) (2,NULL) (3,NULL)   정상
-- 3분기 x 5리프 = 125 (>100)  -> (1,1) 뿐                   오답
SELECT p.id, q.id FROM p LEFT OUTER JOIN q
  ON p.id=q.id AND ((q.v1=1 AND q.v2=1 AND q.v3=1 AND q.v4=1 AND q.v5=1)
                 OR (q.v1=2 AND q.v2=2 AND q.v3=2 AND q.v4=2 AND q.v5=2)
                 OR (q.v1=3 AND q.v2=3 AND q.v3=3 AND q.v4=3 AND q.v5=3));
```

`count_and_or ()` 가 100 을 넘으면 `pt_transform_cnf_post ()` 가 `TRANSFORM_CNF_OR_COMPACT` 경로로 OR 트리를 새로 만드는데, `pt_and ()` 는 op/arg1/arg2 만 세우므로 새 노드의 `info.expr.location` 이 0 이 됩니다. 그러면 ON 에서 온 팩터가 `qo_analyze_term ()` 에서 WHERE 레벨 `(after join term)` 으로 분류되어 패딩 행을 걸러 버립니다. 임계값 이하(<=100)에서는 `or_next` 분배 경로라 location 이 살아남아 정상 동작합니다.

## Implementation

develop 커밋 `53226298b` 를 `git cherry-pick -x` 로 그대로 적용했습니다(충돌 없음). `src/parser/cnf.c` 한 파일 5줄이며, 주변 코드도 develop 과 동일합니다.

```c
list = pt_and (parser, arg1, arg2);
list->info.expr.op = PT_OR;
list->info.expr.location = node->info.expr.location;   /* 추가 */
list->type_enum = PT_TYPE_LOGICAL;                     /* 추가 */
```

## Remarks

`release/11.3`(`e493759e8`) 기준으로 백포트 **적용 전/후 릴리스 빌드**를 각각 만들어 A/B 검증했습니다(SA 모드, 위 스키마).

| # | 케이스 | release/11.3 | 이 PR |
|---|---|---|---|
| C1 | LEFT OUTER, ON 작은 OR (65 <= 100) | 3 rows | 3 rows |
| C2 | LEFT OUTER, ON 큰 OR (3x5=125) | **1 row** | 3 rows |
| C3 | LEFT OUTER, ON 큰 OR (4x4=256) | **1 row** | 3 rows |
| C4 | RIGHT OUTER, ON 큰 OR | **1 row** | 3 rows |
| C5 | LEFT OUTER, ON 큰 OR + 매칭 없음 | **0 rows** | 3 rows |
| C6 | INNER JOIN, ON 큰 OR | 1 row | 1 row |
| C7 | LEFT OUTER + WHERE 레벨 큰 OR | 1 row | 1 row |
| C8 | 단일 테이블 WHERE 큰 OR | 1 row | 1 row |
| C9 | 인라인 뷰 대상 LEFT OUTER, ON 큰 OR | **1 row** | 3 rows |

**차분 퍼저** — 무작위 술어 200개(분기 2~4 x 리프 1~6, 6개 컬럼 x 6개 연산자)를 세 가지 형태로 총 600질의 실행했습니다. `b.id` 가 PK 라 `a LEFT OUTER JOIN b` 의 `COUNT(*)` 는 술어와 무관하게 항상 `|a|`(=8) 여야 한다는 오라클을 씁니다.

| 질의 형태 | 건수 | release/11.3 | 이 PR |
|---|---|---|---|
| ON 절 큰 OR (count_and_or > 100) | 53 | **53건 전부 내부 오류** (`Internal error- reporting semantic error`) | 오류 0, 위반 0 |
| ON 절 작은 OR (<= 100) | 147 | 위반 0 | 위반 0 |
| WHERE 레벨 큰/작은 OR | 200 | — | 200건 결과 동일 |
| INNER JOIN | 200 | — | 200건 결과 동일 |

`SELECT COUNT(*)` 처럼 outer 스펙의 컬럼을 투영하지 않는 형태에서는 오답 대신 outer 스펙이 통째로 제거되어 위 내부 오류가 납니다(같은 원인). 컬럼을 투영하는 C2~C5, C9 형태에서는 오답으로 나타납니다.

**TC**: develop 수정(#7729)에는 별도 테스트케이스가 없습니다(자동 생성된 TC draft PR `cubrid-testcases#3292` 는 변경 없이 close 됨). 필요하면 위 C1~C9 를 sql 테스트케이스로 추가하겠습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
