### PR TITLE
[CBRD-27290] Remove the dead private_heap_id == 0 gate from parallel scan open

### DIFF
--- a/src/query/parallel/px_scan/px_scan.cpp
+++ b/src/query/parallel/px_scan/px_scan.cpp
@@ -387,10 +387,9 @@ extern "C"
 	    return NO_ERROR;
 	  }
 
+	assert (thread_p->private_heap_id != 0);
 	if (oid_is_system_class (class_oid)
-	    || mvcc_is_mvcc_disabled_class (class_oid) || mvcc_select_lock_needed
-	    /* private_heap_id==0 means not main thread; parallel heap scan requires main thread. */
-	    || thread_p->private_heap_id == 0)
+	    || mvcc_is_mvcc_disabled_class (class_oid) || mvcc_select_lock_needed)
 	  {
 	    /* parallel-thread heap scan not supported */
 	    ACCESS_SPEC_SET_FLAG (spec, ACCESS_SPEC_FLAG_NO_PARALLEL_SCAN);
@@ -857,11 +856,7 @@ extern "C"
 
     scan_id->type = S_LIST_SCAN;
 
-    if (thread_p->private_heap_id == 0)
-      {
-	/* not main thread; cannot use parallel list scan */
-	return NO_ERROR;
-      }
+    assert (thread_p->private_heap_id != 0);
 
     /* DML reads val_list directly from scan_id; result handler does not populate it as DML expects. */
     if (xasl->type == INSERT_PROC || xasl->type == UPDATE_PROC
@@ -1309,11 +1304,7 @@ extern "C"
     /* clear stale pending from previous open (e.g., partition pruning re-open in qexec_next_scan_block_iterations). */
     scan_clear_parallel_index_pending (thread_p, scan_id);
 
-    if (thread_p->private_heap_id == 0)
-      {
-	/* not main thread; cannot use parallel index scan */
-	return NO_ERROR;
-      }
+    assert (thread_p->private_heap_id != 0);
 
     /* DML reads val_list directly; parallel scan does not populate it the same way */
     if (xasl->type == INSERT_PROC || xasl->type == UPDATE_PROC


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27290>

### Purpose

병렬 스캔 open 경로의 `private_heap_id == 0` 게이트("메인 스레드가 아니면 병렬 금지")는 사문화된 코드다. `thread_entry` 생성자가 `THREAD_ENTRY::private_heap_id`에 항상 유효한 heap을 할당하고, 이후 0으로 되돌리는 코드가 없다(SA 모드 `query_method.cpp`의 0 대입은 별개의 전역 변수이지 스레드 필드가 아님). 병렬 스캔 워커는 `scan_open_heap_scan` 등을 직접 호출해 이 게이트를 거치지 않고, 병렬 서브쿼리 워커는 비메인 스레드에서 의도적으로 `qexec_execute_mainblock`을 재진입해 게이트를 통과한다. 중첩 병렬 방지는 checker가 서브트리에 `NO_PARALLEL_SCAN`을 강제해 담당한다.

### Implementation

`src/query/parallel/px_scan/px_scan.cpp`의 세 scan-open 지점에서 `private_heap_id == 0` 검사를 제거하고 `assert (thread_p->private_heap_id != 0)`로 대체:
- heap: 복합 조건에서 `|| thread_p->private_heap_id == 0` 항만 제거하고 if 앞에 assert 추가
- list / index: 단독 `if (... == 0) return NO_ERROR;`를 assert로 교체

### Remarks

제거된 경로는 도달 불가이므로 동작 변화 없음. 정합성(CTP) 회귀는 CircleCI로 검증.