### PR TITLE
[CBRD-27166] Back up the log archives outside the log critical section

### DIFF
--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -7354,8 +7354,16 @@ fileio_finish_backup (THREAD_ENTRY * thread_p, FILEIO_BACKUP_SESSION * session_p
   char *msg_area = NULL;
   char io_time_val[CTIME_MAX];
   INT64 end_time;
+  bool make_end_time_strict = false;
 
-  end_time = (INT64) time (NULL);
+  /* The caller stamps this when the log content of the backup is frozen, which is what a point in time restore
+   * has to compare commit timestamps against. Only fall back to "now" if nobody did. */
+  end_time = session_p->bkup.bkuphdr->end_time;
+  if (end_time == -1)
+    {
+      end_time = (INT64) time (NULL);
+      make_end_time_strict = true;
+    }
 
   /*
    * Indicate end of backup and flush any buffered data.
@@ -7473,11 +7481,16 @@ fileio_finish_backup (THREAD_ENTRY * thread_p, FILEIO_BACKUP_SESSION * session_p
    *   accurately separate concurrent transactions.
    * -------------------------------------------------------------------------
    */
-  do
+  if (make_end_time_strict)
     {
-      thread_sleep (1000);
+      /* Only needed when the end time was stamped here. A caller that stamps it does so while transactions are
+       * still held off, and waits there. */
+      do
+	{
+	  thread_sleep (1000);
+	}
+      while (end_time >= time (NULL));
     }
-  while (end_time >= time (NULL));
 
   return session_p;
 }

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -8841,11 +8841,9 @@ fileio_read_backup (THREAD_ENTRY * thread_p, FILEIO_BACKUP_SESSION * session_p, 
   /* Backup Thread is reading data/log pages slowly to avoid IO burst */
   if (session_p->dbfile.volid == LOG_DBLOG_ACTIVE_VOLID || session_p->dbfile.volid == LOG_DBLOG_ARCHIVE_VOLID)
     {
-      /* Log volumes are never paced. The archive arm used to also require LOG_CS_OWN_WRITE_MODE (), which stood
-       * for "the log subsystem is stopped while we copy this, so do not linger". CBRD-27166 moved the archive
-       * transfer out of the log critical section, so that no longer holds there - and pacing archives would only
-       * trade a shorter commit stall for a longer window in which archives cannot be reclaimed. The intent is
-       * stated as "this is a log volume" now, instead of being inferred from who owns the critical section. */
+      /* Log volumes are never paced. The archive arm also required LOG_CS_OWN_WRITE_MODE (), which meant "the log
+       * subsystem is stopped while we copy this". CBRD-27166 moved the archive transfer out of that critical
+       * section, and pacing it there would only stretch the window where archives cannot be removed. */
       ;				/* go ahead */
     }
   else

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -8854,9 +8854,9 @@ fileio_read_backup (THREAD_ENTRY * thread_p, FILEIO_BACKUP_SESSION * session_p, 
   /* Backup Thread is reading data/log pages slowly to avoid IO burst */
   if (session_p->dbfile.volid == LOG_DBLOG_ACTIVE_VOLID || session_p->dbfile.volid == LOG_DBLOG_ARCHIVE_VOLID)
     {
-      /* Log volumes are never paced. The archive arm also required LOG_CS_OWN_WRITE_MODE (), which meant "the log
-       * subsystem is stopped while we copy this". CBRD-27166 moved the archive transfer out of that critical
-       * section, and pacing it there would only stretch the window where archives cannot be removed. */
+      /* Log volumes are never paced. The archive arm also required LOG_CS_OWN_WRITE_MODE (); CBRD-27166 moved the
+       * transfer out of that critical section, and pacing it there would only stretch the window where archives
+       * cannot be removed. */
       ;				/* go ahead */
     }
   else

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -7356,8 +7356,9 @@ fileio_finish_backup (THREAD_ENTRY * thread_p, FILEIO_BACKUP_SESSION * session_p
   INT64 end_time;
   bool make_end_time_strict = false;
 
-  /* The caller stamps this when the log content of the backup is frozen, which is what a point in time restore
-   * has to compare commit timestamps against. Only fall back to "now" if nobody did. */
+  /* logpb_backup () stamps this when the log content of the backup is frozen - the point a restore can actually
+   * reach - and does the strictness wait there, while transactions are still held off. Fall back to "now" only
+   * if nobody stamped it. */
   end_time = session_p->bkup.bkuphdr->end_time;
   if (end_time == -1)
     {
@@ -7483,8 +7484,8 @@ fileio_finish_backup (THREAD_ENTRY * thread_p, FILEIO_BACKUP_SESSION * session_p
    */
   if (make_end_time_strict)
     {
-      /* Only needed when the end time was stamped here. A caller that stamps it does so while transactions are
-       * still held off, and waits there. */
+      /* Only when the end time was stamped here. Waiting after the caller stamped it would guarantee nothing:
+       * transactions are already running again by now. */
       do
 	{
 	  thread_sleep (1000);

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -8839,9 +8839,13 @@ fileio_read_backup (THREAD_ENTRY * thread_p, FILEIO_BACKUP_SESSION * session_p, 
 
 #if defined(SERVER_MODE)
   /* Backup Thread is reading data/log pages slowly to avoid IO burst */
-  if (session_p->dbfile.volid == LOG_DBLOG_ACTIVE_VOLID
-      || (session_p->dbfile.volid == LOG_DBLOG_ARCHIVE_VOLID && LOG_CS_OWN_WRITE_MODE (thread_p)))
+  if (session_p->dbfile.volid == LOG_DBLOG_ACTIVE_VOLID || session_p->dbfile.volid == LOG_DBLOG_ARCHIVE_VOLID)
     {
+      /* Log volumes are never paced. The archive arm used to also require LOG_CS_OWN_WRITE_MODE (), which stood
+       * for "the log subsystem is stopped while we copy this, so do not linger". CBRD-27166 moved the archive
+       * transfer out of the log critical section, so that no longer holds there - and pacing archives would only
+       * trade a shorter commit stall for a longer window in which archives cannot be reclaimed. The intent is
+       * stated as "this is a log volume" now, instead of being inferred from who owns the critical section. */
       ;				/* go ahead */
     }
   else

--- a/src/transaction/log_global.c
+++ b/src/transaction/log_global.c
@@ -63,6 +63,7 @@ log_global::log_global ()
   , rcv_phase_lsa (NULL_LSA)
 #if defined(SERVER_MODE)
   , backup_in_progress (false)
+  , backup_first_arv_num_needed (-1)
 #else // not SERVER_MODE = SA_MODE
   , final_restored_lsa (NULL_LSA)
 #endif // not SERVER_MODE = SA_MODE

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -693,9 +693,8 @@ struct log_global
 
 #if defined(SERVER_MODE)
   bool backup_in_progress;
-  /* First archive the running backup still has to read. Archive removal keeps everything from this number on
-   * until the backup clears it. -1 when no backup is reading archives. Kept in memory on purpose:
-   * a crash must not leave a pin behind that blocks archive removal forever. */
+  /* First archive a running backup still has to read; removal keeps this one and up. -1 when no backup is
+   * reading. In memory only: a crash must not leave a pin behind that blocks archive removal forever. */
   int backup_first_arv_num_needed;
 #else				/* SERVER_MODE */
   LOG_LSA final_restored_lsa;

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -693,6 +693,10 @@ struct log_global
 
 #if defined(SERVER_MODE)
   bool backup_in_progress;
+  /* First archive the running backup still has to read. Archive removal keeps everything from this number on
+   * until the backup clears it. -1 when no backup is reading archives. Kept in memory on purpose:
+   * a crash must not leave a pin behind that blocks archive removal forever. */
+  int backup_first_arv_num_needed;
 #else				/* SERVER_MODE */
   LOG_LSA final_restored_lsa;
 #endif				/* SERVER_MODE */

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -693,8 +693,8 @@ struct log_global
 
 #if defined(SERVER_MODE)
   bool backup_in_progress;
-  /* First archive a running backup still has to read; removal keeps this one and up. -1 when no backup is
-   * reading. In memory only: a crash must not leave a pin behind that blocks archive removal forever. */
+  /* First archive a running backup still needs; -1 when none. In memory only: a crash must not leave
+   * a pin that blocks archive removal forever. */
   int backup_first_arv_num_needed;
 #else				/* SERVER_MODE */
   LOG_LSA final_restored_lsa;

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -6168,9 +6168,9 @@ logpb_remove_archive_logs_exceed_limit (THREAD_ENTRY * thread_p, int max_count)
        * archives. The bound is exclusive here - last_arv_num_to_delete is decremented below. */
       if (log_Gl.backup_first_arv_num_needed >= 0 && last_arv_num_to_delete > log_Gl.backup_first_arv_num_needed)
 	{
-	  log_archive_er_log ("Archive removal capped at %d (was %d): a backup still needs %d and up\n",
-			      log_Gl.backup_first_arv_num_needed - 1, last_arv_num_to_delete - 1,
-			      log_Gl.backup_first_arv_num_needed);
+	  _er_log_debug (ARG_FILE_LINE, "Archive removal capped at %d (was %d): a backup still needs %d and up\n",
+			 log_Gl.backup_first_arv_num_needed - 1, last_arv_num_to_delete - 1,
+			 log_Gl.backup_first_arv_num_needed);
 	  last_arv_num_to_delete = log_Gl.backup_first_arv_num_needed;
 	}
 #endif /* SERVER_MODE */
@@ -6362,9 +6362,8 @@ logpb_remove_archive_logs (THREAD_ENTRY * thread_p, const char *info_reason)
   assert_release (log_Gl.backup_first_arv_num_needed == -1);
   if (log_Gl.backup_first_arv_num_needed >= 0 && last_deleted_arv_num > log_Gl.backup_first_arv_num_needed - 1)
     {
-      log_archive_er_log ("Archive removal capped at %d (was %d): a backup still needs %d and up\n",
-			  log_Gl.backup_first_arv_num_needed - 1, last_deleted_arv_num,
-			  log_Gl.backup_first_arv_num_needed);
+      _er_log_debug (ARG_FILE_LINE, "Archive removal capped at %d (was %d): a backup still needs %d and up\n",
+		     log_Gl.backup_first_arv_num_needed - 1, last_deleted_arv_num, log_Gl.backup_first_arv_num_needed);
       last_deleted_arv_num = log_Gl.backup_first_arv_num_needed - 1;
     }
 #endif /* SERVER_MODE */

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -9083,16 +9083,19 @@ logpb_restore (THREAD_ENTRY * thread_p, const char *db_fullname, const char *log
 
 		      if (to_volid == LOG_DBLOG_ACTIVE_VOLID)
 			{
-			  /* Take back the database lock given up just above. Archives are restored after the active
-			   * log, and a server started in that gap would come up on a half restored log directory. */
+			  /* Hold the database lock on the active log we just put in place. Archives are restored after
+			   * it, and a server started in that gap would come up on a half restored log directory. Best
+			   * effort only: fileio_mount () also reports failure when it merely cannot write the lock
+			   * information file, and losing an advisory lock must not fail a restore that is otherwise
+			   * fine - that is what happened before this lock was taken at all. */
 			  lgat_vdes =
-			    fileio_mount (thread_p, db_fullname, log_Name_active, LOG_DBLOG_ACTIVE_VOLID, true, false);
+			    fileio_mount (thread_p, db_fullname, to_volname, LOG_DBLOG_ACTIVE_VOLID, true, false);
 			  if (lgat_vdes == NULL_VOLDES)
 			    {
-			      success = ER_FAILED;
-			      error_code = ER_FAILED;
-			      LOG_CS_EXIT (thread_p);
-			      goto error;
+			      er_log_debug (ARG_FILE_LINE,
+					    "logpb_restore: could not lock %s; restore continues unlocked\n",
+					    to_volname);
+			      er_clear ();
 			    }
 			}
 		    }
@@ -9210,6 +9213,12 @@ logpb_restore (THREAD_ENTRY * thread_p, const char *db_fullname, const char *log
     }
 
   LOG_CS_EXIT (thread_p);
+
+  if (lgat_vdes != NULL_VOLDES)
+    {
+      fileio_dismount (thread_p, lgat_vdes);
+      lgat_vdes = NULL_VOLDES;
+    }
 
   fileio_page_bitmap_list_destroy (&page_bitmap_list);
 

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -6164,8 +6164,7 @@ logpb_remove_archive_logs_exceed_limit (THREAD_ENTRY * thread_p, int max_count)
 	}
 
 #if defined(SERVER_MODE)
-      /* Live path: the removal daemon and logpb_archive_active_log () both run while a backup is streaming
-       * archives. The bound is exclusive here - last_arv_num_to_delete is decremented below. */
+      /* Keep what a running backup still reads. Bound is exclusive: last_arv_num_to_delete is decremented below. */
       if (log_Gl.backup_first_arv_num_needed >= 0 && last_arv_num_to_delete > log_Gl.backup_first_arv_num_needed)
 	{
 	  _er_log_debug (ARG_FILE_LINE, "Archive removal capped at %d (was %d): a backup still needs %d and up\n",
@@ -6356,9 +6355,8 @@ logpb_remove_archive_logs (THREAD_ENTRY * thread_p, const char *info_reason)
     }
 
 #if defined(SERVER_MODE)
-  /* Defensive. logpb_backup (), the only caller, has no pin left by the time it gets here - that is what the
-   * assert states. The clamp stays because this is the general "remove what is no longer needed" entry point:
-   * a future caller reached during a backup would delete archives it is still reading. Bound is inclusive here. */
+  /* Defensive: the only caller, logpb_backup (), has already dropped the pin. Kept for a future caller that could
+   * reach here during a backup. Bound is inclusive. */
   assert_release (log_Gl.backup_first_arv_num_needed == -1);
   if (log_Gl.backup_first_arv_num_needed >= 0 && last_deleted_arv_num > log_Gl.backup_first_arv_num_needed - 1)
     {
@@ -7836,7 +7834,7 @@ logpb_backup (THREAD_ENTRY * thread_p, int num_perm_vols, const char *allbackup_
   int keys_vdes = NULL_VOLDES;
 #if defined(SERVER_MODE)
   int first_arv_needed = -1;	/* for self contained, consistent */
-  int last_arv_needed = -1;	/* last archive of the set frozen under the log critical section */
+  int last_arv_needed = -1;	/* last archive of the frozen set */
 
   int rv;
   time_t wait_checkpoint_begin_time;
@@ -8358,9 +8356,8 @@ loop:
 
   if (first_arv_needed < log_Gl.hdr.nxarv_num)
     {
-      /* Freeze the archive set and pin it against removal. The archives are transferred below, after the log
-       * critical section is released; they never change once nxarv_num has passed them, so the pin is all they
-       * need. logpb_backup_needed_archive_logs () releases each one as it copies it. */
+      /* Freeze the archive set and pin it against removal. It is transferred after the critical section is
+       * released; an archive never changes once nxarv_num has passed it, so the pin is all it needs. */
       last_arv_needed = log_Gl.hdr.nxarv_num - 1;
       log_Gl.backup_first_arv_num_needed = first_arv_needed;
     }
@@ -8378,10 +8375,8 @@ loop:
     }
 
   /*
-   * Write what is known so far, so a backup that dies from here on still leaves most of its unit names behind.
-   * This is no longer the last word on the file: the archive transfer below can add units, and the write after
-   * the backup completes is the complete one. If any unit is missing from it, restore asks the user for the
-   * subsequent backup unit num.
+   * Write what is known so far, so a backup that dies below still leaves most of its unit names behind. The
+   * write after the transfer is the complete one. If a unit is missing from it, restore asks the user for it.
    */
   error_code = logpb_update_backup_volume_info (log_Name_bkupinfo);
   if (error_code != NO_ERROR)
@@ -8411,9 +8406,8 @@ loop:
       thread_sleep (1000);
     }
 
-  /* The log is captured: the archive set is frozen and pinned, and the active log image goes with it. Everything
-   * below only reads files that cannot change, so release the critical section here and let transactions run
-   * while the archives are transferred. */
+  /* The log is captured and the archive set is pinned. Everything below only reads files that cannot change, so
+   * let transactions run while the archives are transferred. */
   LOG_CS_EXIT (thread_p);
 
   er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_LOG_BACKUP_CS_EXIT, 1, log_Name_active);
@@ -8421,12 +8415,11 @@ loop:
 #if defined(SERVER_MODE)
   if (first_arv_needed >= 0 && first_arv_needed <= last_arv_needed)
     {
-      /* Left ungated on purpose: once per backup, and the only trace of a phase that ER_LOG_BACKUP_CS_ENTER and
-       * ER_LOG_BACKUP_CS_EXIT no longer bracket. The removal clamp messages are gated, they repeat. */
+      /* Once per backup: the only trace of a phase that ER_LOG_BACKUP_CS_ENTER and _EXIT no longer bracket. */
       _er_log_debug (ARG_FILE_LINE, "Backup of log archives %d to %d started outside the log critical section",
 		     first_arv_needed, last_arv_needed);
 
-      /* Clears the pin on the way out; the error path below clears it too if the transfer stopped early. */
+      /* Clears the pin as it goes; the error path clears it too. */
       error_code = logpb_backup_needed_archive_logs (thread_p, &session, first_arv_needed, last_arv_needed);
       if (error_code != NO_ERROR)
 	{
@@ -8453,18 +8446,13 @@ loop:
       goto error;
     }
 
-  /* The backup exists and its volume names are on disk, and this is the last point that can still fail: the error
-   * path from here up would have called fileio_abort_backup (), which destroys every backup volume of this level.
-   * So the header learns about the backup only now, and it is the only place it does. That makes the outcome
-   * atomic with nothing to undo - a backup that fails or is killed anywhere above leaves the previous record
-   * exactly as it was, and a recorded backup is one that exists. Deleting archives, which cannot be undone
-   * either, waits for the same point.
+  /* Past the last point that can destroy the backup: every error path above calls fileio_abort_backup (), which
+   * removes all backup volumes of this level. Recording only here makes the outcome atomic with nothing to undo -
+   * a backup that fails or is killed leaves the previous record untouched. Archive deletion waits for the same
+   * point.
    *
-   * The active log image copied above was taken before this, so it carries whatever record the previous backup
-   * left rather than this one's. A database restored from this backup therefore reports that older backup as its
-   * last one, and an incremental taken on it chains onto that older backup instead of the one it was restored
-   * from. Restoring from a backup and then taking an incremental against it is not a supported flow - take a
-   * full backup on the restored database first. */
+   * The active log image was copied before this, so it carries the previous backup's record. Taking an
+   * incremental on a database restored from this backup is therefore not supported; take a full backup first. */
   LOG_CS_ENTER (thread_p);
   logpb_set_backup_info_in_header (&log_Gl.hdr, backup_level, session.bkup.bkuphdr->start_time, &chkpt_lsa);
   logpb_flush_header (thread_p);
@@ -9105,11 +9093,9 @@ logpb_restore (THREAD_ENTRY * thread_p, const char *db_fullname, const char *log
 
 		      if (to_volid == LOG_DBLOG_ACTIVE_VOLID)
 			{
-			  /* Hold the database lock on the active log we just put in place. Archives are restored after
-			   * it, and a server started in that gap would come up on a half restored log directory. Best
-			   * effort only: fileio_mount () also reports failure when it merely cannot write the lock
-			   * information file, and losing an advisory lock must not fail a restore that is otherwise
-			   * fine - that is what happened before this lock was taken at all. */
+			  /* Re-lock the active log: archives are restored after it, and a server started in that gap
+			   * would come up on a half restored log directory. Best effort - fileio_mount () also fails
+			   * when it merely cannot write the lock information file, which must not fail the restore. */
 			  lgat_vdes =
 			    fileio_mount (thread_p, db_fullname, to_volname, LOG_DBLOG_ACTIVE_VOLID, true, false);
 			  if (lgat_vdes == NULL_VOLDES)
@@ -11041,10 +11027,8 @@ logpb_backup_needed_archive_logs (THREAD_ENTRY * thread_p, FILEIO_BACKUP_SESSION
 	  break;
 	}
 
-      /* Archive i is in the backup, so stop keeping it; after the last one nothing needs keeping. The pin has to
-       * move as we go: the log keeps making archives while we stream to a destination that may be slow, and
-       * holding the whole range would stop removal long enough to fill the log volume - and a full log volume
-       * takes the server down in logpb_archive_active_log (). */
+      /* Archive i is in the backup now. The pin must move as we go: holding the whole range while streaming to a
+       * slow destination stops removal long enough to fill the log volume, which takes the server down. */
       LOG_CS_ENTER (thread_p);
       log_Gl.backup_first_arv_num_needed = (i == last_arv_num) ? -1 : i + 1;
       LOG_CS_EXIT (thread_p);

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -6161,6 +6161,18 @@ logpb_remove_archive_logs_exceed_limit (THREAD_ENTRY * thread_p, int max_count)
 	    }
 	}
 
+#if defined(SERVER_MODE)
+      if (log_Gl.backup_first_arv_num_needed >= 0 && last_arv_num_to_delete > log_Gl.backup_first_arv_num_needed)
+	{
+	  /* A backup still has to read these archives; keep them until it clears the pin. */
+	  _er_log_debug (ARG_FILE_LINE,
+			 "Archive removal capped at %d (was %d): backup still needs archives from %d on",
+			 log_Gl.backup_first_arv_num_needed, last_arv_num_to_delete,
+			 log_Gl.backup_first_arv_num_needed);
+	  last_arv_num_to_delete = log_Gl.backup_first_arv_num_needed;
+	}
+#endif /* SERVER_MODE */
+
       if (max_count > 0)
 	{
 	  /* check max count for deletion */
@@ -6340,6 +6352,16 @@ logpb_remove_archive_logs (THREAD_ENTRY * thread_p, const char *info_reason)
 	    }
 	}
     }
+
+#if defined(SERVER_MODE)
+  if (log_Gl.backup_first_arv_num_needed >= 0 && last_deleted_arv_num > log_Gl.backup_first_arv_num_needed - 1)
+    {
+      /* A backup still has to read these archives; keep them until it clears the pin. */
+      _er_log_debug (ARG_FILE_LINE, "Archive removal capped at %d (was %d): backup still needs archives from %d on",
+		     log_Gl.backup_first_arv_num_needed - 1, last_deleted_arv_num, log_Gl.backup_first_arv_num_needed);
+      last_deleted_arv_num = log_Gl.backup_first_arv_num_needed - 1;
+    }
+#endif /* SERVER_MODE */
 
   if (log_Gl.hdr.last_deleted_arv_num + 1 > last_deleted_arv_num)
     {
@@ -8284,7 +8306,14 @@ loop:
 
   if (first_arv_needed < log_Gl.hdr.nxarv_num)
     {
+      /* Keep the archives this backup is about to read out of reach of archive removal. Under the log critical
+       * section nothing can remove them anyway, but the pin is what will hold once the transfer runs outside it. */
+      log_Gl.backup_first_arv_num_needed = first_arv_needed;
+
       error_code = logpb_backup_needed_archive_logs (thread_p, &session, first_arv_needed, log_Gl.hdr.nxarv_num - 1);
+
+      log_Gl.backup_first_arv_num_needed = -1;
+
       if (error_code != NO_ERROR)
 	{
 	  LOG_CS_EXIT (thread_p);
@@ -8420,6 +8449,7 @@ loop:
   LOG_CS_ENTER (thread_p);
   log_Gl.run_nxchkpt_atpageid = saved_run_nxchkpt_atpageid;
   log_Gl.backup_in_progress = false;
+  log_Gl.backup_first_arv_num_needed = -1;
   LOG_CS_EXIT (thread_p);
 #endif /* SERVER_MODE */
 
@@ -8452,6 +8482,7 @@ error:
       log_Gl.run_nxchkpt_atpageid = saved_run_nxchkpt_atpageid;
     }
   log_Gl.backup_in_progress = false;
+  log_Gl.backup_first_arv_num_needed = -1;
   LOG_CS_EXIT (thread_p);
 #endif /* SERVER_MODE */
 

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -8308,6 +8308,7 @@ loop:
 
   /* Flush before selecting archive logs. This may create a new archive and advance nxarv_num. */
   logpb_flush_pages_direct (thread_p);
+  logpb_flush_header (thread_p);
 
 #if defined(SERVER_MODE)
   /*
@@ -8389,11 +8390,6 @@ loop:
       er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_LOG_BACKUP_CS_EXIT, 1, log_Name_active);
       goto error;
     }
-
-  /* Get the header on disk in step with the log pages flushed above, so the active log image copied below is
-   * self consistent. This backup is not recorded in it: a backup is recorded only once it exists, which is after
-   * the archives have been transferred. */
-  logpb_flush_header (thread_p);
 
   /* Include active log always. Skipping log active is obsolete. */
   error_code = fileio_backup_volume (thread_p, &session, log_Name_active, LOG_DBLOG_ACTIVE_VOLID, -1, false);

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -8398,6 +8398,17 @@ loop:
       goto error;
     }
 
+  /* The log content of this backup is frozen at this instant, so this is its end time - not the moment the
+   * archive transfer happens to finish. restoredb -d backuptime stops at this timestamp, so a transaction that
+   * commits later has to carry a strictly later one, or the restore would ask for log the backup does not have.
+   * The wait is what makes "later" strict at second resolution, and it has to happen here, while nothing can
+   * commit yet. */
+  session.bkup.bkuphdr->end_time = (INT64) time (NULL);
+  while (session.bkup.bkuphdr->end_time >= time (NULL))
+    {
+      thread_sleep (1000);
+    }
+
   /* The log is captured: the archive set is frozen and pinned, and the active log image carries the header that
    * names it. Everything below only reads files that cannot change, so release the critical section here and let
    * transactions run while the archives are transferred. */

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -9099,6 +9099,24 @@ logpb_restore (THREAD_ENTRY * thread_p, const char *db_fullname, const char *log
 			}
 
 		      os_rename_file (tmp_logfiles_from_backup, to_volname);
+
+		      if (to_volid == LOG_DBLOG_ACTIVE_VOLID)
+			{
+			  /* The mount at the top of this function is what keeps anything else from opening the database
+			   * while it is being restored, and it had to be given up to replace the file it was holding.
+			   * Take it again on the restored active log: volumes are still being extracted below - archives
+			   * now come after the active log in the backup stream - and a server started in that gap would
+			   * come up on a log directory that is only half restored. */
+			  lgat_vdes =
+			    fileio_mount (thread_p, db_fullname, log_Name_active, LOG_DBLOG_ACTIVE_VOLID, true, false);
+			  if (lgat_vdes == NULL_VOLDES)
+			    {
+			      success = ER_FAILED;
+			      error_code = ER_FAILED;
+			      LOG_CS_EXIT (thread_p);
+			      goto error;
+			    }
+			}
 		    }
 		  else
 		    {

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -6162,18 +6162,13 @@ logpb_remove_archive_logs_exceed_limit (THREAD_ENTRY * thread_p, int max_count)
 	}
 
 #if defined(SERVER_MODE)
-      /* Live path: this runs from the archive removal daemon and inline from logpb_archive_active_log (), both of
-       * which can be reached while logpb_backup () is streaming archives outside the log critical section. The
-       * bound below is exclusive - last_arv_num_to_delete is decremented further down - so the archive the backup
-       * is currently reading survives. */
+      /* Live path: the removal daemon and logpb_archive_active_log () both run while a backup is streaming
+       * archives. The bound is exclusive here - last_arv_num_to_delete is decremented below. */
       if (log_Gl.backup_first_arv_num_needed >= 0 && last_arv_num_to_delete > log_Gl.backup_first_arv_num_needed)
 	{
-	  if (prm_get_bool_value (PRM_ID_DEBUG_LOG_ARCHIVES))
-	    {
-	      _er_log_debug (ARG_FILE_LINE, "Archive removal capped at %d (was %d): a backup still needs %d and up",
-			     log_Gl.backup_first_arv_num_needed - 1, last_arv_num_to_delete - 1,
-			     log_Gl.backup_first_arv_num_needed);
-	    }
+	  log_archive_er_log ("Archive removal capped at %d (was %d): a backup still needs %d and up\n",
+			      log_Gl.backup_first_arv_num_needed - 1, last_arv_num_to_delete - 1,
+			      log_Gl.backup_first_arv_num_needed);
 	  last_arv_num_to_delete = log_Gl.backup_first_arv_num_needed;
 	}
 #endif /* SERVER_MODE */
@@ -6359,21 +6354,15 @@ logpb_remove_archive_logs (THREAD_ENTRY * thread_p, const char *info_reason)
     }
 
 #if defined(SERVER_MODE)
-  /* Defensive only. The single caller today is logpb_backup (), which clears the pin as soon as the last archive
-   * is in the backup and before it gets here, so the assert states that invariant and the clamp never fires.
-   * The clamp is kept because this is the general "remove everything no longer needed" entry point: a future
-   * caller reached while a backup is still streaming archives would otherwise delete them under it. If the
-   * assert ever fires, that new caller is the thing to look at - not this clamp. The bound is inclusive here,
-   * unlike logpb_remove_archive_logs_exceed_limit (), which decrements afterwards. */
+  /* Defensive. logpb_backup (), the only caller, has no pin left by the time it gets here - that is what the
+   * assert states. The clamp stays because this is the general "remove what is no longer needed" entry point:
+   * a future caller reached during a backup would delete archives it is still reading. Bound is inclusive here. */
   assert (log_Gl.backup_first_arv_num_needed == -1);
   if (log_Gl.backup_first_arv_num_needed >= 0 && last_deleted_arv_num > log_Gl.backup_first_arv_num_needed - 1)
     {
-      if (prm_get_bool_value (PRM_ID_DEBUG_LOG_ARCHIVES))
-	{
-	  _er_log_debug (ARG_FILE_LINE, "Archive removal capped at %d (was %d): a backup still needs %d and up",
-			 log_Gl.backup_first_arv_num_needed - 1, last_deleted_arv_num,
-			 log_Gl.backup_first_arv_num_needed);
-	}
+      log_archive_er_log ("Archive removal capped at %d (was %d): a backup still needs %d and up\n",
+			  log_Gl.backup_first_arv_num_needed - 1, last_deleted_arv_num,
+			  log_Gl.backup_first_arv_num_needed);
       last_deleted_arv_num = log_Gl.backup_first_arv_num_needed - 1;
     }
 #endif /* SERVER_MODE */
@@ -7790,8 +7779,7 @@ logpb_backup (THREAD_ENTRY * thread_p, int num_perm_vols, const char *allbackup_
   const char *bk_vol;		/* ptr to old bkup volume name */
   int unit_num;
   FILEIO_BACKUP_RECORD_INFO all_bkup_info[FILEIO_BACKUP_UNDEFINED_LEVEL];
-  /* Log header backup bookkeeping as it was before this backup touched it, so that a backup which fails
-   * after the header has been flushed does not leave the header advertising a backup that was removed. */
+  /* Header backup bookkeeping as it was before this backup, to put back if the backup fails. */
   LOG_HDR_BKUP_LEVEL_INFO saved_bkinfo[FILEIO_BACKUP_UNDEFINED_LEVEL];
   LOG_LSA saved_bkup_level_lsa[FILEIO_BACKUP_UNDEFINED_LEVEL];
   bool bkup_hdr_info_saved = false;
@@ -8327,10 +8315,9 @@ loop:
 
   if (first_arv_needed < log_Gl.hdr.nxarv_num)
     {
-      /* Freeze the archive set here and pin it against archive removal. The archives themselves are transferred
-       * further below, after the log critical section has been released: they are complete and never written again
-       * once nxarv_num moved past them, and the pin is what keeps them on disk until then. The pin does not stay
-       * on the whole range - logpb_backup_needed_archive_logs () advances it as each archive lands in the backup. */
+      /* Freeze the archive set and pin it against removal. The archives are transferred below, after the log
+       * critical section is released; they never change once nxarv_num has passed them, so the pin is all they
+       * need. logpb_backup_needed_archive_logs () releases each one as it copies it. */
       last_arv_needed = log_Gl.hdr.nxarv_num - 1;
       log_Gl.backup_first_arv_num_needed = first_arv_needed;
     }
@@ -8363,9 +8350,8 @@ loop:
       goto error;
     }
 
-  /* Remember what the header said before this backup overwrites it. From here on the header no longer describes
-   * a backup that exists on the destination: the record becomes true only when this backup completes, and the
-   * archives are transferred after the header is flushed below. */
+  /* Remember what the header said. From here it describes this backup, which is not on the destination yet -
+   * the archives are transferred after the header is flushed below. */
   memcpy (saved_bkinfo, log_Gl.hdr.bkinfo, sizeof (saved_bkinfo));
   LSA_COPY (&saved_bkup_level_lsa[FILEIO_BACKUP_FULL_LEVEL], &log_Gl.hdr.bkup_level0_lsa);
   LSA_COPY (&saved_bkup_level_lsa[FILEIO_BACKUP_BIG_INCREMENT_LEVEL], &log_Gl.hdr.bkup_level1_lsa);
@@ -8412,9 +8398,9 @@ loop:
       goto error;
     }
 
-  /* The log is captured: the archive set is frozen and pinned, and the active log image was taken with the log
-   * header that names it. Everything below only reads files that cannot change any more, so the log critical
-   * section is released here and user transactions resume while the archives are still being transferred. */
+  /* The log is captured: the archive set is frozen and pinned, and the active log image carries the header that
+   * names it. Everything below only reads files that cannot change, so release the critical section here and let
+   * transactions run while the archives are transferred. */
   LOG_CS_EXIT (thread_p);
 
   er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_LOG_BACKUP_CS_EXIT, 1, log_Name_active);
@@ -8425,12 +8411,8 @@ loop:
       _er_log_debug (ARG_FILE_LINE, "Backup of log archives %d to %d started outside the log critical section",
 		     first_arv_needed, last_arv_needed);
 
+      /* Clears the pin on the way out; the error path below clears it too if the transfer stopped early. */
       error_code = logpb_backup_needed_archive_logs (thread_p, &session, first_arv_needed, last_arv_needed);
-
-      LOG_CS_ENTER (thread_p);
-      log_Gl.backup_first_arv_num_needed = -1;
-      LOG_CS_EXIT (thread_p);
-
       if (error_code != NO_ERROR)
 	{
 	  goto error;
@@ -8531,9 +8513,8 @@ error:
   log_Gl.backup_first_arv_num_needed = -1;
   if (bkup_hdr_info_saved)
     {
-      /* fileio_abort_backup () above removed what this backup had written, so the header must stop claiming it.
-       * Leaving the claim behind would let the next incremental backup pass the "lower level exists" gate and
-       * build on a backup that is gone - a gap that only shows up at restore time. */
+      /* The partial backup was removed above, so the header must stop claiming it. Otherwise the next
+       * incremental backup builds on a backup that is gone, and only the restore finds out. */
       memcpy (log_Gl.hdr.bkinfo, saved_bkinfo, sizeof (saved_bkinfo));
       LSA_COPY (&log_Gl.hdr.bkup_level0_lsa, &saved_bkup_level_lsa[FILEIO_BACKUP_FULL_LEVEL]);
       LSA_COPY (&log_Gl.hdr.bkup_level1_lsa, &saved_bkup_level_lsa[FILEIO_BACKUP_BIG_INCREMENT_LEVEL]);
@@ -9102,11 +9083,8 @@ logpb_restore (THREAD_ENTRY * thread_p, const char *db_fullname, const char *log
 
 		      if (to_volid == LOG_DBLOG_ACTIVE_VOLID)
 			{
-			  /* The mount at the top of this function is what keeps anything else from opening the database
-			   * while it is being restored, and it had to be given up to replace the file it was holding.
-			   * Take it again on the restored active log: volumes are still being extracted below - archives
-			   * now come after the active log in the backup stream - and a server started in that gap would
-			   * come up on a log directory that is only half restored. */
+			  /* Take back the database lock given up just above. Archives are restored after the active
+			   * log, and a server started in that gap would come up on a half restored log directory. */
 			  lgat_vdes =
 			    fileio_mount (thread_p, db_fullname, log_Name_active, LOG_DBLOG_ACTIVE_VOLID, true, false);
 			  if (lgat_vdes == NULL_VOLDES)
@@ -11032,14 +11010,12 @@ logpb_backup_needed_archive_logs (THREAD_ENTRY * thread_p, FILEIO_BACKUP_SESSION
 	  break;
 	}
 
-      /* Archive i is in the backup now, so release it and pin only what is left. The pin has to move as the
-       * transfer goes: the log keeps producing archives while we stream to a destination that may be slow, and
-       * holding the whole range for the whole transfer would stop archive removal long enough to fill the log
-       * volume - which ends in logpb_archive_active_log () failing to create an archive and taking the server
-       * down. Moving it per archive costs one short critical section per archive and leaves log_max_archives
-       * exceeded by at most the one archive still being read. */
+      /* Archive i is in the backup, so stop keeping it; after the last one nothing needs keeping. The pin has to
+       * move as we go: the log keeps making archives while we stream to a destination that may be slow, and
+       * holding the whole range would stop removal long enough to fill the log volume - and a full log volume
+       * takes the server down in logpb_archive_active_log (). */
       LOG_CS_ENTER (thread_p);
-      log_Gl.backup_first_arv_num_needed = i + 1;
+      log_Gl.backup_first_arv_num_needed = (i == last_arv_num) ? -1 : i + 1;
       LOG_CS_EXIT (thread_p);
     }
 

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -8395,11 +8395,22 @@ loop:
       goto error;
     }
 
-  /* The log content of this backup is frozen at this instant, so this is its end time - not the moment the
-   * archive transfer happens to finish. restoredb -d backuptime stops at this timestamp, so a transaction that
-   * commits later has to carry a strictly later one, or the restore would ask for log the backup does not have.
-   * The wait is what makes "later" strict at second resolution, and it has to happen here, while nothing can
-   * commit yet. */
+  /* Stamp the end time here, right after the active log image has been taken.
+   *
+   * |--------------- LOG_CS ----------------|
+   * flush > pin archives > copy active log  |  archive transfer  |  backup done
+   *                                     (1)                  (2)
+   *
+   * (1) is where the log content of the backup is frozen. (2) is where the transfer ends.
+   *
+   * end_time has one reader: restoredb -d backuptime recovers up to it. This backup can restore up to (1), so
+   * end_time has to be (1). Stamping it at (2), where fileio_finish_backup () used to, would name a time this
+   * backup cannot reach - transactions commit and are acknowledged during the transfer, but their log is not in
+   * the backup, so the restore would stop at (1) and report nothing.
+   *
+   * The wait below makes the boundary strict. Recovery replays a commit whose time equals end_time, and
+   * end_time is in seconds, so the second has to tick before anyone can commit again. That is why the wait is
+   * here, inside the critical section where nothing can commit, and no longer in fileio_finish_backup (). */
   session.bkup.bkuphdr->end_time = (INT64) time (NULL);
   while (session.bkup.bkuphdr->end_time >= time (NULL))
     {

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -322,6 +322,11 @@ static int logpb_copy_volume (THREAD_ENTRY * thread_p, VOLID from_volid, const c
 			      LOG_LSA * vol_chkpt_lsa);
 static bool logpb_check_if_exists (const char *fname, char *first_vol);
 #if defined(SERVER_MODE)
+static void logpb_set_backup_info_in_header (LOG_HEADER * log_hdr, FILEIO_BACKUP_LEVEL backup_level,
+					     INT64 bkup_attime, const LOG_LSA * chkpt_lsa);
+static void logpb_restore_backup_info_in_header (LOG_HEADER * log_hdr,
+						 const LOG_HDR_BKUP_LEVEL_INFO * saved_bkinfo,
+						 const LOG_LSA * saved_bkup_level_lsa);
 static int logpb_backup_needed_archive_logs (THREAD_ENTRY * thread_p, FILEIO_BACKUP_SESSION * session,
 					     int first_arv_num, int last_arv_num);
 #endif /* SERVER_MODE */
@@ -6357,7 +6362,7 @@ logpb_remove_archive_logs (THREAD_ENTRY * thread_p, const char *info_reason)
   /* Defensive. logpb_backup (), the only caller, has no pin left by the time it gets here - that is what the
    * assert states. The clamp stays because this is the general "remove what is no longer needed" entry point:
    * a future caller reached during a backup would delete archives it is still reading. Bound is inclusive here. */
-  assert (log_Gl.backup_first_arv_num_needed == -1);
+  assert_release (log_Gl.backup_first_arv_num_needed == -1);
   if (log_Gl.backup_first_arv_num_needed >= 0 && last_deleted_arv_num > log_Gl.backup_first_arv_num_needed - 1)
     {
       log_archive_er_log ("Archive removal capped at %d (was %d): a backup still needs %d and up\n",
@@ -7730,6 +7735,70 @@ logpb_backup_ensure_fresh_checkpoint (THREAD_ENTRY * thread_p, FILEIO_BACKUP_SES
 #endif /* SERVER_MODE */
 
 /*
+ * logpb_set_backup_info_in_header - Record a backup in the log header
+ *
+ * return: nothing
+ *
+ *   log_hdr(in/out): log header to record into
+ *   backup_level(in): level of the backup being recorded
+ *   bkup_attime(in): time the backup started
+ *   chkpt_lsa(in): checkpoint the backup starts from
+ *
+ * NOTE: A backup of one level invalidates the levels above it, so those are cleared here as well.
+ */
+static void
+logpb_set_backup_info_in_header (LOG_HEADER * log_hdr, FILEIO_BACKUP_LEVEL backup_level, INT64 bkup_attime,
+				 const LOG_LSA * chkpt_lsa)
+{
+  /* Clear log header information regarding previous backups */
+  logpb_initialize_backup_info (log_hdr);
+
+  /* Save additional info and metrics from this backup */
+  log_hdr->bkinfo[backup_level].bkup_attime = bkup_attime;
+
+  switch (backup_level)
+    {
+    case FILEIO_BACKUP_FULL_LEVEL:
+    default:
+      LSA_COPY (&log_hdr->bkup_level0_lsa, chkpt_lsa);
+      LSA_SET_NULL (&log_hdr->bkup_level1_lsa);
+      LSA_SET_NULL (&log_hdr->bkup_level2_lsa);
+      log_hdr->bkinfo[FILEIO_BACKUP_BIG_INCREMENT_LEVEL].bkup_attime = 0;
+      log_hdr->bkinfo[FILEIO_BACKUP_SMALL_INCREMENT_LEVEL].bkup_attime = 0;
+      break;
+
+    case FILEIO_BACKUP_BIG_INCREMENT_LEVEL:
+      LSA_COPY (&log_hdr->bkup_level1_lsa, chkpt_lsa);
+      LSA_SET_NULL (&log_hdr->bkup_level2_lsa);
+      log_hdr->bkinfo[FILEIO_BACKUP_SMALL_INCREMENT_LEVEL].bkup_attime = 0;
+      break;
+
+    case FILEIO_BACKUP_SMALL_INCREMENT_LEVEL:
+      LSA_COPY (&log_hdr->bkup_level2_lsa, chkpt_lsa);
+      break;
+    }
+}
+
+/*
+ * logpb_restore_backup_info_in_header - Put previously saved backup bookkeeping back into the log header
+ *
+ * return: nothing
+ *
+ *   log_hdr(in/out): log header to restore into
+ *   saved_bkinfo(in): bkinfo array as it was before this backup touched it
+ *   saved_bkup_level_lsa(in): the three backup level LSAs as they were
+ */
+static void
+logpb_restore_backup_info_in_header (LOG_HEADER * log_hdr, const LOG_HDR_BKUP_LEVEL_INFO * saved_bkinfo,
+				     const LOG_LSA * saved_bkup_level_lsa)
+{
+  memcpy (log_hdr->bkinfo, saved_bkinfo, sizeof (log_hdr->bkinfo));
+  LSA_COPY (&log_hdr->bkup_level0_lsa, &saved_bkup_level_lsa[FILEIO_BACKUP_FULL_LEVEL]);
+  LSA_COPY (&log_hdr->bkup_level1_lsa, &saved_bkup_level_lsa[FILEIO_BACKUP_BIG_INCREMENT_LEVEL]);
+  LSA_COPY (&log_hdr->bkup_level2_lsa, &saved_bkup_level_lsa[FILEIO_BACKUP_SMALL_INCREMENT_LEVEL]);
+}
+
+/*
  * logpb_backup - Execute a level backup for the given database volume
  *
  * return: NO_ERROR if all OK, ER status otherwise
@@ -7779,10 +7848,9 @@ logpb_backup (THREAD_ENTRY * thread_p, int num_perm_vols, const char *allbackup_
   const char *bk_vol;		/* ptr to old bkup volume name */
   int unit_num;
   FILEIO_BACKUP_RECORD_INFO all_bkup_info[FILEIO_BACKUP_UNDEFINED_LEVEL];
-  /* Header backup bookkeeping as it was before this backup, to put back if the backup fails. */
+  /* Header backup bookkeeping as it was before this backup, put back while the backup is still in flight. */
   LOG_HDR_BKUP_LEVEL_INFO saved_bkinfo[FILEIO_BACKUP_UNDEFINED_LEVEL];
   LOG_LSA saved_bkup_level_lsa[FILEIO_BACKUP_UNDEFINED_LEVEL];
-  bool bkup_hdr_info_saved = false;
   bool beenwarned;
   bool isincremental = false;	/* Assume full backups */
   bool bkup_in_progress = false;
@@ -8335,11 +8403,9 @@ loop:
     }
 
   /*
-   * We must store the final bkvinf file at the very end of the backup
-   * to have the best chance of having all of the information in it.
-   * Note: that there is a window that the last bkvinf entry still not being
-   * there if a new backup volume is needed while writing this volume.
-   * However, in this case, then restore will ask the user for the
+   * Write what is known so far, so a backup that dies from here on still leaves most of its unit names behind.
+   * This is no longer the last word on the file: the archive transfer below can add units, and the write after
+   * the backup completes is the complete one. If any unit is missing from it, restore asks the user for the
    * subsequent backup unit num.
    */
   error_code = logpb_update_backup_volume_info (log_Name_bkupinfo);
@@ -8350,43 +8416,14 @@ loop:
       goto error;
     }
 
-  /* Remember what the header said. From here it describes this backup, which is not on the destination yet -
-   * the archives are transferred after the header is flushed below. */
+  /* Remember what the header said, to put back before the critical section is released. */
   memcpy (saved_bkinfo, log_Gl.hdr.bkinfo, sizeof (saved_bkinfo));
   LSA_COPY (&saved_bkup_level_lsa[FILEIO_BACKUP_FULL_LEVEL], &log_Gl.hdr.bkup_level0_lsa);
   LSA_COPY (&saved_bkup_level_lsa[FILEIO_BACKUP_BIG_INCREMENT_LEVEL], &log_Gl.hdr.bkup_level1_lsa);
   LSA_COPY (&saved_bkup_level_lsa[FILEIO_BACKUP_SMALL_INCREMENT_LEVEL], &log_Gl.hdr.bkup_level2_lsa);
-  bkup_hdr_info_saved = true;
 
-  /* Clear log header information regarding previous backups */
-  logpb_initialize_backup_info (&log_Gl.hdr);
-
-  /* Save additional info and metrics from this backup */
-  log_Gl.hdr.bkinfo[backup_level].bkup_attime = session.bkup.bkuphdr->start_time;
-
-  switch (backup_level)
-    {
-    case FILEIO_BACKUP_FULL_LEVEL:
-    default:
-      LSA_COPY (&log_Gl.hdr.bkup_level0_lsa, &chkpt_lsa);
-      LSA_SET_NULL (&log_Gl.hdr.bkup_level1_lsa);
-      LSA_SET_NULL (&log_Gl.hdr.bkup_level2_lsa);
-      log_Gl.hdr.bkinfo[FILEIO_BACKUP_BIG_INCREMENT_LEVEL].bkup_attime = 0;
-      log_Gl.hdr.bkinfo[FILEIO_BACKUP_SMALL_INCREMENT_LEVEL].bkup_attime = 0;
-      break;
-
-    case FILEIO_BACKUP_BIG_INCREMENT_LEVEL:
-      LSA_COPY (&log_Gl.hdr.bkup_level1_lsa, &chkpt_lsa);
-      LSA_SET_NULL (&log_Gl.hdr.bkup_level2_lsa);
-      log_Gl.hdr.bkinfo[FILEIO_BACKUP_SMALL_INCREMENT_LEVEL].bkup_attime = 0;
-      break;
-
-    case FILEIO_BACKUP_SMALL_INCREMENT_LEVEL:
-      LSA_COPY (&log_Gl.hdr.bkup_level2_lsa, &chkpt_lsa);
-      break;
-    }
-
-  /* Now indicate how many volumes were backed up */
+  /* Put this backup in the header so the active log image copied below carries it. */
+  logpb_set_backup_info_in_header (&log_Gl.hdr, backup_level, session.bkup.bkuphdr->start_time, &chkpt_lsa);
   logpb_flush_header (thread_p);
 
   /* Include active log always. Skipping log active is obsolete. */
@@ -8409,6 +8446,12 @@ loop:
       thread_sleep (1000);
     }
 
+  /* The image in the backup keeps the record; the live header must not. From here the backup can still fail or
+   * the server can be killed, and neither leaves anything able to undo a durable claim. The record goes back in
+   * only once the backup is complete, below. */
+  logpb_restore_backup_info_in_header (&log_Gl.hdr, saved_bkinfo, saved_bkup_level_lsa);
+  logpb_flush_header (thread_p);
+
   /* The log is captured: the archive set is frozen and pinned, and the active log image carries the header that
    * names it. Everything below only reads files that cannot change, so release the critical section here and let
    * transactions run while the archives are transferred. */
@@ -8419,6 +8462,8 @@ loop:
 #if defined(SERVER_MODE)
   if (first_arv_needed >= 0 && first_arv_needed <= last_arv_needed)
     {
+      /* Left ungated on purpose: once per backup, and the only trace of a phase that ER_LOG_BACKUP_CS_ENTER and
+       * ER_LOG_BACKUP_CS_EXIT no longer bracket. The removal clamp messages are gated, they repeat. */
       _er_log_debug (ARG_FILE_LINE, "Backup of log archives %d to %d started outside the log critical section",
 		     first_arv_needed, last_arv_needed);
 
@@ -8442,6 +8487,13 @@ loop:
 #if defined(SERVER_MODE)
   logpb_destroy_backup_read_worker_pool ();
 #endif
+
+  /* The backup exists now, so record it. Doing it here rather than before the transfer is what keeps a failed or
+   * killed backup from leaving the header pointing at something that is not there. */
+  LOG_CS_ENTER (thread_p);
+  logpb_set_backup_info_in_header (&log_Gl.hdr, backup_level, session.bkup.bkuphdr->start_time, &chkpt_lsa);
+  logpb_flush_header (thread_p);
+  LOG_CS_EXIT (thread_p);
 
   if (delete_unneeded_logarchives != false)
     {
@@ -8522,16 +8574,6 @@ error:
     }
   log_Gl.backup_in_progress = false;
   log_Gl.backup_first_arv_num_needed = -1;
-  if (bkup_hdr_info_saved)
-    {
-      /* The partial backup was removed above, so the header must stop claiming it. Otherwise the next
-       * incremental backup builds on a backup that is gone, and only the restore finds out. */
-      memcpy (log_Gl.hdr.bkinfo, saved_bkinfo, sizeof (saved_bkinfo));
-      LSA_COPY (&log_Gl.hdr.bkup_level0_lsa, &saved_bkup_level_lsa[FILEIO_BACKUP_FULL_LEVEL]);
-      LSA_COPY (&log_Gl.hdr.bkup_level1_lsa, &saved_bkup_level_lsa[FILEIO_BACKUP_BIG_INCREMENT_LEVEL]);
-      LSA_COPY (&log_Gl.hdr.bkup_level2_lsa, &saved_bkup_level_lsa[FILEIO_BACKUP_SMALL_INCREMENT_LEVEL]);
-      logpb_flush_header (thread_p);
-    }
   LOG_CS_EXIT (thread_p);
 #endif /* SERVER_MODE */
 

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -6162,13 +6162,18 @@ logpb_remove_archive_logs_exceed_limit (THREAD_ENTRY * thread_p, int max_count)
 	}
 
 #if defined(SERVER_MODE)
+      /* Live path: this runs from the archive removal daemon and inline from logpb_archive_active_log (), both of
+       * which can be reached while logpb_backup () is streaming archives outside the log critical section. The
+       * bound below is exclusive - last_arv_num_to_delete is decremented further down - so the archive the backup
+       * is currently reading survives. */
       if (log_Gl.backup_first_arv_num_needed >= 0 && last_arv_num_to_delete > log_Gl.backup_first_arv_num_needed)
 	{
-	  /* A backup still has to read these archives; keep them until it clears the pin. */
-	  _er_log_debug (ARG_FILE_LINE,
-			 "Archive removal capped at %d (was %d): backup still needs archives from %d on",
-			 log_Gl.backup_first_arv_num_needed, last_arv_num_to_delete,
-			 log_Gl.backup_first_arv_num_needed);
+	  if (prm_get_bool_value (PRM_ID_DEBUG_LOG_ARCHIVES))
+	    {
+	      _er_log_debug (ARG_FILE_LINE, "Archive removal capped at %d (was %d): a backup still needs %d and up",
+			     log_Gl.backup_first_arv_num_needed - 1, last_arv_num_to_delete - 1,
+			     log_Gl.backup_first_arv_num_needed);
+	    }
 	  last_arv_num_to_delete = log_Gl.backup_first_arv_num_needed;
 	}
 #endif /* SERVER_MODE */
@@ -6354,11 +6359,21 @@ logpb_remove_archive_logs (THREAD_ENTRY * thread_p, const char *info_reason)
     }
 
 #if defined(SERVER_MODE)
+  /* Defensive only. The single caller today is logpb_backup (), which clears the pin as soon as the last archive
+   * is in the backup and before it gets here, so the assert states that invariant and the clamp never fires.
+   * The clamp is kept because this is the general "remove everything no longer needed" entry point: a future
+   * caller reached while a backup is still streaming archives would otherwise delete them under it. If the
+   * assert ever fires, that new caller is the thing to look at - not this clamp. The bound is inclusive here,
+   * unlike logpb_remove_archive_logs_exceed_limit (), which decrements afterwards. */
+  assert (log_Gl.backup_first_arv_num_needed == -1);
   if (log_Gl.backup_first_arv_num_needed >= 0 && last_deleted_arv_num > log_Gl.backup_first_arv_num_needed - 1)
     {
-      /* A backup still has to read these archives; keep them until it clears the pin. */
-      _er_log_debug (ARG_FILE_LINE, "Archive removal capped at %d (was %d): backup still needs archives from %d on",
-		     log_Gl.backup_first_arv_num_needed - 1, last_deleted_arv_num, log_Gl.backup_first_arv_num_needed);
+      if (prm_get_bool_value (PRM_ID_DEBUG_LOG_ARCHIVES))
+	{
+	  _er_log_debug (ARG_FILE_LINE, "Archive removal capped at %d (was %d): a backup still needs %d and up",
+			 log_Gl.backup_first_arv_num_needed - 1, last_deleted_arv_num,
+			 log_Gl.backup_first_arv_num_needed);
+	}
       last_deleted_arv_num = log_Gl.backup_first_arv_num_needed - 1;
     }
 #endif /* SERVER_MODE */
@@ -8312,9 +8327,10 @@ loop:
 
   if (first_arv_needed < log_Gl.hdr.nxarv_num)
     {
-      /* Freeze the archive set here and keep it out of reach of archive removal. The archives themselves are
-       * transferred further below, after the log critical section has been released: they are complete and never
-       * written again once nxarv_num moved past them, and the pin is what keeps them on disk until then. */
+      /* Freeze the archive set here and pin it against archive removal. The archives themselves are transferred
+       * further below, after the log critical section has been released: they are complete and never written again
+       * once nxarv_num moved past them, and the pin is what keeps them on disk until then. The pin does not stay
+       * on the whole range - logpb_backup_needed_archive_logs () advances it as each archive lands in the backup. */
       last_arv_needed = log_Gl.hdr.nxarv_num - 1;
       log_Gl.backup_first_arv_num_needed = first_arv_needed;
     }
@@ -10997,6 +11013,16 @@ logpb_backup_needed_archive_logs (THREAD_ENTRY * thread_p, FILEIO_BACKUP_SESSION
 	{
 	  break;
 	}
+
+      /* Archive i is in the backup now, so release it and pin only what is left. The pin has to move as the
+       * transfer goes: the log keeps producing archives while we stream to a destination that may be slow, and
+       * holding the whole range for the whole transfer would stop archive removal long enough to fill the log
+       * volume - which ends in logpb_archive_active_log () failing to create an archive and taking the server
+       * down. Moving it per archive costs one short critical section per archive and leaves log_max_archives
+       * exceeded by at most the one archive still being read. */
+      LOG_CS_ENTER (thread_p);
+      log_Gl.backup_first_arv_num_needed = i + 1;
+      LOG_CS_EXIT (thread_p);
     }
 
   return error_code;

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -7775,6 +7775,11 @@ logpb_backup (THREAD_ENTRY * thread_p, int num_perm_vols, const char *allbackup_
   const char *bk_vol;		/* ptr to old bkup volume name */
   int unit_num;
   FILEIO_BACKUP_RECORD_INFO all_bkup_info[FILEIO_BACKUP_UNDEFINED_LEVEL];
+  /* Log header backup bookkeeping as it was before this backup touched it, so that a backup which fails
+   * after the header has been flushed does not leave the header advertising a backup that was removed. */
+  LOG_HDR_BKUP_LEVEL_INFO saved_bkinfo[FILEIO_BACKUP_UNDEFINED_LEVEL];
+  LOG_LSA saved_bkup_level_lsa[FILEIO_BACKUP_UNDEFINED_LEVEL];
+  bool bkup_hdr_info_saved = false;
   bool beenwarned;
   bool isincremental = false;	/* Assume full backups */
   bool bkup_in_progress = false;
@@ -8342,6 +8347,15 @@ loop:
       goto error;
     }
 
+  /* Remember what the header said before this backup overwrites it. From here on the header no longer describes
+   * a backup that exists on the destination: the record becomes true only when this backup completes, and the
+   * archives are transferred after the header is flushed below. */
+  memcpy (saved_bkinfo, log_Gl.hdr.bkinfo, sizeof (saved_bkinfo));
+  LSA_COPY (&saved_bkup_level_lsa[FILEIO_BACKUP_FULL_LEVEL], &log_Gl.hdr.bkup_level0_lsa);
+  LSA_COPY (&saved_bkup_level_lsa[FILEIO_BACKUP_BIG_INCREMENT_LEVEL], &log_Gl.hdr.bkup_level1_lsa);
+  LSA_COPY (&saved_bkup_level_lsa[FILEIO_BACKUP_SMALL_INCREMENT_LEVEL], &log_Gl.hdr.bkup_level2_lsa);
+  bkup_hdr_info_saved = true;
+
   /* Clear log header information regarding previous backups */
   logpb_initialize_backup_info (&log_Gl.hdr);
 
@@ -8499,6 +8513,17 @@ error:
     }
   log_Gl.backup_in_progress = false;
   log_Gl.backup_first_arv_num_needed = -1;
+  if (bkup_hdr_info_saved)
+    {
+      /* fileio_abort_backup () above removed what this backup had written, so the header must stop claiming it.
+       * Leaving the claim behind would let the next incremental backup pass the "lower level exists" gate and
+       * build on a backup that is gone - a gap that only shows up at restore time. */
+      memcpy (log_Gl.hdr.bkinfo, saved_bkinfo, sizeof (saved_bkinfo));
+      LSA_COPY (&log_Gl.hdr.bkup_level0_lsa, &saved_bkup_level_lsa[FILEIO_BACKUP_FULL_LEVEL]);
+      LSA_COPY (&log_Gl.hdr.bkup_level1_lsa, &saved_bkup_level_lsa[FILEIO_BACKUP_BIG_INCREMENT_LEVEL]);
+      LSA_COPY (&log_Gl.hdr.bkup_level2_lsa, &saved_bkup_level_lsa[FILEIO_BACKUP_SMALL_INCREMENT_LEVEL]);
+      logpb_flush_header (thread_p);
+    }
   LOG_CS_EXIT (thread_p);
 #endif /* SERVER_MODE */
 

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -8452,9 +8452,18 @@ loop:
   logpb_destroy_backup_read_worker_pool ();
 #endif
 
-  /* The backup exists now, so record it. This is the only place the header learns about it, which is what makes
-   * the outcome atomic: a backup that fails or is killed anywhere above leaves the previous record untouched,
-   * with nothing to undo.
+  error_code = logpb_update_backup_volume_info (log_Name_bkupinfo);
+  if (error_code != NO_ERROR)
+    {
+      goto error;
+    }
+
+  /* The backup exists and its volume names are on disk, and this is the last point that can still fail: the error
+   * path from here up would have called fileio_abort_backup (), which destroys every backup volume of this level.
+   * So the header learns about the backup only now, and it is the only place it does. That makes the outcome
+   * atomic with nothing to undo - a backup that fails or is killed anywhere above leaves the previous record
+   * exactly as it was, and a recorded backup is one that exists. Deleting archives, which cannot be undone
+   * either, waits for the same point.
    *
    * The active log image copied above was taken before this, so it carries whatever record the previous backup
    * left rather than this one's. A database restored from this backup therefore reports that older backup as its
@@ -8475,12 +8484,6 @@ loop:
 	  logpb_remove_archive_logs (thread_p, catmsg);
 	  LOG_CS_EXIT (thread_p);
 	}
-    }
-
-  error_code = logpb_update_backup_volume_info (log_Name_bkupinfo);
-  if (error_code != NO_ERROR)
-    {
-      goto error;
     }
 
   if (session.verbose_fp)

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -324,9 +324,6 @@ static bool logpb_check_if_exists (const char *fname, char *first_vol);
 #if defined(SERVER_MODE)
 static void logpb_set_backup_info_in_header (LOG_HEADER * log_hdr, FILEIO_BACKUP_LEVEL backup_level,
 					     INT64 bkup_attime, const LOG_LSA * chkpt_lsa);
-static void logpb_restore_backup_info_in_header (LOG_HEADER * log_hdr,
-						 const LOG_HDR_BKUP_LEVEL_INFO * saved_bkinfo,
-						 const LOG_LSA * saved_bkup_level_lsa);
 static int logpb_backup_needed_archive_logs (THREAD_ENTRY * thread_p, FILEIO_BACKUP_SESSION * session,
 					     int first_arv_num, int last_arv_num);
 #endif /* SERVER_MODE */
@@ -7780,25 +7777,6 @@ logpb_set_backup_info_in_header (LOG_HEADER * log_hdr, FILEIO_BACKUP_LEVEL backu
 }
 
 /*
- * logpb_restore_backup_info_in_header - Put previously saved backup bookkeeping back into the log header
- *
- * return: nothing
- *
- *   log_hdr(in/out): log header to restore into
- *   saved_bkinfo(in): bkinfo array as it was before this backup touched it
- *   saved_bkup_level_lsa(in): the three backup level LSAs as they were
- */
-static void
-logpb_restore_backup_info_in_header (LOG_HEADER * log_hdr, const LOG_HDR_BKUP_LEVEL_INFO * saved_bkinfo,
-				     const LOG_LSA * saved_bkup_level_lsa)
-{
-  memcpy (log_hdr->bkinfo, saved_bkinfo, sizeof (log_hdr->bkinfo));
-  LSA_COPY (&log_hdr->bkup_level0_lsa, &saved_bkup_level_lsa[FILEIO_BACKUP_FULL_LEVEL]);
-  LSA_COPY (&log_hdr->bkup_level1_lsa, &saved_bkup_level_lsa[FILEIO_BACKUP_BIG_INCREMENT_LEVEL]);
-  LSA_COPY (&log_hdr->bkup_level2_lsa, &saved_bkup_level_lsa[FILEIO_BACKUP_SMALL_INCREMENT_LEVEL]);
-}
-
-/*
  * logpb_backup - Execute a level backup for the given database volume
  *
  * return: NO_ERROR if all OK, ER status otherwise
@@ -7848,9 +7826,6 @@ logpb_backup (THREAD_ENTRY * thread_p, int num_perm_vols, const char *allbackup_
   const char *bk_vol;		/* ptr to old bkup volume name */
   int unit_num;
   FILEIO_BACKUP_RECORD_INFO all_bkup_info[FILEIO_BACKUP_UNDEFINED_LEVEL];
-  /* Header backup bookkeeping as it was before this backup, put back while the backup is still in flight. */
-  LOG_HDR_BKUP_LEVEL_INFO saved_bkinfo[FILEIO_BACKUP_UNDEFINED_LEVEL];
-  LOG_LSA saved_bkup_level_lsa[FILEIO_BACKUP_UNDEFINED_LEVEL];
   bool beenwarned;
   bool isincremental = false;	/* Assume full backups */
   bool bkup_in_progress = false;
@@ -8416,14 +8391,9 @@ loop:
       goto error;
     }
 
-  /* Remember what the header said, to put back before the critical section is released. */
-  memcpy (saved_bkinfo, log_Gl.hdr.bkinfo, sizeof (saved_bkinfo));
-  LSA_COPY (&saved_bkup_level_lsa[FILEIO_BACKUP_FULL_LEVEL], &log_Gl.hdr.bkup_level0_lsa);
-  LSA_COPY (&saved_bkup_level_lsa[FILEIO_BACKUP_BIG_INCREMENT_LEVEL], &log_Gl.hdr.bkup_level1_lsa);
-  LSA_COPY (&saved_bkup_level_lsa[FILEIO_BACKUP_SMALL_INCREMENT_LEVEL], &log_Gl.hdr.bkup_level2_lsa);
-
-  /* Put this backup in the header so the active log image copied below carries it. */
-  logpb_set_backup_info_in_header (&log_Gl.hdr, backup_level, session.bkup.bkuphdr->start_time, &chkpt_lsa);
+  /* Get the header on disk in step with the log pages flushed above, so the active log image copied below is
+   * self consistent. This backup is not recorded in it: a backup is recorded only once it exists, which is after
+   * the archives have been transferred. */
   logpb_flush_header (thread_p);
 
   /* Include active log always. Skipping log active is obsolete. */
@@ -8446,15 +8416,9 @@ loop:
       thread_sleep (1000);
     }
 
-  /* The image in the backup keeps the record; the live header must not. From here the backup can still fail or
-   * the server can be killed, and neither leaves anything able to undo a durable claim. The record goes back in
-   * only once the backup is complete, below. */
-  logpb_restore_backup_info_in_header (&log_Gl.hdr, saved_bkinfo, saved_bkup_level_lsa);
-  logpb_flush_header (thread_p);
-
-  /* The log is captured: the archive set is frozen and pinned, and the active log image carries the header that
-   * names it. Everything below only reads files that cannot change, so release the critical section here and let
-   * transactions run while the archives are transferred. */
+  /* The log is captured: the archive set is frozen and pinned, and the active log image goes with it. Everything
+   * below only reads files that cannot change, so release the critical section here and let transactions run
+   * while the archives are transferred. */
   LOG_CS_EXIT (thread_p);
 
   er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_LOG_BACKUP_CS_EXIT, 1, log_Name_active);
@@ -8488,8 +8452,15 @@ loop:
   logpb_destroy_backup_read_worker_pool ();
 #endif
 
-  /* The backup exists now, so record it. Doing it here rather than before the transfer is what keeps a failed or
-   * killed backup from leaving the header pointing at something that is not there. */
+  /* The backup exists now, so record it. This is the only place the header learns about it, which is what makes
+   * the outcome atomic: a backup that fails or is killed anywhere above leaves the previous record untouched,
+   * with nothing to undo.
+   *
+   * The active log image copied above was taken before this, so it carries whatever record the previous backup
+   * left rather than this one's. A database restored from this backup therefore reports that older backup as its
+   * last one, and an incremental taken on it chains onto that older backup instead of the one it was restored
+   * from. Restoring from a backup and then taking an incremental against it is not a supported flow - take a
+   * full backup on the restored database first. */
   LOG_CS_ENTER (thread_p);
   logpb_set_backup_info_in_header (&log_Gl.hdr, backup_level, session.bkup.bkuphdr->start_time, &chkpt_lsa);
   logpb_flush_header (thread_p);

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -7786,6 +7786,7 @@ logpb_backup (THREAD_ENTRY * thread_p, int num_perm_vols, const char *allbackup_
   int keys_vdes = NULL_VOLDES;
 #if defined(SERVER_MODE)
   int first_arv_needed = -1;	/* for self contained, consistent */
+  int last_arv_needed = -1;	/* last archive of the set frozen under the log critical section */
 
   int rv;
   time_t wait_checkpoint_begin_time;
@@ -8306,20 +8307,11 @@ loop:
 
   if (first_arv_needed < log_Gl.hdr.nxarv_num)
     {
-      /* Keep the archives this backup is about to read out of reach of archive removal. Under the log critical
-       * section nothing can remove them anyway, but the pin is what will hold once the transfer runs outside it. */
+      /* Freeze the archive set here and keep it out of reach of archive removal. The archives themselves are
+       * transferred further below, after the log critical section has been released: they are complete and never
+       * written again once nxarv_num moved past them, and the pin is what keeps them on disk until then. */
+      last_arv_needed = log_Gl.hdr.nxarv_num - 1;
       log_Gl.backup_first_arv_num_needed = first_arv_needed;
-
-      error_code = logpb_backup_needed_archive_logs (thread_p, &session, first_arv_needed, log_Gl.hdr.nxarv_num - 1);
-
-      log_Gl.backup_first_arv_num_needed = -1;
-
-      if (error_code != NO_ERROR)
-	{
-	  LOG_CS_EXIT (thread_p);
-	  er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_LOG_BACKUP_CS_EXIT, 1, log_Name_active);
-	  goto error;
-	}
     }
 #endif
 
@@ -8390,10 +8382,36 @@ loop:
       goto error;
     }
 
+  /* The log is captured: the archive set is frozen and pinned, and the active log image was taken with the log
+   * header that names it. Everything below only reads files that cannot change any more, so the log critical
+   * section is released here and user transactions resume while the archives are still being transferred. */
+  LOG_CS_EXIT (thread_p);
+
+  er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_LOG_BACKUP_CS_EXIT, 1, log_Name_active);
+
+#if defined(SERVER_MODE)
+  if (first_arv_needed >= 0 && first_arv_needed <= last_arv_needed)
+    {
+      _er_log_debug (ARG_FILE_LINE, "Backup of log archives %d to %d started outside the log critical section",
+		     first_arv_needed, last_arv_needed);
+
+      error_code = logpb_backup_needed_archive_logs (thread_p, &session, first_arv_needed, last_arv_needed);
+
+      LOG_CS_ENTER (thread_p);
+      log_Gl.backup_first_arv_num_needed = -1;
+      LOG_CS_EXIT (thread_p);
+
+      if (error_code != NO_ERROR)
+	{
+	  goto error;
+	}
+
+      _er_log_debug (ARG_FILE_LINE, "Backup of log archives %d to %d finished", first_arv_needed, last_arv_needed);
+    }
+#endif
+
   if (fileio_finish_backup (thread_p, &session) == NULL)
     {
-      LOG_CS_EXIT (thread_p);
-      er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_LOG_BACKUP_CS_EXIT, 1, log_Name_active);
       error_code = ER_FAILED;
       goto error;
     }
@@ -8407,13 +8425,11 @@ loop:
       catmsg = msgcat_message (MSGCAT_CATALOG_CUBRID, MSGCAT_SET_LOG, MSGCAT_LOG_DATABASE_BACKUP_WAS_TAKEN);
       if (catmsg)
 	{
+	  LOG_CS_ENTER (thread_p);
 	  logpb_remove_archive_logs (thread_p, catmsg);
+	  LOG_CS_EXIT (thread_p);
 	}
     }
-
-  LOG_CS_EXIT (thread_p);
-
-  er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_LOG_BACKUP_CS_EXIT, 1, log_Name_active);
 
   error_code = logpb_update_backup_volume_info (log_Name_bkupinfo);
   if (error_code != NO_ERROR)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27166

### Purpose
`backupdb`로 온라인 백업을 수행하면 로그 백업 구간에서 로그 임계 구역(`LOG_CS`)을 배타 모드로 잡은 채
아카이브 로그를 전부 전송합니다. 이 구간의 소요 시간은 백업 데이터를 받아가는 쪽의 처리 속도에 그대로
종속되므로, 목적지가 느리면 그 시간만큼 로그 서브시스템 전체가 정지합니다.

커밋 경로인 `logpb_flush_pages()`도 같은 임계 구역을 배타 모드로 요구하기 때문에, 그동안 커밋·로그
flush가 모두 대기하고 로그 버퍼가 차는 시점부터는 진행 중인 DML까지 지연됩니다. 사용자에게는 백업 중
DB가 멈춘 것처럼 보입니다. 3rd party 프로그램이 `cubrid-backup-api`로 백업 데이터를 받아 테이프에
저장하는 고객사 구성에서 보고된 문제입니다.

아카이브 전송을 임계 구역 밖으로 빼서, 백업 목적지의 속도가 사용자 트랜잭션 지연으로 이어지지 않게 합니다.

### Implementation
* 아카이브 전송을 `LOG_CS` 밖으로 이동하고, 액티브 로그를 아카이브보다 **먼저** 캡처
    * 기존에 임계 구역이 필요했던 이유는 아카이브 집합을 정하는 시점 `T`와 액티브 로그를 캡처하는 시점
      `T2`가 달라서입니다. 그 사이에 아카이브가 새로 생기면 액티브 로그에 있던 페이지가 백업 대상이 아닌
      새 아카이브로 옮겨가고 액티브 로그에서는 덮여, 복구 시 로그에 구멍이 생깁니다
    * 액티브 로그를 집합 확정과 같은 시점에 캡처하면 이 구멍이 원리적으로 사라집니다. 아카이빙은 append가
      `nxarv_pageid`의 물리 슬롯을 덮으려는 순간에만 일어나므로(`logpb_next_append_page()`), 그 시점의
      액티브 로그는 `[nxarv_pageid, append_lsa]`를 전부 갖고 있습니다. 이후 생기는 아카이브는 이미 액티브
      이미지에 있는 페이지이거나 이 백업의 복구 종점 밖입니다
    * 따라서 새 아카이브를 추적할 필요도, 아카이브 생성을 막을 필요도 없습니다
* 임계 구역 안에 남긴 것: 로그 flush, 아카이브 집합 확정, 헤더 갱신/flush, 액티브 로그 캡처
    * 액티브 로그만 예외적으로 서버의 append 디스크립터를 공유하고(`fileio_backup_volume()`), 내용 일관성
      상으로도 append가 멈춰 있어야 하므로 안에 남깁니다
    * 아카이브는 전용 read-only 디스크립터(`fileio_open(O_RDONLY)`)로 읽고 `log_Gl.archive`를 포함해
      로그 서브시스템의 공유 상태를 전혀 건드리지 않습니다. `nxarv_num`이 지나간 아카이브는 write-once라
      임계 구역 밖에서 읽어도 같은 내용입니다
* 백업이 읽어야 할 아카이브를 삭제로부터 보호하는 핀 추가 (`log_Gl.backup_first_arv_num_needed`)
    * `logpb_remove_archive_logs_exceed_limit()`과 `logpb_remove_archive_logs()`가 이미 crash recovery /
      vacuum / CDC / flashback retention을 `MIN`으로 깎고 있어, 백업을 그 목록에 하나 더 추가하는 형태
    * 실제로 삭제 범위가 줄어든 경우에만 에러 로그를 남겨, 아카이브가 쌓이는 원인을 백업까지 역추적 가능
    * 로그 헤더에 저장하지 않고 **메모리에만** 둡니다. 저장하면 백업 중 크래시 시 핀을 해제할 주체가 없어
      아카이브 삭제가 영구히 막힙니다
    * `-r` 삭제가 방금 백업한 아카이브를 지우던 기존 동작을 유지하기 위해, 전송 직후 해제하고 `-r`을 수행
* 커밋 2개로 분리
    * `fec8ab8` 핀 + 삭제 clamp — 임계 구역이 아직 전 구간을 덮으므로 **단독으로는 동작 변화 없음**
    * `5c8da0c` 아카이브 전송을 임계 구역 밖으로

### Remarks
* **측정** — 아카이브 5개, `--sleep-msecs=40`으로 목적지를 느리게 만든 상태에서 커밋 루프 동시 실행

    | | 수정 전 | 수정 후 |
    |---|---|---|
    | `-1087`~`-1088` (LOG_CS 점유) | 1.320 s | **0.050 s** |
    | 커밋 최대 응답 시간 | 1.342 s | **0.103 s** |

    `-1087`/`-1088`은 문구와 위치를 그대로 두었습니다. 두 메시지의 간격이 "로그 서브시스템이 멈춰 있는 창"
    이라는 의미가 유지되고, 그 값만 짧아집니다. 아카이브 전송 구간은 별도 디버그 로그로 경계를 남깁니다.
* **백업 스트림 순서가 바뀝니다** (`data → _lginf → _lgat → archives`). 각 볼륨의 내용은 동일하고 순서만
  바뀝니다. 복구는 스트림을 순차로 읽어 볼륨 헤더의 `volid`로 디스패치하므로 순서에 의존하지 않고,
  파일시스템을 보는 유일한 판정인 `logpb_is_log_active_from_backup_useful()`은 백업된 액티브 로그의
  `hdr.nxarv_num`번 아카이브를 찾는데 백업 집합은 항상 `nxarv_num - 1`에서 끝나 그 파일이 복구로 생길 수
  없습니다. 순서 의존이 생길 수 있는 유일한 지점이 구조적으로 공집합입니다.
* **검증** — 아래 조합 모두 행수 정확히 일치 + `checkdb` 정상

    | 백업 | 복구 바이너리 | 결과 |
    |---|---|---|
    | 수정 후 (full) | 수정 후 | OK |
    | 수정 후 (level-1 증분) | 수정 후 | OK |
    | 수정 전 | 수정 후 | OK |
    | 수정 후 | 수정 전(미패치) | OK |

    이 외에 트랜잭션 커밋 중 받은 백업 복구(시점 정합), `restoredb --list`, 그리고
    `log_max_archives=2` + `force_remove_log_archives=yes` + 동시 쓰기 상태에서 3분 43초짜리 아카이브
    전송(37개) 정상 완료(핀 아래 번호는 삭제되고 핀 대상은 전부 보존)를 확인했습니다.
* **백포트 가능** — 디스크 이미지 변경 없음(로그 헤더/아카이브 헤더/백업 포맷 무변경, 핀은 메모리 멤버),
  새 에러 코드·메시지 카탈로그·시스템 파라미터 없음.
* **함께 포함된 별건** — `3c79180`은 이 이슈를 검토하면서 `LOG_ARCHIVE_CS` 구간을 전수 조사하다 같이
  정리한 것으로 위 개선과는 독립적입니다. `CSECT_LOG_ARCHIVE`가 7개 지점 전부 write로 잡혀 있었는데,
  CDC/flashback의 LSA 해석 경로 2곳은 `log_Gl.archive`를 읽기만 하거나 아예 건드리지 않아 read로 충분
  합니다. 다만 그 write 모드가 `fileio_mount()`/`fileio_dismount()` 쌍도 직렬화하고 있어(라벨 키 캐시에
  레퍼런스 카운트가 없어 두 reader가 서로의 fd를 닫음) 헤더 읽기를 전용 디스크립터로 바꾼 뒤 read로
  전환했습니다. 부수적으로 `cdc_check_lsa_range()`가 `log_Gl.archive.vdes`를 닫아 dangling으로 만들던
  기존 결함도 사라집니다. 나머지 5개 지점은 `log_Gl.archive`를 실제로 변경하므로 write를 유지했습니다.
* **후속(별건)** — `logpb_fetch_from_archive()`의 read 모드 fast path 분리, 아카이브 단계의 병렬 read 복원,
  목적지가 극단적으로 느릴 때 액티브 로그까지 로컬 스풀로 빼는 방안. 현재 측정치로는 불필요합니다.