### PR TITLE
[CBRD-27151] Reduce DROP/TRUNCATE commit cost with sector-level bulk file destroy

### DIFF
--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -730,7 +730,6 @@ static int file_user_page_table_extdata_dump (THREAD_ENTRY * thread_p, const FIL
 					      bool * stop, void *args);
 static int file_user_page_table_item_dump (THREAD_ENTRY * thread_p, const void *data, int index, bool * stop,
 					   void *args);
-static int file_sector_map_dealloc (THREAD_ENTRY * thread_p, const void *data, int index, bool * stop, void *args);
 static int file_sector_map_dealloc_temp (THREAD_ENTRY * thread_p, const void *data, int index, bool * stop, void *args);
 static int file_set_tde_algorithm (THREAD_ENTRY * thread_p, const VFID * vfid, TDE_ALGORITHM tde_algo);
 static TDE_ALGORITHM file_get_tde_algorithm_internal (const FILE_HEADER * fhead);
@@ -4001,65 +4000,6 @@ file_table_collect_all_vsids (THREAD_ENTRY * thread_p, PAGE_PTR page_fhead, FILE
 }
 
 /*
- * file_sector_map_dealloc () - FILE_EXTDATA_ITEM_FUNC to deallocate user pages
- *
- * return        : error code
- * thread_p (in) : thread entry
- * data (in)     : FILE_PARTIAL_SECTOR * or VSID *
- * index (in)    : unused
- * stop (in)     : unused
- * args (in)     : is_partial
- */
-static int
-file_sector_map_dealloc (THREAD_ENTRY * thread_p, const void *data, int index, bool * stop, void *args)
-{
-  bool is_partial = *(bool *) args;
-  FILE_PARTIAL_SECTOR partsect = FILE_PARTIAL_SECTOR_INITIALIZER;
-  int offset = 0;
-  VPID vpid;
-  PAGE_PTR page = NULL;
-  int error_code = NO_ERROR;
-
-  if (is_partial)
-    {
-      partsect = *(FILE_PARTIAL_SECTOR *) data;
-    }
-  else
-    {
-      partsect.vsid = *(VSID *) data;
-    }
-
-  vpid.volid = partsect.vsid.volid;
-  for (offset = 0, vpid.pageid = SECTOR_FIRST_PAGEID (partsect.vsid.sectid); offset < DISK_SECTOR_NPAGES;
-       offset++, vpid.pageid++)
-    {
-      if (is_partial && !file_partsect_is_bit_set (&partsect, offset))
-	{
-	  /* not allocated */
-	  continue;
-	}
-
-      page = pgbuf_fix (thread_p, &vpid, OLD_PAGE, PGBUF_LATCH_WRITE, PGBUF_UNCONDITIONAL_LATCH);
-      if (page == NULL)
-	{
-	  ASSERT_ERROR_AND_SET (error_code);
-	  return error_code;
-	}
-
-      if (pgbuf_get_page_ptype (thread_p, page) == PAGE_FTAB)
-	{
-	  /* table page, do not deallocate yet */
-	  pgbuf_unfix_and_init (thread_p, page);
-	  continue;
-	}
-      pgbuf_dealloc_page (thread_p, page);
-      page = NULL;
-    }
-
-  return NO_ERROR;
-}
-
-/*
  * file_sector_map_dealloc_temp () - FILE_EXTDATA_ITEM_FUNC to dealloc user pages of temp table
  *
  * return        : error code
@@ -4210,65 +4150,19 @@ file_destroy (THREAD_ENTRY * thread_p, const VFID * vfid, bool is_temp)
 
   if (!FILE_IS_TEMPORARY (fhead))
     {
-      /* we need to deallocate pages */
-      ftab_collector.npages = 0;
-      ftab_collector.nsects = 0;
-      ftab_collector.partsect_ftab =
-	(FILE_PARTIAL_SECTOR *) db_private_alloc (thread_p, fhead->n_page_ftab * sizeof (FILE_PARTIAL_SECTOR));
-      if (ftab_collector.partsect_ftab == NULL)
-	{
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1,
-		  fhead->n_page_ftab * sizeof (FILE_PARTIAL_SECTOR));
-	  error_code = ER_OUT_OF_VIRTUAL_MEMORY;
-	  goto exit;
-	}
+      /* bulk destroy: do not fix and deallocate pages one by one - that reads the whole file from disk
+       * when it is not buffered and appends one dealloc log record per page. the file's logical removal is already
+       * fully logged by the tracker unregister (above) and the sector unreserve (below); page-level state needs no
+       * logging. buffered pages are discarded (cleared of dirty status and invalidated) so that no stale content can
+       * reach disk after the sectors are reused. */
+      pgbuf_unfix_and_init (thread_p, page_fhead);
 
-      FILE_HEADER_GET_PART_FTAB (fhead, extdata_ftab);
-      is_partial = true;
-      error_code =
-	file_extdata_apply_funcs (thread_p, extdata_ftab, file_extdata_collect_ftab_pages, &ftab_collector,
-				  file_sector_map_dealloc, &is_partial, true, NULL, NULL);
+      error_code = pgbuf_discard_pages_of_sectors (thread_p, vsid_collector.vsids, vsid_collector.n_vsids);
       if (error_code != NO_ERROR)
 	{
-	  ASSERT_ERROR ();
+	  assert_release (false);
 	  goto exit;
 	}
-
-      FILE_HEADER_GET_FULL_FTAB (fhead, extdata_ftab);
-      is_partial = false;
-      error_code =
-	file_extdata_apply_funcs (thread_p, extdata_ftab, file_extdata_collect_ftab_pages, &ftab_collector,
-				  file_sector_map_dealloc, &is_partial, true, NULL, NULL);
-      if (error_code != NO_ERROR)
-	{
-	  ASSERT_ERROR ();
-	  goto exit;
-	}
-
-      /* deallocate table pages - other than header page */
-      for (iter_sects = 0; iter_sects < ftab_collector.nsects; iter_sects++)
-	{
-	  vpid_ftab.volid = ftab_collector.partsect_ftab[iter_sects].vsid.volid;
-	  for (offset = 0,
-	       vpid_ftab.pageid = SECTOR_FIRST_PAGEID (ftab_collector.partsect_ftab[iter_sects].vsid.sectid);
-	       offset < DISK_SECTOR_NPAGES; offset++, vpid_ftab.pageid++)
-	    {
-	      if (file_partsect_is_bit_set (&ftab_collector.partsect_ftab[iter_sects], offset))
-		{
-		  page_ftab = pgbuf_fix (thread_p, &vpid_ftab, OLD_PAGE, PGBUF_LATCH_WRITE, PGBUF_UNCONDITIONAL_LATCH);
-		  if (page_ftab == NULL)
-		    {
-		      ASSERT_ERROR_AND_SET (error_code);
-		      goto exit;
-		    }
-		  pgbuf_dealloc_page (thread_p, page_ftab);
-		  page_ftab = NULL;
-		}
-	    }
-	}
-      /* deallocate header page */
-      pgbuf_dealloc_page (thread_p, page_fhead);
-      page_fhead = NULL;
     }
   else
     {

--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -4127,7 +4127,7 @@ file_destroy (THREAD_ENTRY * thread_p, const VFID * vfid, bool is_temp)
   if (file_get_tde_algorithm_internal (fhead) != TDE_ALGORITHM_NONE)
     {
       tde_er_log
-	("file_destroy(): clear tde bit in pflag in all user pages, VFID = %d|%d, # of encrypting (user) pages = %d, tde algorithm = %s\n",
+	("file_destroy(): destroy encrypted file; buffered pages are discarded and never written again, VFID = %d|%d, # of (user) pages = %d, tde algorithm = %s\n",
 	 VFID_AS_ARGS (&fhead->self), fhead->n_page_user,
 	 tde_get_algorithm_name (file_get_tde_algorithm_internal (fhead)));
     }

--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -4157,22 +4157,8 @@ file_destroy (THREAD_ENTRY * thread_p, const VFID * vfid, bool is_temp)
        * reach disk after the sectors are reused; pages that are not buffered are not even touched. */
       pgbuf_unfix_and_init (thread_p, page_fhead);
 
-#if defined (FILE_DESTROY_DISCARD_BY_PROBE)
-      /* probe each page of the destroyed sectors in the buffer hash. cost is proportional to the file size.
-       * kept switchable against the pool-scan below for performance comparison. */
-      for (iter_sects = 0; iter_sects < vsid_collector.n_vsids; iter_sects++)
-	{
-	  vpid_ftab.volid = vsid_collector.vsids[iter_sects].volid;
-	  for (offset = 0, vpid_ftab.pageid = SECTOR_FIRST_PAGEID (vsid_collector.vsids[iter_sects].sectid);
-	       offset < DISK_SECTOR_NPAGES; offset++, vpid_ftab.pageid++)
-	    {
-	      pgbuf_discard_page (thread_p, &vpid_ftab);
-	    }
-	}
-#else
       /* scan the buffer pool once for pages of the destroyed sectors. cost is proportional to the pool size. */
       pgbuf_discard_pages_of_sectors (thread_p, vsid_collector.vsids, vsid_collector.n_vsids);
-#endif
     }
   else
     {

--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -4154,15 +4154,25 @@ file_destroy (THREAD_ENTRY * thread_p, const VFID * vfid, bool is_temp)
        * when it is not buffered and appends one dealloc log record per page. the file's logical removal is already
        * fully logged by the tracker unregister (above) and the sector unreserve (below); page-level state needs no
        * logging. buffered pages are discarded (cleared of dirty status and invalidated) so that no stale content can
-       * reach disk after the sectors are reused. */
+       * reach disk after the sectors are reused; pages that are not buffered are not even touched. */
       pgbuf_unfix_and_init (thread_p, page_fhead);
 
-      error_code = pgbuf_discard_pages_of_sectors (thread_p, vsid_collector.vsids, vsid_collector.n_vsids);
-      if (error_code != NO_ERROR)
+#if defined (FILE_DESTROY_DISCARD_BY_PROBE)
+      /* probe each page of the destroyed sectors in the buffer hash. cost is proportional to the file size.
+       * kept switchable against the pool-scan below for performance comparison. */
+      for (iter_sects = 0; iter_sects < vsid_collector.n_vsids; iter_sects++)
 	{
-	  assert_release (false);
-	  goto exit;
+	  vpid_ftab.volid = vsid_collector.vsids[iter_sects].volid;
+	  for (offset = 0, vpid_ftab.pageid = SECTOR_FIRST_PAGEID (vsid_collector.vsids[iter_sects].sectid);
+	       offset < DISK_SECTOR_NPAGES; offset++, vpid_ftab.pageid++)
+	    {
+	      pgbuf_discard_page (thread_p, &vpid_ftab);
+	    }
 	}
+#else
+      /* scan the buffer pool once for pages of the destroyed sectors. cost is proportional to the pool size. */
+      pgbuf_discard_pages_of_sectors (thread_p, vsid_collector.vsids, vsid_collector.n_vsids);
+#endif
     }
   else
     {

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -3447,6 +3447,100 @@ pgbuf_invalidate_all (THREAD_ENTRY * thread_p, VOLID volid)
 }
 
 /*
+ * pgbuf_discard_page () - discard the buffered copy of a page belonging to a destroyed file: clear its dirty status
+ *                         and invalidate the buffer, without flushing and without any logging.
+ *
+ *                         when the function returns, no bcb for the given page remains in the buffer. this is a hard
+ *                         guarantee: the caller unreserves the page's sector right after, and the sector may be
+ *                         immediately reused by another file. a leftover dirty bcb could overwrite the reused sector
+ *                         with dead content, an in-flight write must finish before the sector can be reused, and even
+ *                         a leftover clean bcb breaks the NEW_PAGE fix of the reused page (it expects no stale
+ *                         permanent page in the buffer).
+ *
+ * return        : void
+ * thread_p (in) : thread entry
+ * vpid (in)     : page identifier
+ *
+ * note: the caller must guarantee the page cannot be fixed concurrently (the destroyed file is unregistered from
+ *       tracker and exclusively locked).
+ */
+void
+pgbuf_discard_page (THREAD_ENTRY * thread_p, const VPID * vpid)
+{
+  PGBUF_BUFFER_HASH *hash_anchor;
+  PGBUF_BCB *bufptr;
+
+  assert (vpid != NULL && !VPID_ISNULL (vpid));
+
+retry:
+  hash_anchor = &pgbuf_Pool.buf_hash_table[PGBUF_HASH_VALUE (vpid)];
+  bufptr = pgbuf_search_hash_chain (thread_p, hash_anchor, vpid);
+  if (bufptr == NULL)
+    {
+      /* not buffered (or no longer buffered); done. */
+      pthread_mutex_unlock (&hash_anchor->hash_mutex);
+      return;
+    }
+  /* bufptr->mutex is held. */
+
+  if (get_fcnt (&bufptr->atomic_latch) > 0)
+    {
+      /* no one should be able to fix a page of a file being destroyed. */
+      assert (false);
+      PGBUF_BCB_UNLOCK (bufptr);
+      thread_sleep (0.01f);
+      goto retry;
+    }
+
+  /* discard content: the buffered copy must never reach disk. */
+  if (pgbuf_bcb_is_dirty (bufptr))
+    {
+      pgbuf_bcb_clear_dirty (thread_p, bufptr);
+    }
+
+  if (pgbuf_bcb_is_flushing (bufptr))
+    {
+      /* a flush is in progress. its write still goes to a sector reserved for the destroyed file, which is harmless,
+       * but we may not return before the write finishes, because the sector is unreserved right after and may be
+       * reused. wait for the flusher to finish and wake us. note that we cannot rely on pgbuf_bcb_safe_flush_* here:
+       * those skip non-dirty bcb's, and the flusher already cleared the dirty flag when it started the flush. */
+      set_waiter_exists (&bufptr->atomic_latch, true);
+      if (pgbuf_block_bcb (thread_p, bufptr, PGBUF_LATCH_FLUSH, 0, false) != NO_ERROR)
+	{
+	  /* interrupted while waiting; the flush may still be in progress, start over. */
+	  thread_sleep (0.01f);
+	}
+      /* bufptr->mutex has been released. state may have changed meanwhile; look the page up again. */
+      goto retry;
+    }
+
+  if (pgbuf_bcb_avoid_victim (bufptr))
+    {
+      /* the bcb was assigned as a direct victim to a thread waiting for one; that thread will claim it and remove it
+       * from the hash shortly. yield and recheck: the next lookup will no longer find this page. */
+      PGBUF_BCB_UNLOCK (bufptr);
+      thread_sleep (0.01f);
+      goto retry;
+    }
+
+  /* clear residual hint flags that would block moving the bcb to the invalid list (see the flags assert in
+   * pgbuf_put_bcb_into_invalid_list): to-vacuum, move-to-lru-bottom and async-flush-request hints are all
+   * meaningless for a page of a destroyed file. */
+  pgbuf_bcb_update_flags (thread_p, bufptr, 0,
+			  PGBUF_BCB_TO_VACUUM_FLAG | PGBUF_BCB_MOVE_TO_LRU_BOTTOM_FLAG | PGBUF_BCB_ASYNC_FLUSH_REQ);
+
+#if defined(CUBRID_DEBUG)
+  pgbuf_scramble (&bufptr->iopage_buffer->iopage);
+#endif /* CUBRID_DEBUG */
+
+  (void) pgbuf_invalidate_bcb (thread_p, bufptr);
+  /* bufptr->mutex has been released in above function. */
+
+  /* confirm the page is really gone; pgbuf_invalidate_bcb gives up on rare transient states. */
+  goto retry;
+}
+
+/*
  * pgbuf_compare_vsids_for_discard () - bsearch comparator for VSID arrays; must match disk_compare_vsids ordering
  *                                      (volume id first, then sector id)
  *
@@ -3472,21 +3566,24 @@ pgbuf_compare_vsids_for_discard (const void *first, const void *second)
 }
 
 /*
- * pgbuf_discard_pages_of_sectors () - discard all buffered pages belonging to the given sectors: clear dirty status
- *                                     and invalidate the buffers, without flushing and without any logging.
- *                                     used by bulk permanent file destroy: the file is dropped and
- *                                     invisible, so buffered contents are dead; dirty pages must not reach disk
- *                                     because the sectors are about to be unreserved and may be reused.
+ * pgbuf_discard_pages_of_sectors () - discard all buffered pages belonging to the given sectors, in one pass over
+ *                                     the buffer pool. candidates are detected by scanning the pool; the actual
+ *                                     discard of each candidate goes through pgbuf_discard_page (), which gives the
+ *                                     same hard guarantee: when this function returns, no bcb of the given sectors
+ *                                     remains in the buffer.
  *
- * return        : NO_ERROR
+ * return        : void
  * thread_p (in) : thread entry
- * vsids (in)    : sectors of the file being destroyed, sorted by disk_compare_vsids ordering
+ * vsids (in)    : sectors of the file being destroyed, sorted by disk_compare_vsids ordering (the collector of
+ *                 file_destroy already sorts them)
  * nsects (in)   : number of sectors
  *
- * note: must be called BEFORE the sectors are unreserved. the caller must guarantee that no page of these sectors
- *       can be fixed concurrently (the destroyed file is unregistered from tracker and exclusively locked).
+ * note: cost is proportional to the buffer pool size, not to the file size. see pgbuf_discard_page () for a variant
+ *       whose cost is proportional to the file size.
+ * note: the caller must guarantee that no page of these sectors can be fixed concurrently (the destroyed file is
+ *       unregistered from tracker and exclusively locked).
  */
-int
+void
 pgbuf_discard_pages_of_sectors (THREAD_ENTRY * thread_p, const VSID * vsids, int nsects)
 {
   PGBUF_BCB *bufptr;
@@ -3496,14 +3593,16 @@ pgbuf_discard_pages_of_sectors (THREAD_ENTRY * thread_p, const VSID * vsids, int
 
   if (vsids == NULL || nsects <= 0)
     {
-      return NO_ERROR;
+      return;
     }
 
   for (bufid = 0; bufid < pgbuf_Pool.num_buffers; bufid++)
     {
       bufptr = PGBUF_FIND_BCB_PTR (bufid);
 
-      /* dirty read for quick filtering; a match is rechecked while holding the bcb mutex. */
+      /* dirty read for quick filtering. any vpid that falls inside the given sectors belongs to the destroyed file
+       * (the sectors are reserved exclusively for it), so a matching value is a legitimate discard target no matter
+       * how the bcb changes concurrently; pgbuf_discard_page () re-verifies through the buffer hash anyway. */
       vpid = bufptr->vpid;
       if (VPID_ISNULL (&vpid))
 	{
@@ -3516,78 +3615,8 @@ pgbuf_discard_pages_of_sectors (THREAD_ENTRY * thread_p, const VSID * vsids, int
 	  continue;
 	}
 
-      PGBUF_BCB_LOCK (bufptr);
-
-      /* recheck under mutex */
-      if (VPID_ISNULL (&bufptr->vpid))
-	{
-	  PGBUF_BCB_UNLOCK (bufptr);
-	  continue;
-	}
-      vsid_key.volid = bufptr->vpid.volid;
-      vsid_key.sectid = bufptr->vpid.pageid / DISK_SECTOR_NPAGES;
-      if (bsearch (&vsid_key, vsids, nsects, sizeof (VSID), pgbuf_compare_vsids_for_discard) == NULL)
-	{
-	  PGBUF_BCB_UNLOCK (bufptr);
-	  continue;
-	}
-
-      if (get_fcnt (&bufptr->atomic_latch) > 0)
-	{
-	  /* no one should be able to fix a page of a file being destroyed */
-	  assert (false);
-	  PGBUF_BCB_UNLOCK (bufptr);
-	  continue;
-	}
-
-      /* discard content. the page must never reach disk. */
-      if (pgbuf_bcb_is_dirty (bufptr))
-	{
-	  pgbuf_bcb_clear_dirty (thread_p, bufptr);
-	}
-
-      if (pgbuf_bcb_is_flushing (bufptr))
-	{
-	  /* wait for the in-flight write to finish. it writes to a sector still reserved for the destroyed file,
-	   * which is harmless; but we may not return while a write is in flight, because the sectors are unreserved
-	   * right after this function and may be reused by another file. */
-	  VPID flush_vpid = bufptr->vpid;
-
-	  if (pgbuf_bcb_safe_flush_force_lock (thread_p, bufptr, true) != NO_ERROR)
-	    {
-	      assert (false);
-	      return ER_FAILED;
-	    }
-	  if (VPID_ISNULL (&bufptr->vpid) || !VPID_EQ (&flush_vpid, &bufptr->vpid)
-	      || get_fcnt (&bufptr->atomic_latch) > 0)
-	    {
-	      PGBUF_BCB_UNLOCK (bufptr);
-	      continue;
-	    }
-	}
-
-      if (pgbuf_bcb_avoid_victim (bufptr))
-	{
-	  /* skip invalidation; the bcb is clean now, so leaving it in the buffer is harmless. */
-	  PGBUF_BCB_UNLOCK (bufptr);
-	  continue;
-	}
-
-      /* clear residual hint flags that would block moving the bcb to the invalid list (see the flags assert in
-       * pgbuf_put_bcb_into_invalid_list): to-vacuum, move-to-lru-bottom and async-flush-request hints are all
-       * meaningless for a page of a destroyed file. */
-      pgbuf_bcb_update_flags (thread_p, bufptr, 0,
-			      PGBUF_BCB_TO_VACUUM_FLAG | PGBUF_BCB_MOVE_TO_LRU_BOTTOM_FLAG | PGBUF_BCB_ASYNC_FLUSH_REQ);
-
-#if defined(CUBRID_DEBUG)
-      pgbuf_scramble (&bufptr->iopage_buffer->iopage);
-#endif /* CUBRID_DEBUG */
-
-      (void) pgbuf_invalidate_bcb (thread_p, bufptr);
-      /* bufptr->mutex has been released in above function. */
+      pgbuf_discard_page (thread_p, &vpid);
     }
-
-  return NO_ERROR;
 }
 
 /*

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -1115,6 +1115,7 @@ static PGBUF_BCB *pgbuf_claim_bcb_for_fix (THREAD_ENTRY * thread_p, const VPID *
 static int pgbuf_victimize_bcb (THREAD_ENTRY * thread_p, PGBUF_BCB * bufptr);
 static int pgbuf_bcb_safe_flush_internal (THREAD_ENTRY * thread_p, PGBUF_BCB * bufptr, bool synchronous, bool * locked);
 static int pgbuf_invalidate_bcb (THREAD_ENTRY * thread_p, PGBUF_BCB * bufptr);
+static void pgbuf_discard_page (THREAD_ENTRY * thread_p, const VPID * vpid);
 static int pgbuf_bcb_safe_flush_force_lock (THREAD_ENTRY * thread_p, PGBUF_BCB * bufptr, bool synchronous);
 static int pgbuf_bcb_safe_flush_force_unlock (THREAD_ENTRY * thread_p, PGBUF_BCB * bufptr, bool synchronous);
 static PGBUF_BCB *pgbuf_get_bcb_from_invalid_list (THREAD_ENTRY * thread_p);
@@ -3482,7 +3483,7 @@ pgbuf_invalidate_all (THREAD_ENTRY * thread_p, VOLID volid)
  * note: the caller must guarantee the page cannot be fixed concurrently (the destroyed file is unregistered from
  *       tracker and exclusively locked).
  */
-void
+static void
 pgbuf_discard_page (THREAD_ENTRY * thread_p, const VPID * vpid)
 {
   PGBUF_BUFFER_HASH *hash_anchor;
@@ -3596,8 +3597,7 @@ pgbuf_compare_vsids_for_discard (const void *first, const void *second)
  *                 file_destroy already sorts them)
  * nsects (in)   : number of sectors
  *
- * note: cost is proportional to the buffer pool size, not to the file size. see pgbuf_discard_page () for a variant
- *       whose cost is proportional to the file size.
+ * note: cost is proportional to the buffer pool size, not to the file size.
  * note: the caller must guarantee that no page of these sectors can be fixed concurrently (the destroyed file is
  *       unregistered from tracker and exclusively locked).
  */

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -3447,6 +3447,150 @@ pgbuf_invalidate_all (THREAD_ENTRY * thread_p, VOLID volid)
 }
 
 /*
+ * pgbuf_compare_vsids_for_discard () - bsearch comparator for VSID arrays; must match disk_compare_vsids ordering
+ *                                      (volume id first, then sector id)
+ *
+ * return       : 1 if first is bigger, -1 if first is smaller, 0 if equal
+ * first (in)   : first VSID
+ * second (in)  : second VSID
+ */
+static int
+pgbuf_compare_vsids_for_discard (const void *first, const void *second)
+{
+  VSID *first_vsid = (VSID *) first;
+  VSID *second_vsid = (VSID *) second;
+
+  if (first_vsid->volid > second_vsid->volid)
+    {
+      return 1;
+    }
+  else if (first_vsid->volid < second_vsid->volid)
+    {
+      return -1;
+    }
+  return (int) (first_vsid->sectid - second_vsid->sectid);
+}
+
+/*
+ * pgbuf_discard_pages_of_sectors () - discard all buffered pages belonging to the given sectors: clear dirty status
+ *                                     and invalidate the buffers, without flushing and without any logging.
+ *                                     used by bulk permanent file destroy: the file is dropped and
+ *                                     invisible, so buffered contents are dead; dirty pages must not reach disk
+ *                                     because the sectors are about to be unreserved and may be reused.
+ *
+ * return        : NO_ERROR
+ * thread_p (in) : thread entry
+ * vsids (in)    : sectors of the file being destroyed, sorted by disk_compare_vsids ordering
+ * nsects (in)   : number of sectors
+ *
+ * note: must be called BEFORE the sectors are unreserved. the caller must guarantee that no page of these sectors
+ *       can be fixed concurrently (the destroyed file is unregistered from tracker and exclusively locked).
+ */
+int
+pgbuf_discard_pages_of_sectors (THREAD_ENTRY * thread_p, const VSID * vsids, int nsects)
+{
+  PGBUF_BCB *bufptr;
+  VSID vsid_key;
+  VPID vpid;
+  int bufid;
+
+  if (vsids == NULL || nsects <= 0)
+    {
+      return NO_ERROR;
+    }
+
+  for (bufid = 0; bufid < pgbuf_Pool.num_buffers; bufid++)
+    {
+      bufptr = PGBUF_FIND_BCB_PTR (bufid);
+
+      /* dirty read for quick filtering; a match is rechecked while holding the bcb mutex. */
+      vpid = bufptr->vpid;
+      if (VPID_ISNULL (&vpid))
+	{
+	  continue;
+	}
+      vsid_key.volid = vpid.volid;
+      vsid_key.sectid = vpid.pageid / DISK_SECTOR_NPAGES;
+      if (bsearch (&vsid_key, vsids, nsects, sizeof (VSID), pgbuf_compare_vsids_for_discard) == NULL)
+	{
+	  continue;
+	}
+
+      PGBUF_BCB_LOCK (bufptr);
+
+      /* recheck under mutex */
+      if (VPID_ISNULL (&bufptr->vpid))
+	{
+	  PGBUF_BCB_UNLOCK (bufptr);
+	  continue;
+	}
+      vsid_key.volid = bufptr->vpid.volid;
+      vsid_key.sectid = bufptr->vpid.pageid / DISK_SECTOR_NPAGES;
+      if (bsearch (&vsid_key, vsids, nsects, sizeof (VSID), pgbuf_compare_vsids_for_discard) == NULL)
+	{
+	  PGBUF_BCB_UNLOCK (bufptr);
+	  continue;
+	}
+
+      if (get_fcnt (&bufptr->atomic_latch) > 0)
+	{
+	  /* no one should be able to fix a page of a file being destroyed */
+	  assert (false);
+	  PGBUF_BCB_UNLOCK (bufptr);
+	  continue;
+	}
+
+      /* discard content. the page must never reach disk. */
+      if (pgbuf_bcb_is_dirty (bufptr))
+	{
+	  pgbuf_bcb_clear_dirty (thread_p, bufptr);
+	}
+
+      if (pgbuf_bcb_is_flushing (bufptr))
+	{
+	  /* wait for the in-flight write to finish. it writes to a sector still reserved for the destroyed file,
+	   * which is harmless; but we may not return while a write is in flight, because the sectors are unreserved
+	   * right after this function and may be reused by another file. */
+	  VPID flush_vpid = bufptr->vpid;
+
+	  if (pgbuf_bcb_safe_flush_force_lock (thread_p, bufptr, true) != NO_ERROR)
+	    {
+	      assert (false);
+	      return ER_FAILED;
+	    }
+	  if (VPID_ISNULL (&bufptr->vpid) || !VPID_EQ (&flush_vpid, &bufptr->vpid)
+	      || get_fcnt (&bufptr->atomic_latch) > 0)
+	    {
+	      PGBUF_BCB_UNLOCK (bufptr);
+	      continue;
+	    }
+	}
+
+      if (pgbuf_bcb_avoid_victim (bufptr))
+	{
+	  /* skip invalidation; the bcb is clean now, so leaving it in the buffer is harmless. */
+	  PGBUF_BCB_UNLOCK (bufptr);
+	  continue;
+	}
+
+      /* clear residual hint flags that would block moving the bcb to the invalid list (see the flags assert in
+       * pgbuf_put_bcb_into_invalid_list): to-vacuum, move-to-lru-bottom and async-flush-request hints are all
+       * meaningless for a page of a destroyed file. */
+      pgbuf_bcb_update_flags (thread_p, bufptr, 0,
+			      PGBUF_BCB_TO_VACUUM_FLAG | PGBUF_BCB_MOVE_TO_LRU_BOTTOM_FLAG | PGBUF_BCB_ASYNC_FLUSH_REQ);
+
+#if defined(CUBRID_DEBUG)
+      pgbuf_scramble (&bufptr->iopage_buffer->iopage);
+#endif /* CUBRID_DEBUG */
+
+      (void) pgbuf_invalidate_bcb (thread_p, bufptr);
+      /* bufptr->mutex has been released in above function. */
+    }
+
+  return NO_ERROR;
+}
+
+/*
  * pgbuf_flush () - Flush a page out to disk
  *   return: pgptr on success, NULL on failure
  *   pgptr(in): Page pointer

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -2512,7 +2512,25 @@ fast_path:
     {
       /* this cannot be a new page or a deallocated page.
        * note: temporary pages are not strictly handled in regard with their deallocation status. */
-      assert (fetch_mode != NEW_PAGE || pgbuf_is_lsa_temporary (pgptr));
+      if (fetch_mode == NEW_PAGE && !pgbuf_is_lsa_temporary (pgptr))
+	{
+	  /* a buffered copy with live content was found for a page that is being allocated as new. this can happen
+	   * after a crash: destroying a file discards its buffered pages without logging (see file_destroy), so when
+	   * recovery redo replays the log written before the destroy, it re-materializes those pages in the buffer,
+	   * and nothing replays the discard. the copy is void by definition - the page's sectors were unreserved and
+	   * re-reserved for the new owner, which initializes the page from scratch - so neutralize it the same way a
+	   * freshly claimed frame is initialized instead of handing out the stale content. */
+	  er_log_debug (ARG_FILE_LINE, "pgbuf_fix: neutralize stale buffered copy of new page %d|%d (ptype = %d)\n",
+			VPID_AS_ARGS (vpid), (int) bufptr->iopage_buffer->iopage.prv.ptype);
+	  PGBUF_BCB_LOCK (bufptr);
+	  if (pgbuf_bcb_is_dirty (bufptr))
+	    {
+	      /* the stale content must not reach disk; the new owner logs its own initialization. */
+	      pgbuf_bcb_clear_dirty (thread_p, bufptr);
+	    }
+	  PGBUF_BCB_UNLOCK (bufptr);
+	  fileio_initialize_res (thread_p, &bufptr->iopage_buffer->iopage, IO_PAGESIZE);
+	}
     }
 
   /* Record number of fetches in statistics */

--- a/src/storage/page_buffer.h
+++ b/src/storage/page_buffer.h
@@ -272,6 +272,9 @@ PAGE_PTR pgbuf_simple_fix (THREAD_ENTRY * thread_p, const VPID * vpid, bool need
 void pgbuf_simple_unfix (THREAD_ENTRY * thread_p, PAGE_PTR pgptr);
 int pgbuf_dealloc_temp_page (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, bool need_free);
 
+/* discard buffered pages of destroyed file sectors without flushing or logging */
+extern int pgbuf_discard_pages_of_sectors (THREAD_ENTRY * thread_p, const VSID * vsids, int nsects);
+
 #if !defined(NDEBUG)
 
 #define pgbuf_fix(thread_p, vpid, fetch_mode, requestmode, condition) \

--- a/src/storage/page_buffer.h
+++ b/src/storage/page_buffer.h
@@ -272,8 +272,11 @@ PAGE_PTR pgbuf_simple_fix (THREAD_ENTRY * thread_p, const VPID * vpid, bool need
 void pgbuf_simple_unfix (THREAD_ENTRY * thread_p, PAGE_PTR pgptr);
 int pgbuf_dealloc_temp_page (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, bool need_free);
 
-/* discard buffered pages of destroyed file sectors without flushing or logging */
-extern int pgbuf_discard_pages_of_sectors (THREAD_ENTRY * thread_p, const VSID * vsids, int nsects);
+/* discard the buffered copies of a destroyed file's pages without flushing or logging.
+ * pgbuf_discard_pages_of_sectors scans the buffer pool once (cost: pool size);
+ * pgbuf_discard_page probes one page in the buffer hash (cost per call: O(1); file-size proportional overall). */
+extern void pgbuf_discard_pages_of_sectors (THREAD_ENTRY * thread_p, const VSID * vsids, int nsects);
+extern void pgbuf_discard_page (THREAD_ENTRY * thread_p, const VPID * vpid);
 
 #if !defined(NDEBUG)
 

--- a/src/storage/page_buffer.h
+++ b/src/storage/page_buffer.h
@@ -272,11 +272,9 @@ PAGE_PTR pgbuf_simple_fix (THREAD_ENTRY * thread_p, const VPID * vpid, bool need
 void pgbuf_simple_unfix (THREAD_ENTRY * thread_p, PAGE_PTR pgptr);
 int pgbuf_dealloc_temp_page (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, bool need_free);
 
-/* discard the buffered copies of a destroyed file's pages without flushing or logging.
- * pgbuf_discard_pages_of_sectors scans the buffer pool once (cost: pool size);
- * pgbuf_discard_page probes one page in the buffer hash (cost per call: O(1); file-size proportional overall). */
+/* discard the buffered copies of a destroyed file's pages without flushing or logging (one pass over the buffer
+ * pool; cost is proportional to the pool size) */
 extern void pgbuf_discard_pages_of_sectors (THREAD_ENTRY * thread_p, const VSID * vsids, int nsects);
-extern void pgbuf_discard_page (THREAD_ENTRY * thread_p, const VPID * vpid);
 
 #if !defined(NDEBUG)
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27151>

### Purpose

DROP/TRUNCATE에서 파일 크기에 비례하던 COMMIT 응답 비용을 제거한다.

기존에는 커밋 postpone 단계에서 영속(permanent) 파일을 파괴할 때 파일의 모든 사용자 페이지를 하나씩 fix 하면서 진행했다. 페이지가 버퍼에 없으면 디스크에서 읽어온 뒤 해제하고, 페이지마다 해제 로그(`RVPGBUF_DEALLOC`) 1건을 남긴다. 그 결과 버퍼에 없는(cold) 대용량 테이블을 DROP 하면 "지우기 위해 테이블 전체를 디스크에서 읽는" 동작이 되어 COMMIT 응답이 초 단위까지 지연된다.

실측 — 1GB = CHAR(1000) 100만 행, `async_commit=no`, 클라이언트가 체감하는 COMMIT 응답 시간(3회 중앙값):

| 시나리오 | 개선 전 (page 단위) | 개선 후 (sector 단위) |
|---|---|---|
| DROP 1GB, cold | 1.47 s | **0.002 s** |
| DROP 256MB, cold | 0.43 s | **0.002 s** |
| DROP, warm(버퍼 상주) | 2~7 ms | 2~6 ms |

(측정 장비는 RAM이 커서 OS 페이지 캐시가 "개선 전" cold 수치를 낮추는 방향으로 작용한다. 실제 디스크 환경에서는 개선 폭이 더 크다.)

### Implementation

- `pgbuf_discard_pages_of_sectors()` 신규 추가 (`page_buffer.c`): 파괴 대상 파일의 섹터들에 속한 버퍼 상주 페이지를 버퍼 풀 1-pass로 discard 한다 — dirty 상태 해제, 진행 중인 flush 완료 대기(늦은 쓰기가 재사용된 섹터를 덮지 못하도록), 잔여 힌트 flag(to-vacuum / move-to-lru-bottom / async-flush-request) 정리 후 BCB 무효화. 페이지 read도, 페이지 단위 로깅도 없다.
- `file_destroy()` 영속 분기 (`file_manager.c`): 페이지별 `pgbuf_fix` + `pgbuf_dealloc_page` 루프를 위 discard 호출 1회로 대체하고, 더 이상 사용되지 않는 페이지 단위 해제 콜백 `file_sector_map_dealloc`을 제거했다. 파일 트래커 해제와 섹터 unreserve는 기존 그대로다.

복구(recovery) 의미론이 동일하게 유지되는 이유:
- 파일 전체 파괴의 복구 근거는 파일 트래커 등록 해제와 섹터 예약 해제(`RVDK_UNRESERVE_SECTORS`)가 이미 완결적으로 로깅하고 있으며, 페이지 단위 해제 로그는 이 경우 중복이었다. 해제된 페이지에 다시 접근하는 유일한 경로는 섹터 재사용 후 `NEW_PAGE` 할당인데, 이는 디스크를 읽지 않고 페이지를 재초기화한다.
- 파괴는 기존과 동일하게 `log_sysop_end_logical_run_postpone`으로 끝나는 system operation 안에서 실행되므로 복구 동작도 기존과 같다: 완료된 파괴는 재실행되지 않고(postpone 완료 마킹), postpone 단계 이전에 중단된 파괴는 abort 후(페이지를 수정하지 않으므로 트래커 undo만 필요) 온전한 파일에 재실행되며, 섹터 unreserve postpone 실행 중 중단된 파괴는 roll-forward로 완결된다.

검증: 다음 시나리오 모두에서 `checkdb` 정합을 확인했다 — dirty-discard(적재 직후 DROP), 섹터 재사용(freed 섹터 위에 생성한 테이블의 전체 행 수 무결), TRUNCATE, 재시작, 크래시 복구(커밋 직후 kill -9 / 섹터 unreserve 이전의 파괴 도중 크래시 주입 / 섹터 unreserve postpone 실행 중 크래시 주입 / 크래시를 가로지른 섹터
재사용).

### Remarks

- 일반 DML 중의 단일 페이지 해제(`file_perm_dealloc`)와 임시 파일 파괴 경로는 변경하지 않았다. `RVPGBUF_DEALLOC`과 그 복구 함수들은 해당 경로에서 계속 사용된다.
- discard는 파괴 파일당 버퍼 풀 1회 순회(메모리 작업, 2GB 풀 기준 1ms 미만)이다.
- freed 섹터의 페이지에는 옛 내용이 그대로 남는다(ptype 리셋 없음). `checkdb`는 섹터 비트맵과 트래커 등록 파일만 검사하므로 이를 보지 않으며, 재사용은 `NEW_PAGE`로만 진입하므로(디스크 read 없음) 무해하다.
