### PR TITLE
[CBRD-26910] cherrypick CDC fixes from release/11.4_hotfix to release/11.4

### DIFF
--- a/src/api/cubrid_log.c
+++ b/src/api/cubrid_log.c
@@ -1822,11 +1822,6 @@ cubrid_log_extract (uint64_t * lsa, CUBRID_LOG_ITEM ** log_item_list, int *list_
   int err_code;
   int rc;
 
-  if (g_trace_log_level == 1)
-    {
-      CUBRID_LOG_WRITE_TRACELOG ("[INPUT] current stage (%d), lsa (%lld)\n", g_stage, *lsa);
-    }
-
   if (g_stage != CUBRID_LOG_STAGE_PREPARATION && g_stage != CUBRID_LOG_STAGE_EXTRACTION)
     {
       CUBRID_LOG_ERROR_HANDLING (CUBRID_LOG_INVALID_FUNC_CALL_STAGE,
@@ -1840,6 +1835,11 @@ cubrid_log_extract (uint64_t * lsa, CUBRID_LOG_ITEM ** log_item_list, int *list_
 				 "lsa (%s), log_item_list(%s), list_size(%s) must not be null\n",
 				 lsa ? "not null" : "null", log_item_list ? "not null" : "null",
 				 list_size ? "not null" : "null");
+    }
+
+  if (g_trace_log_level == 1)
+    {
+      CUBRID_LOG_WRITE_TRACELOG ("[INPUT] current stage (%d), lsa (%lld)\n", g_stage, *lsa);
     }
 
   memcpy (&g_next_lsa, lsa, sizeof (LOG_LSA));

--- a/src/api/cubrid_log.c
+++ b/src/api/cubrid_log.c
@@ -500,6 +500,8 @@ cubrid_log_set_all_in_cond (int retrieve_all)
 int
 cubrid_log_set_extraction_table (uint64_t * classoid_arr, int arr_size)
 {
+  uint64_t *new_extraction_table = NULL;
+
   if (g_stage != CUBRID_LOG_STAGE_CONFIGURATION)
     {
       return CUBRID_LOG_INVALID_FUNC_CALL_STAGE;
@@ -510,13 +512,19 @@ cubrid_log_set_extraction_table (uint64_t * classoid_arr, int arr_size)
       return CUBRID_LOG_INVALID_CLASSOID_ARR_SIZE;
     }
 
-  g_extraction_table = (uint64_t *) malloc (sizeof (uint64_t) * arr_size);
-  if (g_extraction_table == NULL)
+  if (arr_size > 0)
     {
-      return CUBRID_LOG_FAILED_MALLOC;
+      new_extraction_table = (uint64_t *) malloc (sizeof (uint64_t) * arr_size);
+      if (new_extraction_table == NULL)
+	{
+	  return CUBRID_LOG_FAILED_MALLOC;
+	}
+
+      memcpy (new_extraction_table, classoid_arr, arr_size * sizeof (uint64_t));
     }
 
-  memcpy (g_extraction_table, classoid_arr, arr_size * sizeof (uint64_t));
+  free_and_init (g_extraction_table);
+  g_extraction_table = new_extraction_table;
   g_extraction_table_count = arr_size;
 
   return CUBRID_LOG_SUCCESS;
@@ -552,24 +560,36 @@ cubrid_log_set_extraction_user (char **user_arr, int arr_size)
 	}
     }
 
-  new_extraction_user = (char **) malloc (sizeof (char *) * arr_size);
-  if (new_extraction_user == NULL)
+  if (arr_size > 0)
     {
-      return CUBRID_LOG_FAILED_MALLOC;
-    }
-
-  for (i = 0; i < arr_size; i++)
-    {
-      new_extraction_user[i] = strdup (user_arr[i]);
-      if (new_extraction_user[i] == NULL)
+      new_extraction_user = (char **) malloc (sizeof (char *) * arr_size);
+      if (new_extraction_user == NULL)
 	{
-	  for (j = 0; j < i; j++)
-	    {
-	      free_and_init (new_extraction_user[j]);
-	    }
-	  free_and_init (new_extraction_user);
 	  return CUBRID_LOG_FAILED_MALLOC;
 	}
+
+      for (i = 0; i < arr_size; i++)
+	{
+	  new_extraction_user[i] = strdup (user_arr[i]);
+	  if (new_extraction_user[i] == NULL)
+	    {
+	      for (j = 0; j < i; j++)
+		{
+		  free_and_init (new_extraction_user[j]);
+		}
+	      free_and_init (new_extraction_user);
+	      return CUBRID_LOG_FAILED_MALLOC;
+	    }
+	}
+    }
+
+  if (g_extraction_user != NULL)
+    {
+      for (i = 0; i < g_extraction_user_count; i++)
+	{
+	  free_and_init (g_extraction_user[i]);
+	}
+      free_and_init (g_extraction_user);
     }
 
   g_extraction_user = new_extraction_user;
@@ -1350,6 +1370,13 @@ cubrid_log_make_dml (char **data_info, DML * dml)
 
   ptr = *data_info;
 
+  dml->changed_column_index = NULL;
+  dml->changed_column_data = NULL;
+  dml->changed_column_data_len = NULL;
+  dml->cond_column_index = NULL;
+  dml->cond_column_data = NULL;
+  dml->cond_column_data_len = NULL;
+
   ptr = or_unpack_int (ptr, &dml->dml_type);
   ptr = or_unpack_int64 (ptr, (INT64 *) & dml->classoid);
   ptr = or_unpack_int (ptr, &dml->num_changed_column);
@@ -1567,6 +1594,13 @@ cubrid_log_make_dml (char **data_info, DML * dml)
 
 cubrid_log_error:
 
+  free_and_init (dml->changed_column_index);
+  free_and_init (dml->changed_column_data);
+  free_and_init (dml->changed_column_data_len);
+  free_and_init (dml->cond_column_index);
+  free_and_init (dml->cond_column_data);
+  free_and_init (dml->cond_column_data_len);
+
   return err_code;
 }
 
@@ -1686,6 +1720,8 @@ cubrid_log_error:
   return err_code;
 }
 
+static int cubrid_log_clear_data_item (DATA_ITEM_TYPE data_item_type, CUBRID_DATA_ITEM * data_item);
+
 static int
 cubrid_log_make_log_item_list (int num_infos, int total_length, CUBRID_LOG_ITEM ** log_item_list, int *list_size)
 {
@@ -1737,8 +1773,16 @@ cubrid_log_make_log_item_list (int num_infos, int total_length, CUBRID_LOG_ITEM 
 
   for (i = 0; i < num_infos; i++)
     {
-      if ((rc = cubrid_log_make_log_item (&ptr, &g_log_items[i]) != CUBRID_LOG_SUCCESS))
+      if ((rc = cubrid_log_make_log_item (&ptr, &g_log_items[i])) != CUBRID_LOG_SUCCESS)
 	{
+	  int j;
+
+	  for (j = 0; j < i; j++)
+	    {
+	      (void) cubrid_log_clear_data_item ((DATA_ITEM_TYPE) g_log_items[j].data_item_type,
+						 &g_log_items[j].data_item);
+	    }
+
 	  CUBRID_LOG_ERROR_HANDLING (rc, NULL);
 	}
 
@@ -2039,8 +2083,7 @@ cubrid_log_reset_globals (void)
 
   if (g_log_infos != NULL)
     {
-//      free (g_log_infos);
-      g_log_infos = NULL;
+      free_and_init (g_log_infos);
     }
 
   g_log_infos_size = 0;

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -3523,6 +3523,7 @@ end:
   RESET_HOST_VARIABLES_IF_INTERNAL_STATEMENT (parser);
 
   do_free_reserved_classinfo (reserved_cls_info);
+  free_and_init (reserved_oid);
 
   if (error == ER_FAILED)
     {
@@ -4211,6 +4212,7 @@ end:
   RESET_HOST_VARIABLES_IF_INTERNAL_STATEMENT (parser);
 
   do_free_reserved_classinfo (reserved_cls_info);
+  free_and_init (reserved_oid);
 
   return ((err == ER_FAILED && (err = er_errid ()) == NO_ERROR) ? ER_GENERIC_ERROR : err);
 }				/* do_execute_statement() */
@@ -16141,7 +16143,7 @@ end:
       free (host_val);
     }
 
-  if (oid != NULL)
+  if (oid != NULL && oid != reserved_oid)
     {
       free_and_init (oid);
     }

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -648,7 +648,8 @@ static DISK_ISVALID heap_hfid_isvalid (HFID * hfid);
 static DISK_ISVALID heap_scanrange_isvalid (HEAP_SCANRANGE * scan_range);
 #endif /* CUBRID_DEBUG */
 static OID *heap_ovf_insert (THREAD_ENTRY * thread_p, const HFID * hfid, OID * ovf_oid, RECDES * recdes);
-static const OID *heap_ovf_update (THREAD_ENTRY * thread_p, const HFID * hfid, const OID * ovf_oid, RECDES * recdes);
+static const OID *heap_ovf_update (THREAD_ENTRY * thread_p, const HFID * hfid, const OID * ovf_oid, RECDES * recdes,
+				   LOG_LSA * change_link_lsa);
 static int heap_ovf_flush (THREAD_ENTRY * thread_p, const OID * ovf_oid);
 static int heap_ovf_get_length (THREAD_ENTRY * thread_p, const OID * ovf_oid);
 static SCAN_CODE heap_ovf_get (THREAD_ENTRY * thread_p, const OID * ovf_oid, RECDES * recdes, int chn,
@@ -6526,11 +6527,13 @@ heap_ovf_insert (THREAD_ENTRY * thread_p, const HFID * hfid, OID * ovf_oid, RECD
  *   hfid(in): Object heap file identifier
  *   ovf_oid(in): Overflow address
  *   recdes(in): Record descriptor
+ *   change_link_lsa(out): LSA used to reconstruct the updated overflow record
  *
  * Note: Update the content of a multipage object.
  */
 static const OID *
-heap_ovf_update (THREAD_ENTRY * thread_p, const HFID * hfid, const OID * ovf_oid, RECDES * recdes)
+heap_ovf_update (THREAD_ENTRY * thread_p, const HFID * hfid, const OID * ovf_oid, RECDES * recdes,
+		 LOG_LSA * change_link_lsa)
 {
   VFID ovf_vfid;
   VPID ovf_vpid;
@@ -6543,7 +6546,7 @@ heap_ovf_update (THREAD_ENTRY * thread_p, const HFID * hfid, const OID * ovf_oid
   ovf_vpid.pageid = ovf_oid->pageid;
   ovf_vpid.volid = ovf_oid->volid;
 
-  if (overflow_update (thread_p, &ovf_vfid, &ovf_vpid, recdes, FILE_MULTIPAGE_OBJECT_HEAP) != NO_ERROR)
+  if (overflow_update (thread_p, &ovf_vfid, &ovf_vpid, recdes, FILE_MULTIPAGE_OBJECT_HEAP, change_link_lsa) != NO_ERROR)
     {
       ASSERT_ERROR ();
       return NULL;
@@ -22102,6 +22105,7 @@ heap_update_bigone (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context, b
   bool is_old_home_updated;
   RECDES new_home_recdes;
   VFID ovf_vfid;
+  LOG_LSA change_link_lsa = LSA_INITIALIZER;
 
   LOG_TDES *tdes = NULL;
 
@@ -22182,22 +22186,25 @@ heap_update_bigone (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context, b
       /* overflow -> overflow update */
       is_old_home_updated = false;
 
-      if (heap_ovf_update (thread_p, &context->hfid, &context->ovf_oid, context->recdes_p) == NULL)
+      if (heap_ovf_update (thread_p, &context->hfid, &context->ovf_oid, context->recdes_p,
+			   context->do_supplemental_log ? &change_link_lsa : NULL) == NULL)
 	{
 	  ASSERT_ERROR_AND_SET (error_code);
 	  goto exit;
 	}
 
-      /* supplemental log for REC_BIGONE to REC_BIGONE case 
+      /* supplemental log for REC_BIGONE to REC_BIGONE case
        * 1. MVCC : redo lsa for SUPPLEMENT_UPDATE, undo lsa has been saved above
        * 2. NON-MVCC : undo, redo lsa for SUPPLEMENT_UPDATE */
       if (context->do_supplemental_log)
 	{
-	  LSA_COPY (&context->supp_redo_lsa, &tdes->tail_lsa);
+	  assert (!LSA_ISNULL (&change_link_lsa));
+	  /* Page deallocation may append LOG_POSTPONE records, so do not use the transaction tail LSA here. */
+	  LSA_COPY (&context->supp_redo_lsa, &change_link_lsa);
 
 	  if (!is_mvcc_op)
 	    {
-	      LSA_COPY (&context->supp_undo_lsa, &tdes->tail_lsa);
+	      LSA_COPY (&context->supp_undo_lsa, &change_link_lsa);
 	    }
 	}
 

--- a/src/storage/overflow_file.c
+++ b/src/storage/overflow_file.c
@@ -363,6 +363,7 @@ exit_on_error:
  * ovf_vpid (in)  : VPID of first page in multi-page data
  * recdes (in)    : New multi-page data
  * file_type (in) : Overflow file type
+ * change_link_lsa (out) : LSA of the overflow link-change log record
  *
  * Note: The function may allocate or deallocate several overflow pages if the multipage data increase/decrease in
  *       length.
@@ -372,7 +373,7 @@ exit_on_error:
  */
 int
 overflow_update (THREAD_ENTRY * thread_p, const VFID * ovf_vfid, const VPID * ovf_vpid, RECDES * recdes,
-		 FILE_TYPE file_type)
+		 FILE_TYPE file_type, LOG_LSA * change_link_lsa)
 {
   OVERFLOW_FIRST_PART *first_part = NULL;
   OVERFLOW_REST_PART *rest_parts = NULL;
@@ -391,6 +392,11 @@ overflow_update (THREAD_ENTRY * thread_p, const VFID * ovf_vfid, const VPID * ov
   int error_code = NO_ERROR;
 
   assert (ovf_vfid != NULL && !VFID_ISNULL (ovf_vfid));
+
+  if (change_link_lsa != NULL)
+    {
+      LSA_SET_NULL (change_link_lsa);
+    }
 
   /* used only for heap for now... I left this here just in case other file types start using this.
    * If you hit this assert, check the code is alright for your usage (e.g. this doesn't consider temporary files).
@@ -547,6 +553,12 @@ overflow_update (THREAD_ENTRY * thread_p, const VFID * ovf_vfid, const VPID * ov
 
 	  log_append_undoredo_data (thread_p, RVOVF_CHANGE_LINK, &addr, sizeof (next_vpid), sizeof (next_vpid),
 				    &next_vpid, &tmp_vpid);
+
+	  if (change_link_lsa != NULL)
+	    {
+	      /* Save the CDC reconstruction anchor before file_dealloc() appends unrelated postpone log records. */
+	      LSA_COPY (change_link_lsa, logtb_find_current_tran_lsa (thread_p));
+	    }
 
 	  if (rest_parts == NULL)
 	    {

--- a/src/storage/overflow_file.h
+++ b/src/storage/overflow_file.h
@@ -53,7 +53,7 @@ struct overflow_rest_part
 extern int overflow_insert (THREAD_ENTRY * thread_p, const VFID * ovf_vfid, VPID * ovf_vpid, RECDES * recdes,
 			    FILE_TYPE file_type);
 extern int overflow_update (THREAD_ENTRY * thread_p, const VFID * ovf_vfid, const VPID * ovf_vpid, RECDES * recdes,
-			    FILE_TYPE file_type);
+			    FILE_TYPE file_type, LOG_LSA * change_link_lsa);
 extern const VPID *overflow_delete (THREAD_ENTRY * thread_p, const VFID * ovf_vfid, const VPID * ovf_vpid);
 extern void overflow_flush (THREAD_ENTRY * thread_p, const VPID * ovf_vpid);
 extern int overflow_get_length (THREAD_ENTRY * thread_p, const VPID * ovf_vpid);

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -11319,8 +11319,8 @@ cdc_get_recdes (THREAD_ENTRY * thread_p, LOG_LSA * undo_lsa, RECDES * undo_recde
   LOG_RECORD_HEADER *log_rec_hdr = NULL;
   int tmpbuf_index;
 
-  char *log_pgbuf[IO_MAX_PAGE_SIZE + MAX_ALIGNMENT];
-  char *preserved_log_pgbuf[IO_MAX_PAGE_SIZE + MAX_ALIGNMENT];
+  char log_pgbuf[IO_MAX_PAGE_SIZE + MAX_ALIGNMENT];
+  char preserved_log_pgbuf[IO_MAX_PAGE_SIZE + MAX_ALIGNMENT];
   LOG_PAGE *log_page_p = NULL;	// log_page for process_lsa : when process_lsa is advanced, then next log_page can be fetched into this buffer
   LOG_PAGE *preserved_log_page_p = NULL;	// log_page for redo/undo lsa
 
@@ -11708,8 +11708,11 @@ cdc_get_recdes (THREAD_ENTRY * thread_p, LOG_LSA * undo_lsa, RECDES * undo_recde
 		/*if LOG_MVCC_UNDOREDO_DATA_DIFF , get undo data first and get diff */
 		if (is_diff)
 		  {
-		    char temp_buf[IO_MAX_PAGE_SIZE + MAX_ALIGNMENT] = "\0";
+		    char temp_buf[IO_MAX_PAGE_SIZE + MAX_ALIGNMENT];
 		    LOG_PAGE *temp_pgptr = (LOG_PAGE *) PTR_ALIGN (temp_buf, MAX_ALIGNMENT);
+
+		    /* page id 0 is a valid data page; an empty buffer must not match any requested page */
+		    temp_pgptr->hdr.logical_pageid = NULL_LOG_PAGEID;
 
 		    scan_code = cdc_get_undo_record (thread_p, temp_pgptr, *redo_lsa, &tmp_undo_recdes);
 		    if (scan_code != S_SUCCESS)
@@ -11927,8 +11930,11 @@ cdc_get_recdes (THREAD_ENTRY * thread_p, LOG_LSA * undo_lsa, RECDES * undo_recde
 		/*if LOG_MVCC_UNDOREDO_DATA_DIFF , get undo data first and get diff */
 		if (is_diff)
 		  {
-		    char temp_buf[IO_MAX_PAGE_SIZE + MAX_ALIGNMENT] = "\0";
+		    char temp_buf[IO_MAX_PAGE_SIZE + MAX_ALIGNMENT];
 		    LOG_PAGE *temp_pgptr = (LOG_PAGE *) PTR_ALIGN (temp_buf, MAX_ALIGNMENT);
+
+		    /* page id 0 is a valid data page; an empty buffer must not match any requested page */
+		    temp_pgptr->hdr.logical_pageid = NULL_LOG_PAGEID;
 
 		    scan_code = cdc_get_undo_record (thread_p, temp_pgptr, *redo_lsa, &tmp_undo_recdes);
 		    if (scan_code != S_SUCCESS)
@@ -14471,7 +14477,7 @@ cdc_validate_lsa (THREAD_ENTRY * thread_p, LOG_LSA * lsa)
 {
   LOG_RECORD_HEADER *log_rec_header;
   LOG_PAGE *log_page_p = NULL;
-  char *log_pgbuf[IO_MAX_PAGE_SIZE + MAX_ALIGNMENT];
+  char log_pgbuf[IO_MAX_PAGE_SIZE + MAX_ALIGNMENT];
 
   LOG_LSA process_lsa;
 
@@ -14798,7 +14804,7 @@ cdc_get_lsa_with_start_point (THREAD_ENTRY * thread_p, time_t * time, LOG_LSA * 
   LOG_LSA current_lsa;
 
   LOG_PAGE *log_page_p = NULL;
-  char *log_pgbuf[IO_MAX_PAGE_SIZE + MAX_ALIGNMENT];
+  char log_pgbuf[IO_MAX_PAGE_SIZE + MAX_ALIGNMENT];
 
   LOG_RECORD_HEADER *log_rec_header;
   LOG_RECTYPE log_type;
@@ -15050,6 +15056,10 @@ cdc_initialize ()
     (LOG_PAGE *) PTR_ALIGN (cdc_Gl.producer.temp_logbuf[0].log_page, MAX_ALIGNMENT);
   cdc_Gl.producer.temp_logbuf[1].log_page_p =
     (LOG_PAGE *) PTR_ALIGN (cdc_Gl.producer.temp_logbuf[1].log_page, MAX_ALIGNMENT);
+
+  /* page id 0 is a valid data page; invalidate the temp log buffers so the first access always fetches */
+  cdc_Gl.producer.temp_logbuf[0].log_page_p->hdr.logical_pageid = NULL_LOG_PAGEID;
+  cdc_Gl.producer.temp_logbuf[1].log_page_p->hdr.logical_pageid = NULL_LOG_PAGEID;
 
   /*communication buffer from server to client initialization */
   cdc_Gl.consumer.log_info = NULL;

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -12122,6 +12122,15 @@ cdc_get_recdes (THREAD_ENTRY * thread_p, LOG_LSA * undo_lsa, RECDES * undo_recde
 	}
     }
 
+  /* A supplemental DML LSA must always reconstruct the requested row image. */
+  if ((undo_lsa != NULL && (undo_recdes == NULL || undo_recdes->data == NULL))
+      || (redo_lsa != NULL && (redo_recdes == NULL || redo_recdes->data == NULL)))
+    {
+      cdc_log ("cdc_get_recdes : failed to reconstruct record descriptor from supplemental log LSA");
+      error_code = ER_FAILED;
+      goto error;
+    }
+
   if (redo_data != NULL && is_redo_alloced)
     {
       free_and_init (redo_data);

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -11031,6 +11031,11 @@ end:
   return error;
 
 error:
+  if (supp_recdes.data != NULL)
+    {
+      free_and_init (supp_recdes.data);
+    }
+
   if (supplement_data != NULL)
     {
       free_and_init (supplement_data);
@@ -11179,6 +11184,9 @@ cdc_loginfo_producer_execute (cubthread::entry & thread_ref)
 		 LSA_AS_ARGS (&process_lsa));
 
 	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (CDC_LOGINFO_ENTRY));
+	      free_and_init (log_info_entry.log_info);
+	      LSA_COPY (&process_lsa, &cur_log_rec_lsa);
+	      thread_sleep (50);
 	      error = ER_OUT_OF_VIRTUAL_MEMORY;
 	      continue;
 	    }
@@ -11252,8 +11260,16 @@ cdc_get_undo_record (THREAD_ENTRY * thread_p, LOG_PAGE * log_page_p, LOG_LSA lsa
     {
       if (scan_code == S_DOESNT_FIT)
 	{
-	  undo_recdes->data = (char *) realloc (undo_recdes->data, (size_t) (-undo_recdes->length));	//realloc error 처리
-	  undo_recdes->area_size = (size_t) (-undo_recdes->length);
+	  size_t required_size = (size_t) (-undo_recdes->length);
+	  char *new_data = (char *) realloc (undo_recdes->data, required_size);
+	  if (new_data == NULL)
+	    {
+	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, required_size);
+	      return S_ERROR;
+	    }
+
+	  undo_recdes->data = new_data;
+	  undo_recdes->area_size = required_size;
 
 	  if (cdc_check_log_page (thread_p, log_page_p, &lsa) != NO_ERROR)
 	    {
@@ -11921,8 +11937,6 @@ cdc_get_recdes (THREAD_ENTRY * thread_p, LOG_LSA * undo_lsa, RECDES * undo_recde
 	      }
 	    else if (rcvindex == RVHF_UPDATE)
 	      {
-		RECDES tmp_undo_recdes = RECDES_INITIALIZER;
-
 		if (ZIP_CHECK (undo_length))
 		  {
 		    undo_length = (int) GET_ZIP_LEN (undo_length);
@@ -14616,8 +14630,11 @@ cdc_reinitialize_queue (LOG_LSA * start_lsa)
 	    {
 	      free_and_init (consume->log_info);
 	    }
+
+	  free_and_init (consume);
 	}
 
+      LSA_COPY (&cdc_Gl.first_loginfo_queue_lsa, &next_consume_lsa);
       cdc_Gl.producer.produced_queue_size -= cdc_Gl.consumer.consumed_queue_size;
       cdc_Gl.consumer.consumed_queue_size = 0;
     }
@@ -14633,6 +14650,8 @@ cdc_reinitialize_queue (LOG_LSA * start_lsa)
 	    {
 	      free_and_init (consume->log_info);
 	    }
+
+	  free_and_init (consume);
 	}
       cdc_Gl.producer.produced_queue_size = 0;
       cdc_Gl.consumer.consumed_queue_size = 0;

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -11351,6 +11351,7 @@ cdc_get_recdes (THREAD_ENTRY * thread_p, LOG_LSA * undo_lsa, RECDES * undo_recde
 
   log_page_p = (LOG_PAGE *) PTR_ALIGN (log_pgbuf, MAX_ALIGNMENT);
   preserved_log_page_p = (LOG_PAGE *) PTR_ALIGN (preserved_log_pgbuf, MAX_ALIGNMENT);
+  preserved_log_page_p->hdr.logical_pageid = NULL_LOG_PAGEID;
 
   /* Get UNDO RECDES from undo lsa */
 
@@ -12307,6 +12308,12 @@ cdc_get_overflow_recdes (THREAD_ENTRY * thread_p, LOG_PAGE * log_page_p, RECDES 
   int area_offset;
   int error_code = NO_ERROR;
   int length = 0;
+
+  /* log_page_p may not hold lsa's page after parsing advanced across a log page boundary. */
+  if (cdc_check_log_page (thread_p, log_page_p, &lsa) != NO_ERROR)
+    {
+      return ER_FAILED;
+    }
 
   LSA_COPY (&current_lsa, &lsa);
   current_log_page = log_page_p;

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -337,7 +337,8 @@ static int cdc_find_user (THREAD_ENTRY * thread_p, LOG_LSA lsa, int trid, char *
 static int cdc_compare_undoredo_dbvalue (const db_value * new_value, const db_value * old_value);
 static int cdc_put_value_to_loginfo (db_value * new_value, char **ptr);
 
-static int cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * ret_lsa, time_t * time);
+static int cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * ret_lsa, time_t * time,
+					  bool * is_found);
 static int cdc_get_lsa_with_start_point (THREAD_ENTRY * thread_p, time_t * time, LOG_LSA * start_lsa);
 
 static bool cdc_is_filtered_class (OID classoid);
@@ -14235,6 +14236,9 @@ cdc_find_lsa (THREAD_ENTRY * thread_p, time_t * extraction_time, LOG_LSA * start
 
   LOG_LSA ret_lsa = LSA_INITIALIZER;
   bool is_found = false;
+  bool active_start_point_found = false;
+  bool archive_start_point_found = false;
+  bool current_start_point_found = false;
 
   char input_time_buf[CTIME_MAX];
   char output_time_buf[CTIME_MAX];
@@ -14248,15 +14252,15 @@ cdc_find_lsa (THREAD_ENTRY * thread_p, time_t * extraction_time, LOG_LSA * start
    */
 
   /* At first, compare the time in active log volume. */
-  error = cdc_get_start_point_from_file (thread_p, -1, &ret_lsa, &active_start_time);
-  if (error == ER_FAILED || error == ER_LOG_READ)
+  error = cdc_get_start_point_from_file (thread_p, -1, &ret_lsa, &active_start_time, &active_start_point_found);
+  if (error != NO_ERROR)
     {
       goto end;
     }
   else
     {
       /* NO ERROR */
-      if (active_start_time != 0 && active_start_time <= *extraction_time)
+      if (active_start_point_found && active_start_time <= *extraction_time)
 	{
 	  // active
 	  error = cdc_get_lsa_with_start_point (thread_p, extraction_time, &ret_lsa);
@@ -14288,11 +14292,18 @@ cdc_find_lsa (THREAD_ENTRY * thread_p, time_t * extraction_time, LOG_LSA * start
 	      /* travers from the latest */
 	      for (int i = end; i > begin; i--)
 		{
-		  error = cdc_get_start_point_from_file (thread_p, i, &ret_lsa, &archive_start_time);
+		  error = cdc_get_start_point_from_file (thread_p, i, &ret_lsa, &archive_start_time,
+							 &current_start_point_found);
 		  if (error != NO_ERROR)
 		    {
 		      goto end;
 		    }
+		  if (!current_start_point_found)
+		    {
+		      continue;
+		    }
+
+		  archive_start_point_found = true;
 
 		  if (archive_start_time <= *extraction_time)
 		    {
@@ -14303,9 +14314,24 @@ cdc_find_lsa (THREAD_ENTRY * thread_p, time_t * extraction_time, LOG_LSA * start
 
 	      if (target_arv_num == -1)
 		{
-		  /* returns oldest LSA */
-		  LSA_COPY (start_lsa, &ret_lsa);
-		  *extraction_time = archive_start_time;
+		  if (archive_start_point_found)
+		    {
+		      /* returns oldest LSA found in the archives */
+		      LSA_COPY (start_lsa, &ret_lsa);
+		      *extraction_time = archive_start_time;
+		    }
+		  else if (active_start_point_found)
+		    {
+		      /* no archive contains time information; returns the oldest LSA in the active log */
+		      LSA_COPY (start_lsa, &ret_lsa);
+		      *extraction_time = active_start_time;
+		    }
+		  else
+		    {
+		      /* no time information has been found in any log volume; returns the latest log */
+		      LSA_COPY (start_lsa, &log_Gl.append.prev_lsa);
+		      *extraction_time = time (NULL);
+		    }
 		  is_found = true;
 
 		  ctime_r (&input_time, input_time_buf);
@@ -14338,7 +14364,7 @@ cdc_find_lsa (THREAD_ENTRY * thread_p, time_t * extraction_time, LOG_LSA * start
 	    {
 	      /* num_arvs == 0, and active_start_time > input time 
 	       * returns oldest LSA in active log volume */
-	      if (active_start_time != 0)
+	      if (active_start_point_found)
 		{
 		  *extraction_time = active_start_time;
 		  LSA_COPY (start_lsa, &ret_lsa);
@@ -14626,11 +14652,13 @@ end:
 /*
  * arv_num (in) : archive log volume number to traverse. If it is -1, then traverse active log volume. 
  * ret_lsa (out) : lsa of the first log which contains time info 
- * time (out) : time of the first log which contains time info  
+ * time (out) : time of the first log which contains time info
+ * is_found (out) : true if the specified log volume contains a log with time info
+ * return : error code; a volume without time info returns NO_ERROR with is_found set to false
  */
 
 static int
-cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * ret_lsa, time_t * time)
+cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * ret_lsa, time_t * time, bool * is_found)
 {
   char arv_name[PATH_MAX];
   LOG_ARV_HEADER *arv_hdr;
@@ -14648,6 +14676,7 @@ cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * r
   LOG_LSA process_lsa = LSA_INITIALIZER;
   LOG_LSA forw_lsa = LSA_INITIALIZER;
   LOG_LSA cur_log_lsa = LSA_INITIALIZER;
+  LOG_PAGEID archive_end_pageid = NULL_PAGEID;
 
   LOG_RECORD_HEADER *log_rec_header;
   LOG_RECTYPE log_type;
@@ -14656,6 +14685,7 @@ cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * r
 
   aligned_log_pgbuf = PTR_ALIGN (log_pgbuf, MAX_ALIGNMENT);
   log_pgptr = (LOG_PAGE *) aligned_log_pgbuf;
+  *is_found = false;
   LOG_CS_ENTER_READ_MODE (thread_p);
 
   if (arv_num == -1)
@@ -14672,6 +14702,7 @@ cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * r
 	  /* if target archive log volume is currenty mounted, then use that */
 	  process_lsa.pageid = log_Gl.archive.hdr.fpageid;
 	  process_lsa.offset = 0;
+	  archive_end_pageid = log_Gl.archive.hdr.fpageid + log_Gl.archive.hdr.npages;
 	}
       else
 	{
@@ -14713,6 +14744,7 @@ cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * r
 
 		  process_lsa.pageid = arv_hdr->fpageid;
 		  process_lsa.offset = 0;
+		  archive_end_pageid = arv_hdr->fpageid + arv_hdr->npages;
 
 		  fileio_dismount (thread_p, vdes);
 		}
@@ -14735,6 +14767,8 @@ cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * r
       return ER_CDC_LSA_NOT_FOUND;
     }
 
+  assert (arv_num == -1 || archive_end_pageid != NULL_PAGEID);
+
   if ((error_code = logpb_fetch_page (thread_p, &process_lsa, LOG_CS_SAFE_READER, log_pgptr)) != NO_ERROR)
     {
       return error_code;
@@ -14742,6 +14776,32 @@ cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * r
 
   process_lsa.pageid = log_pgptr->hdr.logical_pageid;
   process_lsa.offset = log_pgptr->hdr.offset;
+
+  /*
+   * The first page of an active or archive log volume may contain only the continuation data of a log record
+   * that started in the previous volume. In that case, the page has no log record header and hdr.offset is
+   * NULL_OFFSET. Skip such pages before interpreting page data as LOG_RECORD_HEADER.
+   */
+  while (process_lsa.offset == NULL_OFFSET)
+    {
+      LOG_PAGEID end_pageid = (arv_num == -1) ? log_Gl.append.get_nxio_lsa ().pageid : archive_end_pageid;
+
+      cdc_log ("%s : skip continuation-only log page %lld", __func__, (long long int) process_lsa.pageid);
+      process_lsa.pageid++;
+      if (process_lsa.pageid >= end_pageid)
+	{
+	  /* Reaching the end of one volume is not an error. The caller continues with an older archive. */
+	  return NO_ERROR;
+	}
+
+      if ((error_code = logpb_fetch_page (thread_p, &process_lsa, LOG_CS_SAFE_READER, log_pgptr)) != NO_ERROR)
+	{
+	  return error_code;
+	}
+
+      process_lsa.pageid = log_pgptr->hdr.logical_pageid;
+      process_lsa.offset = log_pgptr->hdr.offset;
+    }
 
   while (!LSA_ISNULL (&process_lsa))
     {
@@ -14760,6 +14820,7 @@ cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * r
 
 	  LSA_COPY (ret_lsa, &cur_log_lsa);
 	  *time = donetime->at_time;
+	  *is_found = true;
 
 	  return NO_ERROR;
 	}
@@ -14771,7 +14832,14 @@ cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * r
 
 	  LSA_COPY (ret_lsa, &cur_log_lsa);
 	  *time = dummy->at_time;
+	  *is_found = true;
 
+	  return NO_ERROR;
+	}
+
+      if (arv_num != -1 && !LSA_ISNULL (&forw_lsa) && forw_lsa.pageid >= archive_end_pageid)
+	{
+	  /* The next log record starts in a newer archive. The caller continues with an older archive. */
 	  return NO_ERROR;
 	}
 
@@ -14779,6 +14847,11 @@ cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * r
 	{
 	  if (LSA_ISNULL (&forw_lsa))
 	    {
+	      if (arv_num != -1)
+		{
+		  return NO_ERROR;
+		}
+
 	      ctime_r (time, ctime_buf);
 	      er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_CDC_LSA_NOT_FOUND, 1, ctime_buf);
 
@@ -14794,9 +14867,13 @@ cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * r
       LSA_COPY (&process_lsa, &forw_lsa);
     }
 
+  if (arv_num != -1)
+    {
+      return NO_ERROR;
+    }
+
   ctime_r (time, ctime_buf);
   er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_CDC_LSA_NOT_FOUND, 1, ctime_buf);
-
   return ER_CDC_LSA_NOT_FOUND;
 }
 

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -12202,6 +12202,14 @@ cdc_get_ovfdata_from_log (THREAD_ENTRY * thread_p, LOG_PAGE * log_page_p,
 
   cdc_log ("cdc_get_ovfdata_from_log : process_lsa:(%lld | %d), recovery index:%d, is_redo:%d",
 	   LSA_AS_ARGS (process_lsa), rcvindex, is_redo);
+
+  /* log_page_p may not hold process_lsa's page; e.g. the LOG_DUMMY_OVF_RECORD branch of cdc_get_overflow_recdes ()
+   * passes prev_tranlsa, which can point to a record on another log page. */
+  if (cdc_check_log_page (thread_p, log_page_p, process_lsa) != NO_ERROR)
+    {
+      return ER_FAILED;
+    }
+
   LOG_READ_ADD_ALIGN (thread_p, DB_SIZEOF (LOG_RECORD_HEADER), process_lsa, log_page_p);
 
   if (is_redo)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26910

### Purpose

`release/11.4_hotfix`에만 반영되어 있던 CDC 수정 7건을 `release/11.4`로 cherrypick한다.

### Implementation

`release/11.4_hotfix`의 커밋을 원본 순서대로 `cherry-pick -x`로 옮겼다. 각 커밋은 원본 SHA 주석을 유지한다.

- [CBRD-27064] Fix CDC log page references across page boundaries — backport #7470
- [CBRD-27077] Fix CDC crash when shrinking overflow records — backport #7481
- [CBRD-27076] Fix CDC temp log page buffers mistaking page id 0 for a cached page — backport #7479
- [CBRD-27081] Fix CDC wrong log page reference when restoring overflow old images — backport #7483
- [CBRD-27075] Fix CDC timestamp lookup on continuation-only log pages — backport #7478
- [CBRD-27082] Fix remaining CDC memory leaks and resource ownership errors — backport #7484
- [CBRD-27083] Fix CDC client crash on NULL LSA with trace logging enabled — backport #7485

변경 파일은 `src/transaction/log_manager.c`, `src/storage/heap_file.c`, `src/storage/overflow_file.c`, `src/storage/overflow_file.h`, `src/api/cubrid_log.c`, `src/query/execute_statement.c` 6개이다.

### Test

- 7건 모두 충돌 없이 적용되었다. `src/storage/heap_file.c`와 `src/query/execute_statement.c`는 auto-merge되었으나, 해당 파일을 함께 건드린 `release/11.4` 측 커밋([CBRD-26761], [CBRD-26768], [CBRD-27004])과 수정 영역이 겹치지 않는다.
- 적용 결과의 net diff가 `release/11.4_hotfix`의 net diff(`64e2b8218..release/11.4_hotfix`)와 추가/삭제 라인 기준 완전히 동일함을 확인했다.
- `overflow_update()` 시그니처 변경(`LOG_LSA *change_link_lsa` 추가)에 대해 `release/11.4` 트리 내 호출부가 `heap_ovf_update()` 한 곳뿐이며 함께 갱신되었음을 확인했다.
- Debug preset 전체 빌드(1287개 타깃) 성공, 컴파일 에러 0건.

### Remarks

- 신규 코드 변경은 없으며, `release/11.4_hotfix`에서 이미 리뷰·머지된 커밋만 그대로 옮겼다.
- CDC wire format 및 API 변경은 없다.
