### PR TITLE
[CBRD-27224] Fix the debug abort in pgbuf_ordered_callback by asserting only a query result page may stay fixed

### DIFF
--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -11575,11 +11575,15 @@ pgbuf_wakeup_page_flush_daemon (THREAD_ENTRY * thread_p)
 }
 
 /*
- * pgbuf_has_perm_pages_fixed () -
+ * pgbuf_has_perm_pages_fixed () - does the thread still hold a page other than a query result page?
  *
- * return	       : The number of pages fixed by the thread.
+ * return	       : true if any page whose type is not PAGE_QRESULT is fixed by the thread.
  * thread_p (in)       : Thread entry.
  *
+ * Note: PAGE_QRESULT is the single exemption, because a query result page belongs to the thread's own list file
+ *       scan and no other thread fixes it. Callers use this to check that a thread is not holding a latch another
+ *       thread needs before it blocks - see lock_suspend and pgbuf_ordered_callback. Widening the exemption to the
+ *       other temporary page types would loosen those asserts, so weigh those callers before changing it.
  */
 bool
 pgbuf_has_perm_pages_fixed (THREAD_ENTRY * thread_p)
@@ -12935,38 +12939,6 @@ exit:
   return er_status;
 }
 
-#if !defined(NDEBUG)
-/*
- * pgbuf_only_qresult_pages_fixed () - is every page still fixed by this thread a query result page?
- *   return: true if no other page type is fixed
- *   thrd_idx (in): thread index
- *
- * Note: pgbuf_ordered_callback used to require that the thread holds no page at all. It unfixes ordered pages only,
- *       so a fix without a watcher may now remain - in practice the query result page of the thread's own list file
- *       scan, which no other thread fixes. This is deliberately narrower than "not an ordered page", so that any
- *       other type surfaces in testing: the shard allocator the callback waits for fixes PAGE_FTAB and
- *       PAGE_VOLHEADER itself, and keeping one of those across the wait would deadlock against it.
- *
- * TODO: if this fires, decide whether the reported page type must be unfixed across the callback too, rather than
- *       allowing it here.
- */
-static bool
-pgbuf_only_qresult_pages_fixed (int thrd_idx)
-{
-  PGBUF_HOLDER *holder;
-
-  for (holder = pgbuf_Pool.thrd_holder_info[thrd_idx].thrd_hold_list; holder != NULL; holder = holder->thrd_link)
-    {
-      if (holder->bufptr->iopage_buffer->iopage.prv.ptype != PAGE_QRESULT)
-	{
-	  return false;
-	}
-    }
-
-  return true;
-}
-#endif /* NDEBUG */
-
 /*
  * pgbuf_ordered_callback () - Temporarily unfix all ordered pages while executing a callback.
  *   return: error code
@@ -12975,7 +12947,8 @@ pgbuf_only_qresult_pages_fixed (int thrd_idx)
  *   callback_args (in): callback arguments
  *
  * Note: Only ordered pages are unfixed, because only they carry a watcher through which the fix can be restored. Any
- *       other fix is left in place - see pgbuf_only_qresult_pages_fixed. The callback must not fix a page of its own.
+ *       other fix is left in place - see the assert before the callback. The callback must not fix a page of its
+ *       own.
  *       Unfixed pages are re-fixed in page order even when the callback returns an error. If re-fixing fails, some
  *       watchers may remain without a fixed page and callers must check watcher page pointers before using them.
  */
@@ -13160,7 +13133,14 @@ pgbuf_ordered_callback_release (THREAD_ENTRY * thread_p, PGBUF_ORDERED_CALLBACK_
 	}
     }
 
-  assert (pgbuf_only_qresult_pages_fixed (thrd_idx));
+  /* pgbuf_ordered_callback used to require that the thread holds no page at all. It unfixes ordered pages only, so a
+   * fix without a watcher may now remain - in practice the query result page of the thread's own list file scan,
+   * which no other thread fixes. Any other type must surface here: the shard allocator the callback waits for fixes
+   * PAGE_FTAB and PAGE_VOLHEADER itself, and keeping one of those across the wait would deadlock against it.
+   *
+   * TODO: if this fires, decide whether the reported page type must be unfixed across the callback too, rather than
+   * allowing it here. */
+  assert (!pgbuf_has_perm_pages_fixed (thread_p));
 
   callback_status = callback_func (thread_p, callback_args);
 

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -12965,7 +12965,7 @@ pgbuf_only_qresult_pages_fixed (int thrd_idx)
 
   return true;
 }
-#endif				/* NDEBUG */
+#endif /* NDEBUG */
 
 /*
  * pgbuf_ordered_callback () - Temporarily unfix all ordered pages while executing a callback.

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -12935,6 +12935,38 @@ exit:
   return er_status;
 }
 
+#if !defined(NDEBUG)
+/*
+ * pgbuf_only_qresult_pages_fixed () - is every page still fixed by this thread a query result page?
+ *   return: true if no other page type is fixed
+ *   thrd_idx (in): thread index
+ *
+ * Note: pgbuf_ordered_callback used to require that the thread holds no page at all. It unfixes ordered pages only,
+ *       so a fix without a watcher may now remain - in practice the query result page of the thread's own list file
+ *       scan, which no other thread fixes. This is deliberately narrower than "not an ordered page", so that any
+ *       other type surfaces in testing: the shard allocator the callback waits for fixes PAGE_FTAB and
+ *       PAGE_VOLHEADER itself, and keeping one of those across the wait would deadlock against it.
+ *
+ * TODO: if this fires, decide whether the reported page type must be unfixed across the callback too, rather than
+ *       allowing it here.
+ */
+static bool
+pgbuf_only_qresult_pages_fixed (int thrd_idx)
+{
+  PGBUF_HOLDER *holder;
+
+  for (holder = pgbuf_Pool.thrd_holder_info[thrd_idx].thrd_hold_list; holder != NULL; holder = holder->thrd_link)
+    {
+      if (holder->bufptr->iopage_buffer->iopage.prv.ptype != PAGE_QRESULT)
+	{
+	  return false;
+	}
+    }
+
+  return true;
+}
+#endif				/* NDEBUG */
+
 /*
  * pgbuf_ordered_callback () - Temporarily unfix all ordered pages while executing a callback.
  *   return: error code
@@ -12942,12 +12974,10 @@ exit:
  *   callback_func (in): callback executed without any fixed pages
  *   callback_args (in): callback arguments
  *
- * Note: Every ordered page fixed by the current thread must have a watcher, because its fix can only be restored
- *       through the watcher's page pointer. Fixes on pages that are not ordered pages are left alone: the heap
- *       allocation path never fixes them, so keeping them cannot deadlock with the allocating thread. The callback
- *       must not leave any page fixed. Unfixed pages are re-fixed in page order even when the callback returns an
- *       error. If re-fixing fails, some watchers may remain without a fixed page and callers must check watcher page
- *       pointers before using them.
+ * Note: Only ordered pages are unfixed, because only they carry a watcher through which the fix can be restored. Any
+ *       other fix is left in place - see pgbuf_only_qresult_pages_fixed. The callback must not fix a page of its own.
+ *       Unfixed pages are re-fixed in page order even when the callback returns an error. If re-fixing fails, some
+ *       watchers may remain without a fixed page and callers must check watcher page pointers before using them.
  */
 #if !defined(NDEBUG)
 int
@@ -12999,10 +13029,8 @@ pgbuf_ordered_callback_release (THREAD_ENTRY * thread_p, PGBUF_ORDERED_CALLBACK_
 
       if (!PGBUF_IS_ORDERED_PAGETYPE (holder->bufptr->iopage_buffer->iopage.prv.ptype))
 	{
-	  /* not part of the heap latch ordering protocol, so the heap allocation path never fixes it and keeping it */
-	  /* across the callback cannot deadlock with the thread that owns the allocation. query result page fixed by */
-	  /* the select side of an INSERT ... SELECT is the usual case here, and it carries no watcher. leave it fixed */
-	  /* and untouched, exactly as pgbuf_ordered_fix does for the holders it cannot restore. */
+	  /* outside the heap latch ordering protocol, so it has no watcher and its fix cannot be restored. leave it
+	   * in place, exactly as pgbuf_ordered_fix does for the holders it cannot restore. */
 	  continue;
 	}
 
@@ -13132,13 +13160,9 @@ pgbuf_ordered_callback_release (THREAD_ENTRY * thread_p, PGBUF_ORDERED_CALLBACK_
 	}
     }
 
-  assert (pgbuf_Pool.thrd_holder_info[thrd_idx].thrd_hold_list == NULL);
+  assert (pgbuf_only_qresult_pages_fixed (thrd_idx));
 
   callback_status = callback_func (thread_p, callback_args);
-
-  /* only callback functions that do not fix any pages are allowed. */
-  /* it must not leave a page fixed. */
-  assert (pgbuf_Pool.thrd_holder_info[thrd_idx].thrd_hold_list == NULL);
 
   /* restore every page in the same global order used by ordered fix. */
   for (i = 0; i < saved_pages_cnt; i++)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27224

### Purpose
`bestspace_shard_count`를 낮춘 상태에서 여러 세션이 같은 테이블에 동시에 INSERT 하면 debug 서버가
`page_buffer.c`의 `assert (thrd_hold_list == NULL)`에서 abort 합니다.

`pgbuf_ordered_callback()`의 저장/unfix 루프는 ordered 페이지만 unfix 하고 나머지는 fix한 채 건너뜁니다
([CBRD-27120](http://jira.cubrid.org/browse/CBRD-27120)(#7553)에서 변경). 그런데 그 아래 assert는 "이 스레드가
잡은 페이지가 하나도 없어야 한다"를 그대로 요구합니다. `INSERT ... SELECT`는 자기 리스트파일 스캔의
query result 페이지를 fix한 채 콜백에 진입하므로 hold list가 비지 않고, assert가 항상 실패합니다.

낮은 shard 수는 원인이 아니라 방아쇠입니다. shard가 하나면 회피할 대안 shard가 없어 이 콜백이 상시 경로가
됩니다. 기본값(8)에서는 미재현, `bestspace_shard_count=1`에서는 부하 시작 1~2초 내 100% 재현됩니다.

### Implementation
* assert 조건을 "hold list가 비었는가"에서 "남아 있는 fix가 모두 `PAGE_QRESULT`인가"로 변경
    * debug 전용 술어 `pgbuf_only_qresult_pages_fixed()` 추가
* 루프가 실제로 허용하는 "ordered가 아닌 페이지"보다 **의도적으로 좁게** 둠
    * 다른 타입이 남는 경우를 회귀 테스트에서 드러내기 위함
    * 콜백이 대기하는 shard 할당자가 `file_alloc`에서 `PAGE_FTAB`/`PAGE_VOLHEADER`를 직접 fix 하므로,
      그 타입을 쥔 채 대기하면 할당자와 데드락
    * TODO 주석: 다른 타입이 발견되면 허용 범위를 넓힐 것이 아니라 그 페이지도 unfix 대상인지 검토
* 콜백 뒤에 중복으로 있던 동일 assert 제거
    * 콜백은 yield/sleep과 인터럽트 확인만 하므로 fix 상태를 바꿀 수 없음. 계약은 함수 헤더 주석에 유지
* 주석 정정: "the heap allocation path never fixes them"은 사실과 다름
    * 할당 경로는 `file_alloc`에서 `PAGE_FTAB`를 fix 함. 안전한 이유는 그 페이지들이 모듈 밖으로 나가지
      않는 것이지 할당자가 건드리지 않는 것이 아님

### Remarks
* release 빌드는 NDEBUG로 assert가 제외되어 abort 하지 않습니다. 실체는 debug/CI 빌드 abort 입니다.
  이슈에 언급된 release의 `-495`는 #7553 이전 사례로 별건입니다.
* 검증: 이슈 재현 시나리오(`bestspace_shard_count=1`, 6세션 × 12라운드 × 2000행) 기준 동일 커밋에서
  수정 전 서버 abort, 수정 후 3회 반복 모두 정상 완료(144,000행, csql 오류 0, 서버 pid 유지).
* 계측 빌드로 콜백 진입 24만 회 이상을 관측한 결과, 남아 있던 fix는 100% `PAGE_QRESULT`(임시 볼륨,
  WRITE 래치)였고 다른 타입은 관측되지 않았습니다.