### PR TITLE
[CBRD-27185] Include system worker transactions in the log archive retention boundary

### DIFF
--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -7073,6 +7073,21 @@ logpb_checkpoint (THREAD_ENTRY * thread_p)
       logpb_checkpoint_trans (chkpt_trans, act_tdes, ntrans, ntops, smallest_lsa);
     }
 
+  /* System worker transactions (e.g. online index loaders) must also hold
+   * smallest_lsa: recovery undo processes them too, so the log archive
+   * retention boundary derived from it may not skip their in-flight log.
+   */
+  // *INDENT-OFF*
+  log_system_tdes::map_all_tdes ([&smallest_lsa] (log_tdes & sys_tdes)
+    {
+      if (!LSA_ISNULL (&sys_tdes.head_lsa)
+	  && (LSA_ISNULL (&smallest_lsa) || LSA_GT (&smallest_lsa, &sys_tdes.head_lsa)))
+	{
+	  LSA_COPY (&smallest_lsa, &sys_tdes.head_lsa);
+	}
+    });
+  // *INDENT-ON*
+
   /*
    * Reset the structure to the correct number of transactions and
    * recalculate the length

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -4487,6 +4487,21 @@ logtb_find_smallest_lsa (THREAD_ENTRY * thread_p, LOG_LSA * lsa)
       LSA_COPY (lsa, min_lsa);
     }
 
+  /* Consider system worker transactions (e.g. online index loaders) as well.
+   * Recovery undo processes them too (see logtb_rv_read_only_map_undo_tdes),
+   * so the smallest LSA that decides log archive retention must not skip
+   * their in-flight log.
+   */
+  // *INDENT-OFF*
+  log_system_tdes::map_all_tdes ([lsa] (log_tdes & sys_tdes)
+    {
+      if (!LSA_ISNULL (&sys_tdes.head_lsa) && (LSA_ISNULL (lsa) || LSA_LT (&sys_tdes.head_lsa, lsa)))
+	{
+	  LSA_COPY (lsa, &sys_tdes.head_lsa);
+	}
+    });
+  // *INDENT-ON*
+
   TR_TABLE_CS_EXIT (thread_p);
 }
 

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -4462,9 +4462,9 @@ logtb_find_smallest_lsa (THREAD_ENTRY * thread_p, LOG_LSA * lsa)
 {
   int i;
   LOG_TDES *tdes;		/* Transaction descriptor */
-  LOG_LSA *min_lsa = NULL;	/* The smallest lsa value */
+  LOG_LSA smallest_lsa;		/* The smallest lsa value */
 
-  LSA_SET_NULL (lsa);
+  LSA_SET_NULL (&smallest_lsa);
 
   TR_TABLE_CS_ENTER_READ_MODE (thread_p);
 
@@ -4475,17 +4475,14 @@ logtb_find_smallest_lsa (THREAD_ENTRY * thread_p, LOG_LSA * lsa)
 	  tdes = log_Gl.trantable.all_tdes[i];
 
 	  if (tdes != NULL && tdes->trid != NULL_TRANID && !LSA_ISNULL (&tdes->head_lsa)
-	      && (min_lsa == NULL || LSA_LT (&tdes->head_lsa, min_lsa)))
+	      && (LSA_ISNULL (&smallest_lsa) || LSA_LT (&tdes->head_lsa, &smallest_lsa)))
 	    {
-	      min_lsa = &tdes->head_lsa;
+	      LSA_COPY (&smallest_lsa, &tdes->head_lsa);
 	    }
 	}
     }
 
-  if (min_lsa != NULL)
-    {
-      LSA_COPY (lsa, min_lsa);
-    }
+  TR_TABLE_CS_EXIT (thread_p);
 
   /* Consider system worker transactions (e.g. online index loaders) as well.
    * Recovery undo processes them too (see logtb_rv_read_only_map_undo_tdes),
@@ -4493,16 +4490,17 @@ logtb_find_smallest_lsa (THREAD_ENTRY * thread_p, LOG_LSA * lsa)
    * their in-flight log.
    */
   // *INDENT-OFF*
-  log_system_tdes::map_all_tdes ([lsa] (log_tdes & sys_tdes)
+  log_system_tdes::map_all_tdes ([&smallest_lsa] (log_tdes & sys_tdes)
     {
-      if (!LSA_ISNULL (&sys_tdes.head_lsa) && (LSA_ISNULL (lsa) || LSA_LT (&sys_tdes.head_lsa, lsa)))
+      if (!LSA_ISNULL (&sys_tdes.head_lsa)
+	  && (LSA_ISNULL (&smallest_lsa) || LSA_LT (&sys_tdes.head_lsa, &smallest_lsa)))
 	{
-	  LSA_COPY (lsa, &sys_tdes.head_lsa);
+	  LSA_COPY (&smallest_lsa, &sys_tdes.head_lsa);
 	}
     });
   // *INDENT-ON*
 
-  TR_TABLE_CS_EXIT (thread_p);
+  LSA_COPY (lsa, &smallest_lsa);
 }
 
 /*


### PR DESCRIPTION


<http://jira.cubrid.org/browse/CBRD-27185>

### Purpose

온라인 인덱스 빌드처럼 시스템 워커 트랜잭션이 작업 중일 때 `cubrid backupdb -r`을 수행하면, 복원 시 복구(UNDO)에 필요한 아카이브 로그가 백업에서 누락되고 디스크에서도 삭제될 수 있다. 이런 백업은 restoredb 후 서버 기동 시 FATAL(-97, unable to find log page in log archives)로 복원이 불가능하거나, 중단된 내부 작업의 롤백이 조용히 소실된다.

원인은 복구와 보존의 비대칭이다. 복구 UNDO는 시스템 워커 트랜잭션을 포함해 수집하지만(`logtb_rv_read_only_map_undo_tdes`), 아카이브 보존 경계(`last_arv_num_for_syscrashes`)를 결정하는 smallest LSA 계산(`logtb_find_smallest_lsa()`, 체크포인트의 `smallest_lsa`)은 정규 트랜잭션 테이블만 순회한다. 그 결과 시스템 워커가 system operation을 연 채 로그를 쓰는 동안 체크포인트가 완료되면, 그 작업의 롤백에 필요한 로그를 지나 경계가 전진할 수 있고, backupdb는 이 경계를 그대로 믿고 백업 범위를 정하며 `-r`은 경계 아래를 물리 삭제한다.

### Implementation

smallest LSA 계산 두 곳이 복구 UNDO와 동일하게 시스템 워커 tdes 맵도 순회하도록 수정한다.

* `logtb_find_smallest_lsa()` (log_tran_table.c): 정규 tran table 순회 후 `log_system_tdes::map_all_tdes()`로 시스템 tdes의 `head_lsa`를 최솟값에 반영
* `logpb_checkpoint()` (log_page_buffer.c): `logpb_checkpoint_trans()` 루프 직후 동일하게 `smallest_lsa`에 반영

시스템 tdes의 `head_lsa`는 최상위 system operation이 시작될 때마다 리셋되므로(`log_tdes::on_sysop_start`), 이 값은 "진행 중인 작업의 시작점"만 정확히 붙잡는다. 유휴 워커는 `head_lsa`가 NULL이라 아무것도 보존하지 않으며, 락 순서는 체크포인트가 이미 같은 위치에서 `map_all_tdes()`를 호출하고 있어(chkpt_topops 기록) 새로 생기지 않는다.

### Remarks
N/A

