### PR TITLE
[CBRD-27203] Increase the size of the buffer for the function name in pt_find_function_name() (#7633)

### DIFF
--- a/src/parser/keyword.c
+++ b/src/parser/keyword.c
@@ -1008,7 +1008,7 @@ pt_find_function_name (const char *text)
 #endif
     }
 
-  char temp[MAX_KEYWORD_SIZE];
+  char temp[DB_MAX_IDENTIFIER_LENGTH];
 
   dummy.keyword = temp;
   return (FUNCTION_MAP *) find_keyword_tables (functions, dummy, finfo, keyword_hash_comparator < FUNCTION_MAP >, text);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27203

* fix memory overwrite
* backport #7633 

