### PR TITLE
[CBRD-27279] Copy the histogram blob out of the class cache before annotating names

### DIFF
--- a/src/optimizer/query_graph.c
+++ b/src/optimizer/query_graph.c
@@ -251,6 +251,7 @@ static void qo_free_index (QO_ENV * env, QO_INDEX *);
 static QO_INDEX *qo_alloc_index (QO_ENV * env, int);
 static void qo_free_node_index_info (QO_ENV * env, QO_NODE_INDEX * node_indexp);
 static void qo_free_attr_info (QO_ENV * env, QO_ATTR_INFO * info);
+static DB_VALUE *qo_copy_histogram_value (PARSER_CONTEXT * parser, DB_VALUE * src);
 static QO_ATTR_INFO *qo_get_attr_info (QO_ENV * env, QO_SEGMENT * seg);
 static QO_ATTR_INFO *qo_get_attr_info_func_index (QO_ENV * env, QO_SEGMENT * seg, const char *expr_str);
 static void qo_free_class_info (QO_ENV * env, QO_CLASS_INFO *);
@@ -5209,6 +5210,71 @@ qo_get_attr_info_func_index (QO_ENV * env, QO_SEGMENT * seg, const char *expr_st
 }
 
 /*
+ * qo_copy_histogram_value () - parser-arena copy of a cached histogram blob
+ *   return: the copy, or NULL when there is nothing usable to copy
+ *   parser(in):
+ *   src(in): DB_VALUE owned by the workspace class cache (smclass->histogram)
+ *
+ * Note: PT_NAME.histogram used to alias the cache-owned blob directly, but the cache frees the
+ *	 blob on any statistics refresh or class decache (sm_get_class_with_statistics () when
+ *	 the server reports newer statistics, sm_get_statistics_force (),
+ *	 sm_update_statistics (), install_new_representation (), classobj_free_class ()) while
+ *	 the annotation is consumed only later, by the term analysis.  A self-join's later FROM
+ *	 entities re-fetch the very class the earlier entities annotated, so term selectivity
+ *	 read freed memory: usually a silently wrong join selectivity, and a crash when the
+ *	 block had been reused.  Copy the blob into the parser arena, whose lifetime covers the
+ *	 whole optimization, so the annotation owns what it points to.  The buffer is arena
+ *	 memory, so the copy carries no need_clear and is freed with the parser.
+ */
+static DB_VALUE *
+qo_copy_histogram_value (PARSER_CONTEXT * parser, DB_VALUE * src)
+{
+  DB_VALUE *copy;
+  const char *src_buf;
+  char *buf;
+  int bit_len = 0, size;
+  DB_TYPE src_type;
+
+  if (src == NULL || DB_IS_NULL (src))
+    {
+      return NULL;
+    }
+
+  src_type = DB_VALUE_DOMAIN_TYPE (src);
+  if (src_type != DB_TYPE_BIT && src_type != DB_TYPE_VARBIT)
+    {
+      /* not a histogram blob shape; annotating nothing beats annotating a guess */
+      return NULL;
+    }
+
+  src_buf = db_get_bit (src, &bit_len);
+  if (src_buf == NULL || bit_len <= 0)
+    {
+      return NULL;
+    }
+  size = (bit_len + 7) / 8;
+
+  copy = (DB_VALUE *) parser_alloc (parser, (int) sizeof (DB_VALUE));
+  buf = (char *) parser_alloc (parser, size);
+  if (copy == NULL || buf == NULL)
+    {
+      return NULL;		/* same effect as having no histogram */
+    }
+
+  memcpy (buf, src_buf, size);
+  if (src_type == DB_TYPE_BIT)
+    {
+      db_make_bit (copy, DB_VALUE_PRECISION (src), buf, bit_len);
+    }
+  else
+    {
+      db_make_varbit (copy, DB_VALUE_PRECISION (src), buf, bit_len);
+    }
+
+  return copy;
+}
+
+/*
  * qo_get_attr_info () - Find the ATTR_STATS information about each actual
  *			 attribute that underlies this segment
  *   return: QO_ATTR_INFO *
@@ -5356,7 +5422,10 @@ qo_get_attr_info (QO_ENV * env, QO_SEGMENT * seg)
 	    {
 	      if (hist_stats->attr_ids[h] == attr_id)
 		{
-		  QO_SEG_PT_NODE (seg)->info.name.histogram = hist_stats->histogram[h];
+		  /* own a copy: the cache-owned blob can be freed before the term analysis
+		   * consumes this annotation (see qo_copy_histogram_value ()) */
+		  QO_SEG_PT_NODE (seg)->info.name.histogram =
+		    qo_copy_histogram_value (QO_ENV_PARSER (env), hist_stats->histogram[h]);
 		  QO_SEG_PT_NODE (seg)->info.name.null_frequency = hist_stats->null_frequency[h];
 		  break;
 		}


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27279>

### Purpose

`PT_NAME.histogram`은 워크스페이스에 캐시된 `SM_CLASS->histogram`을 가리키는 **소유권 없는 생포인터**다. 질의 그래프 빌더가 FROM 엔티티 단위로 이 포인터를 배포하지만, 소비(term 선택도 계산)는 엔티티 목록 처리가 전부 끝난 뒤에 일어난다. 그 사이에 통계 갱신·클래스 decache 등 5개 경로가 캐시된 blob을 해제할 수 있고(self-join이면 뒤쪽 엔티티의 `sm_get_class_with_statistics()`가 앞쪽 엔티티가 배포한 blob을 해제), term 분석이 해제된 메모리를 읽는다. 대부분은 **에러 없이 조인 선택도만 틀어지고**, 해제 블록이 재사용된 경우 SIGSEGV(`hist::HistogramReader::reset()`)로 죽는다. CBRD-26746(#7508)에서 유입.

### Implementation

배포 지점 한 곳(`qo_get_attr_info()`)에서 blob을 **파서 아레나로 깊은 복사**하고 주석이 사본을 가리키게 한다 (`qo_copy_histogram_value()` 신설, query_graph.c).

- 아레나 수명이 최적화 전체를 덮으므로 창이 닫힌다. `set_seg_node()`의 전파는 아레나 포인터 복사가 되어 그대로 안전하다.
- **사본의 해제 주체**: 사본 DB_VALUE와 blob 버퍼는 둘 다 `parser_alloc()`으로 잡은 파서 아레나 메모리라, 파스 트리가 정리될 때 `parser_free_parser()`가 아레나 블록째 함께 해제한다 (parse_tree.c:950의 계약 — "ALL BUFFERS for a parser will be FREED by parser_free_parser"). 코드에 명시적 free가 없는 것은 누수가 아니라 아레나 소유이기 때문이다.
- **이중 해제 없음**: `db_make_bit/varbit` → `db_make_db_char()`가 `need_clear = false`로 만들므로(dbtype_function.i), 사본에 `db_value_clear()`가 호출되어도 아레나 버퍼를 free하려 들지 않는다. 캐시 원본은 기존대로 `stats_free_histogram_and_init()`이 소유·해제하며 사본과 분리된다.
- 캐시(`SM_CLASS->histogram`)의 소유·해제 경로는 손대지 않는다 — 소비자가 소유권을 갖는 방향의 최소 수정.
- blob 크기는 실측 1.4~1.8KB/컬럼으로 아레나 부담은 무시 가능.

### Verification

JIRA 첨부 repro.sh 기준(폐기된 `ANALYZE TABLE` 구문만 `UPDATE STATISTICS`로 치환), 60k행·히스토그램 6컬럼, debug 빌드:

| 단계 | develop (dd53b2f2a) | 본 PR (5d4c14748) |
|---|---|---|
| `core` (캐시 blob 오염 후 6-별칭 self-join 컴파일) | **SIGSEGV** in `hist::HistogramReader::reset()` — 티켓 스택 그대로 | **크래시 없음**, 14개 조인 term 전부 분석 완주 |

- 수정 빌드에서 종료 시점의 SIGABRT 1건은 gdb가 오염시킨 캐시 blob을 (수정 범위 밖인) 캐시 소유자 `ws_final()`이 정리하다 만난 주입 부산물로, 옵티마이저가 캐시 대신 아레나 사본을 읽었다는 반증이다.
- 기본값 환경(`update_statistics_update_histogram=false`)은 histogram이 배포되지 않아 영향이 없다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJG3W9JhvjYKRe5GUzbb6m
