### PR TITLE
[CBRD-27292] Keep parallelism for constant-output scans (empty pred+rest)

### DIFF
--- a/src/query/parallel/px_scan/px_scan_checker.cpp
+++ b/src/query/parallel/px_scan/px_scan_checker.cpp
@@ -553,9 +553,10 @@ namespace parallel_scan
       case BUILDLIST_PROC:
 	break;
       case BUILDVALUE_PROC:
+	/* agg-less buildvalue too: MERGEABLE_LIST would misread proc.buildlist in result_handler init. */
+	set_flag (result, CANNOT_LIST_MERGE);
 	if (arg->proc.buildvalue.agg_list)
 	  {
-	    set_flag (result, CANNOT_LIST_MERGE);
 	    buildvalue_opt = true;
 	    AGGREGATE_TYPE *agg_it = arg->proc.buildvalue.agg_list;
 	    temp = 0;

--- a/src/query/parallel/px_scan/px_scan_checker.cpp
+++ b/src/query/parallel/px_scan/px_scan_checker.cpp
@@ -421,20 +421,12 @@ namespace parallel_scan
 	    result |= check<false> (arg->s.cls_node.cls_regu_list_range);
 	    result |= check<false> (arg->where_range);
 	  }
-	if (!arg->s.cls_node.cls_regu_list_pred && !arg->s.cls_node.cls_regu_list_rest)
-	  {
-	    set_flag (result, CANNOT_LIST_MERGE);
-	  }
       }
     else if (arg->type == TARGET_LIST)
       {
 	result |= check<false> (arg->s.list_node.list_regu_list_pred);
 	result |= check<false> (arg->s.list_node.list_regu_list_rest);
 	result |= check<false> (arg->where_pred);
-	if (!arg->s.list_node.list_regu_list_pred && !arg->s.list_node.list_regu_list_rest)
-	  {
-	    set_flag (result, CANNOT_LIST_MERGE);
-	  }
       }
     return result;
   }


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27292>

### Purpose

parallel scan checker는 spec에 pred regu list와 rest regu list가 둘 다 없으면 `CANNOT_LIST_MERGE`를 세워 heap을 row-by-row로, list/index를 직렬로 강등했다. 대표 대상은 `SELECT 1 FROM t`(상수 출력)다. 이 게이트는 CBRD-26465에서 count fast path를 ROWNUM/Java SP 쿼리로부터 보호하며 추가됐으나, ROWNUM과 SP는 지금 각자 별도 게이트를 가지므로 이 게이트의 잔여 실익이 없다.

### Implementation

`src/query/parallel/px_scan/px_scan_checker.cpp`에서 TARGET_CLASS와 TARGET_LIST 분기의 empty-pred+rest `CANNOT_LIST_MERGE` 설정을 제거. 워커의 MERGEABLE_LIST write는 `qdata_generate_tuple_desc_for_valptr_list`로 outptr_list를 직접 투영하므로 상수 출력 행에는 pred/rest regu list가 필요 없다. 주변 regu-list 검사는 그대로 유지.

`BUILDVALUE_PROC`은 agg 유무와 무관하게 `CANNOT_LIST_MERGE`로 차단(commit afca53740). empty-pred 강등을 제거하면 agg-less BUILDVALUE(`SELECT 1 FROM t HAVING <비집계>`)가 MERGEABLE_LIST에 도달할 수 있는데, 그 경로의 result-handler init이 union `proc.buildlist.g_hash_eligible`을 오독한다(노드가 BUILDVALUE라 다른 union 멤버의 쓰레기값 → 참이면 `agg_hash_context->part_list_id` 역참조). 이 오독은 술어가 붙은 경로(`WHERE ... HAVING <비집계>`)로도 도달 가능한 develop 선재 버그이며, 무조건 차단이 empty-pred·술어 두 경로를 모두 row-by-row로 되돌린다. agg 있는 BUILDVALUE의 병렬 집계(buildvalue_opt)는 그대로 유지. 본 PR Purpose가 COUNT(*)/buildvalue_opt를 "해당 없음"으로 둔 것은 agg 있는 BUILDVALUE 경로를 가리키며, afca53740이 다루는 것은 그와 구분되는 agg-less BUILDVALUE다.

### Remarks

ROWNUM/instnum·SP 게이트는 유지. 정합성(CTP) 회귀는 CircleCI로 검증. 회귀 TC는 no-predicate(SYS_TIMESTAMP)와 predicate(`WHERE ... HAVING 1=1`, plan-cache aliasing 회피 위해 `/*+ RECOMPILE */`로 BUILDVALUE 고정) 두 경로를 모두 커버.