### PR TITLE
[CBRD-27300] Allow hostname labels starting with a digit in cubrid_hosts.conf

### DIFF
--- a/src/connection/host_lookup.c
+++ b/src/connection/host_lookup.c
@@ -526,9 +526,9 @@ is_valid_ipv4 (const char *ip_addr)
 
 
 /*
-* is_valid_hostname () - Check the host name is valid format.
+* is_valid_label () - Check the label name is valid format.
 *
-* return   : true if host name is valid format, false otherwise
+* return   : true if label name is valid format, false otherwise
 */
 static int
 is_valid_label (const char *label)
@@ -546,7 +546,7 @@ is_valid_label (const char *label)
       return 0;
     }
 
-  if (!isalpha (label[0]) || !isalnum (label[length - 1]))
+  if (!isalnum (label[0]) || !isalnum ((unsigned char) label[length - 1]))
     {
       return 0;
     }

--- a/src/connection/host_lookup.c
+++ b/src/connection/host_lookup.c
@@ -546,14 +546,14 @@ is_valid_label (const char *label)
       return 0;
     }
 
-  if (!isalnum (label[0]) || !isalnum ((unsigned char) label[length - 1]))
+  if (!isalnum ((unsigned char) label[0]) || !isalnum ((unsigned char) label[length - 1]))
     {
       return 0;
     }
 
   for (int i = 0; i < length; i++)
     {
-      if (!isalnum (label[i]) && label[i] != '-')
+      if (!isalnum ((unsigned char) label[i]) && label[i] != '-')
 	{
 	  return 0;
 	}
@@ -588,6 +588,12 @@ is_valid_fqdn (const char *fqdn)
   length = strlen (fqdn);
 
   if (length > MAX_FQDN_LEN)
+    {
+      return 0;
+    }
+
+  /* reject dotted-decimal strings so they can't collide with IP keys in user_host_Map */
+  if (is_valid_ipv4 (fqdn))
     {
       return 0;
     }
@@ -747,7 +753,7 @@ handle_uhost_conf (int action_type)
 		{
 		  fprintf (stderr,
 			   msgcat_message (MSGCAT_CATALOG_CUBRID, MSGCAT_SET_PARAMETERS,
-					   PRM_ERR_INVALID_HOSTNAME), hostname, line_number, hosts_conf_dir);
+					   PRM_ERR_INVALID_HOSTNAME), token, line_number, hosts_conf_dir);
 		  has_invalid_entries = true;
 		  goto end;
 		}


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27300>

### Purpose

cubrid_hostㄴ.conf 설정에서 숫자로 시작하는 호스트명도 유효한 이름으로 처리되어야 한다.
RFC 952는 라벨이 문자로 시작할 것을 요구했으나, RFC 1123 §2.1에서 "호스트명의 첫 문자는 숫자일 수 있다"로 완화되었고 현재 대부분의 DNS/OS resolver가 이를 허용한다.

### Implementation

is_valid_label function에서 허용되는 label name을 첫 글자도 숫자를 허용

### Remarks

11.4에 백포트 필요
