### PR TITLE
[CBRD-27281] TP_DOMAIN is not released in the schema change error path

### DIFF
--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -8147,12 +8147,14 @@ do_add_attribute (PARSER_CONTEXT * parser, DB_CTMPL * ctemplate, PT_NODE * attri
   error = check_default_on_update_clause (parser, attribute);
   if (error != NO_ERROR)
     {
+      tp_domain_free (attr_db_domain);
       goto error_exit;
     }
 
   error = get_att_order_from_def (attribute, &add_first, &add_after_attr);
   if (error != NO_ERROR)
     {
+      tp_domain_free (attr_db_domain);
       goto error_exit;
     }
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27281>

### Purpose

DDL 실행 중 만든 임시 도메인(transient domain)이 오류 경로에서 해제되지 않아 클라이언트 프로세스에 누적되는 문제를 고친다.

### Implementation

do_add_attribute 에서 tp_domain_free로 할당된 메모리 해제

### Remarks

N/A
