### PR TITLE
[CBRD-26861] [CMS] refactor make_temp_filepath () for CMS

### DIFF
--- a/src/cm_common/cm_dep.h
+++ b/src/cm_common/cm_dep.h
@@ -267,8 +267,6 @@ extern "C"
   int cm_util_log_write_command (int argc, char *argv[]);
 
   int make_temp_filename (char *tempfile, const char *prefix, int size);
-  int make_temp_filepath (char *tempfile, char *tempdir, char *prefix, int task_code, int size);
-
 #ifdef __cplusplus
 }
 #endif

--- a/src/cm_common/cm_utils.c
+++ b/src/cm_common/cm_utils.c
@@ -761,7 +761,7 @@ make_temp_filename (char *tempfile, const char *prefix, int size)
 int
 make_temp_filepath (char *tempfile, char *tempdir, char *prefix, int task_code, int size)
 {
-  static std::atomic<long> seq_counter (0);
+  static std::atomic < long > seq_counter (0);
   long seq;
   long pid;
   time_t now;

--- a/src/cm_common/cm_utils.c
+++ b/src/cm_common/cm_utils.c
@@ -776,7 +776,7 @@ make_temp_filepath (char *tempfile, char *tempdir, char *prefix, int task_code, 
   pid = (long) getpid ();
 
   snprintf (tempfile, size - 1, "%s/%s_%03d_%ld_%ld_%ld", tempdir, prefix ? prefix : "", task_code,
-           (long) now, pid, seq);
+	    (long) now, pid, seq);
 
   return 0;
 }

--- a/src/cm_common/cm_utils.c
+++ b/src/cm_common/cm_utils.c
@@ -755,32 +755,6 @@ make_temp_filename (char *tempfile, const char *prefix, int size)
   return 0;
 }
 
-/*
- * even with pid and atomic seq, we can gurantee uniqness for a temp filename
- */
-int
-make_temp_filepath (char *tempfile, char *tempdir, char *prefix, int task_code, int size)
-{
-  static std::atomic < long >seq_counter (0);
-  long seq;
-  long pid;
-  time_t now;
-
-  if (tempfile == NULL || tempdir == NULL || size < 1)
-    {
-      return -1;
-    }
-
-  now = time (NULL);
-  seq = seq_counter.fetch_add (1, std::memory_order_relaxed);
-  pid = (long) getpid ();
-
-  snprintf (tempfile, size - 1, "%s/%s_%03d_%ld_%ld_%ld", tempdir, prefix ? prefix : "", task_code,
-	    (long) now, pid, seq);
-
-  return 0;
-}
-
 #if defined (WINDOWS)
 /* Number of 100 nanosecond units from 1/1/1601 to 1/1/1970 */
 #define EPOCH_BIAS_IN_100NANOSECS 116444736000000000LL

--- a/src/cm_common/cm_utils.c
+++ b/src/cm_common/cm_utils.c
@@ -31,6 +31,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <time.h>
+#include <atomic>
 
 #if defined(WINDOWS)
 #include <process.h>
@@ -758,20 +759,25 @@ int
 make_temp_filepath (char *tempfile, char *tempdir, char *prefix, int task_code, int size)
 {
   struct timeval current_time;
+  static std::atomic<long> seq_counter (0);
+  long seq;
+  long pid;
 
   if (tempfile == NULL || tempdir == NULL || size < 1)
     {
       return -1;
     }
 
-  srand (time (NULL));
   if (gettimeofday (&current_time, NULL) < 0)
     {
       return -1;
     }
 
-  snprintf (tempfile, size - 1, "%s/%s_%03d_%ld_%ld_%d", tempdir, prefix ? prefix : "", task_code,
-	    current_time.tv_sec, current_time.tv_usec, rand () % 997);
+  seq = seq_counter.fetch_add (1, std::memory_order_relaxed);
+  pid = (long) getpid ();
+
+  snprintf (tempfile, size - 1, "%s/%s_%03d_%ld_%ld_%ld_%ld", tempdir, prefix ? prefix : "", task_code,
+	    current_time.tv_sec, current_time.tv_usec, pid, seq);
 
   return 0;
 }

--- a/src/cm_common/cm_utils.c
+++ b/src/cm_common/cm_utils.c
@@ -761,7 +761,7 @@ make_temp_filename (char *tempfile, const char *prefix, int size)
 int
 make_temp_filepath (char *tempfile, char *tempdir, char *prefix, int task_code, int size)
 {
-  static std::atomic < long > seq_counter (0);
+  static std::atomic < long >seq_counter (0);
   long seq;
   long pid;
   time_t now;

--- a/src/cm_common/cm_utils.c
+++ b/src/cm_common/cm_utils.c
@@ -755,29 +755,28 @@ make_temp_filename (char *tempfile, const char *prefix, int size)
   return 0;
 }
 
+/*
+ * even with pid and atomic seq, we can gurantee uniqness for a temp filename
+ */
 int
 make_temp_filepath (char *tempfile, char *tempdir, char *prefix, int task_code, int size)
 {
-  struct timeval current_time;
   static std::atomic<long> seq_counter (0);
   long seq;
   long pid;
+  time_t now;
 
   if (tempfile == NULL || tempdir == NULL || size < 1)
     {
       return -1;
     }
 
-  if (gettimeofday (&current_time, NULL) < 0)
-    {
-      return -1;
-    }
-
+  now = time (NULL);
   seq = seq_counter.fetch_add (1, std::memory_order_relaxed);
   pid = (long) getpid ();
 
-  snprintf (tempfile, size - 1, "%s/%s_%03d_%ld_%ld_%ld_%ld", tempdir, prefix ? prefix : "", task_code,
-	    current_time.tv_sec, current_time.tv_usec, pid, seq);
+  snprintf (tempfile, size - 1, "%s/%s_%03d_%ld_%ld_%ld", tempdir, prefix ? prefix : "", task_code,
+           (long) now, pid, seq);
 
   return 0;
 }


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26861>

### Purpose
* refactor make_temp_filepath () to gen_tempfile_path () and move to cubridmanager/server/src/cm_server_util.cpp

### Implementation
- engine에서 make_temp_filepath ()를 제거하니, CI 빌드에서 cubridmanager 빌드오류가 발생하네요 수정된 cubridmanager가 develop에 merge된 이후 make_temp_filepath ()를 제거하는 작업을 진행하겠습니다.

### Remarks
* Claude review의 comment에 따라서 make_temp_filepath ()를 thread-safe version으로 수정
* 수정된 함수는 cubridmanager로 이동했습니다. 이 함수는 engine과 관련 없는 general library 성격이고
* cubridmanager 에 포함되면, 엔진의 각 version과 빌드시에 engine (cm_common)을 수정하지 않아도 됩니다.
* cubridmanager의 모든 make_temp_filepath ()는 수정된 함수 gen_tempfile_path ()으로 변경되었습니다.
* 결과적으로 make_temp_filepath ()은 UNUSED function이 되어서 cm_common/에서 지우거나 그냥 두어도 영향이 없습니다.
* 일단 develop에서 먼저 제거하고, 추후 각 엔진별 submodule update시에 'make_temp_filepath ()' 코드를 같이 지우면 될듯 합니다.
* reviewer 참고용으로 cm_server_util.cpp에 정의한 대체용 함수를 첨부합니다

```
int
gen_tempfile_path (char *tempfile, const char *tempdir, const char *prefix, int task_code, size_t size)
{
  static atomic_counter_t seq = 0;
  time_t now;
  long tid;
  int ret = -1;

  if (tempfile == NULL || tempdir == NULL || size < 1)
    {
      return -1;
    }

#if defined (WINDOWS)
  tid = GetCurrentThreadId ();
#else
  tid = pthread_self ();
#endif

  now = time (NULL);
  ATOMIC_FETCH_ADD1 (seq);

  ret = snprintf (tempfile, size - 1, "%s/%s_%03d_%ld_%ld_%ld", tempdir, prefix ? prefix : "", task_code,
           (long) now, tid, seq);

  return (ret > 0 && ret < (size - 1)) ? 0 : -1;
}
```