### PR TITLE
[CBRD-27306] Count OR- and LIKE-derived restrictions in scan cardinality, compensating the predicate that implies them

### DIFF
--- a/src/optimizer/query_graph.c
+++ b/src/optimizer/query_graph.c
@@ -2066,7 +2066,7 @@ qo_analyze_term (QO_TERM * term, int term_type)
   if (PT_EXPR_INFO_IS_FLAGED (pt_expr, PT_EXPR_INFO_OR_DERIVED))
     {
       /* counted at the node scan (qo_node_add_sarg ()); the origin factor is discounted in
-       * qo_or_derived_compensate () so the join output estimate stays unchanged */
+       * qo_derived_term_compensate () so the join output estimate stays unchanged */
       QO_TERM_SET_FLAG (term, QO_TERM_OR_DERIVED);
     }
 

--- a/src/optimizer/query_graph.c
+++ b/src/optimizer/query_graph.c
@@ -205,6 +205,8 @@ static void qo_estimate_statistics (MOP class_mop, CLASS_STATS *);
 static void qo_node_free (QO_NODE *);
 static void qo_node_dump (QO_NODE *, FILE *);
 static void qo_node_add_sarg (QO_NODE *, QO_TERM *);
+static QO_TERM *qo_derived_term_origin (QO_ENV * env, QO_TERM * derived, int idx, BITSET * taken);
+static void qo_derived_term_compensate (QO_ENV * env);
 
 static void qo_seg_free (QO_SEGMENT *);
 
@@ -544,6 +546,10 @@ qo_optimize_helper (QO_ENV * env)
       term = qo_add_term (conj, PREDICATE_TERM, env);
       conj->next = next;
     }
+
+  /* every WHERE term now has its selectivity: reconcile each derived duplicate with the
+   * predicate that implies it */
+  qo_derived_term_compensate (env);
 
   /* check join-edge for ansi(explicit) join */
   for (n = 1; n < env->nnodes; n++)
@@ -2059,7 +2065,8 @@ qo_analyze_term (QO_TERM * term, int term_type)
 
   if (PT_EXPR_INFO_IS_FLAGED (pt_expr, PT_EXPR_INFO_OR_DERIVED))
     {
-      /* keep real selectivity for index-access cost; flag so row-count skips it */
+      /* counted at the node scan (qo_node_add_sarg ()); the origin factor is discounted in
+       * qo_or_derived_compensate () so the join output estimate stays unchanged */
       QO_TERM_SET_FLAG (term, QO_TERM_OR_DERIVED);
     }
 
@@ -8777,6 +8784,226 @@ qo_node_free (QO_NODE * node)
 }
 
 /*
+ * qo_derived_term_origin () - the predicate a derived restriction was extracted from
+ *   return: the origin term, or NULL when no candidate exists at all
+ *   env(in):
+ *   derived(in): a term flagged QO_TERM_OR_DERIVED or QO_TERM_LIKE_DERIVED_RANGE
+ *   idx(in): index of derived, so it cannot pair with itself
+ *   taken(in/out): bitset of terms already paired, so several derived terms spread over the
+ *		    origins available instead of piling onto the first one
+ *
+ * Note: the pairing is recovered structurally rather than carried on the parse nodes: the
+ *	 rewrite passes that run between the extraction and this point rebuild predicates
+ *	 without preserving annotations of their own.
+ *
+ *	 An OR-derived restriction comes from a multi-spec OR factor, so its origin is a
+ *	 disjunction spanning several specs whose segments cover the derived term's own -- the
+ *	 segments, not just the node, because a query can hold more than one such factor over
+ *	 the same tables and only the columns tell them apart.  A LIKE-derived range comes from
+ *	 the prefix of a LIKE on the same segment, which carries the paired
+ *	 QO_TERM_LIKE_HAS_DERIVED_RANGE flag; segments rather than identity because
+ *	 qo_apply_range_intersection () may fold several derived ranges into one term.
+ *
+ *	 Candidates can still tie -- two LIKEs on one column leave a single merged range that
+ *	 either could have produced.  Any of them may be taken: the compensation divides the
+ *	 derived selectivity out of exactly one origin, and since every consumer multiplies the
+ *	 terms, the product is the same whichever origin absorbs it.  Only the split across join
+ *	 levels differs, so the choice just has to be deterministic; preferring an origin no
+ *	 other derived term has taken keeps the division off a single term, where repeated
+ *	 divisions could reach the clamp and stop cancelling.
+ */
+static QO_TERM *
+qo_derived_term_origin (QO_ENV * env, QO_TERM * derived, int idx, BITSET * taken)
+{
+  int j;
+  QO_TERM *candidate, *origin = NULL;
+  PT_NODE *pt;
+
+  for (j = 0; j < env->nterms; j++)
+    {
+      candidate = QO_ENV_TERM (env, j);
+      if (j == idx)
+	{
+	  continue;
+	}
+
+      if (QO_TERM_IS_FLAGED (derived, QO_TERM_LIKE_DERIVED_RANGE))
+	{
+	  if (!QO_TERM_IS_FLAGED (candidate, QO_TERM_LIKE_HAS_DERIVED_RANGE)
+	      || !bitset_intersects (&(QO_TERM_SEGS (candidate)), &(QO_TERM_SEGS (derived))))
+	    {
+	      continue;
+	    }
+	}
+      else
+	{
+	  if (QO_TERM_IS_FLAGED (candidate, QO_TERM_OR_DERIVED)
+	      || bitset_cardinality (&(QO_TERM_NODES (candidate))) < 2
+	      || !bitset_subset (&(QO_TERM_NODES (candidate)), &(QO_TERM_NODES (derived)))
+	      || !bitset_subset (&(QO_TERM_SEGS (candidate)), &(QO_TERM_SEGS (derived))))
+	    {
+	      continue;		/* the origin spans several specs and covers the derived one */
+	    }
+	  pt = QO_TERM_PT_EXPR (candidate);
+	  if (pt == NULL || pt->node_type != PT_EXPR || (pt->info.expr.op != PT_OR && pt->or_next == NULL))
+	    {
+	      continue;		/* the origin is a disjunction */
+	    }
+	}
+
+      if (origin == NULL || (BITSET_MEMBER (*taken, QO_TERM_IDX (origin)) && !BITSET_MEMBER (*taken, j)))
+	{
+	  origin = candidate;	/* first match, or one no other derived term has taken */
+	}
+    }
+
+  return origin;
+}
+
+/*
+ * qo_derived_term_compensate () - reconcile each derived duplicate with the predicate that
+ *				   implies it, so one constraint is counted once
+ *   env(in):
+ *
+ * Note: two rewrites add a term that is implied by a predicate already in the tree -- a
+ *	 single-spec restriction extracted from a multi-spec OR factor
+ *	 (qo_extract_or_restrictions ()) and the prefix range derived from a LIKE
+ *	 (qo_rewrite_like_for_index_scan ()).  Both are counted in their node's cardinality by
+ *	 qo_node_add_sarg (), which is what lets the plan react to the filtering; the origin
+ *	 predicate must then contribute only what it rejects ON TOP of the derived term, or the
+ *	 same constraint is charged twice.  That share is the conditional selectivity
+ *	 sel (origin) / sel (derived).
+ *
+ *	 Containment also bounds the estimates: the origin implies the derived term, so
+ *	 sel (origin) <= sel (derived) must hold.  A violation is an inconsistency between two
+ *	 estimates of the same rows, and the derived side is the one to correct -- it is a
+ *	 widened stand-in the estimator probes indirectly, whereas the origin is the predicate
+ *	 as written.  Measured: for `a LIKE 'aaa%9'` over 100k rows the LIKE was sized at 10
+ *	 rows (exact) while its prefix range collapsed to 1, so lowering the LIKE to the range
+ *	 would have thrown away the better estimate.
+ */
+static void
+qo_derived_term_compensate (QO_ENV * env)
+{
+  int i, j, n = env->nterms;
+  int *pair;			/* origin of each derived term, -1 when it has none */
+  double *implied;		/* per origin: product of the terms it implies, -1 when none */
+  double *before;		/* per origin: its selectivity before any division */
+  QO_TERM *derived, *origin;
+  BITSET taken;
+
+  if (n <= 0)
+    {
+      return;
+    }
+
+  pair = (int *) malloc (n * sizeof (int));
+  implied = (double *) malloc (n * sizeof (double));
+  before = (double *) malloc (n * sizeof (double));
+  if (pair == NULL || implied == NULL || before == NULL)
+    {
+      /* Out of memory: leave every duplicate inert rather than half-compensated.  A selectivity
+       * of 1 costs the plan the filter's benefit but can never charge it twice. */
+      for (i = 0; i < n; i++)
+	{
+	  derived = QO_ENV_TERM (env, i);
+	  if (QO_TERM_IS_FLAGED (derived, QO_TERM_OR_DERIVED | QO_TERM_LIKE_DERIVED_RANGE))
+	    {
+	      QO_TERM_SELECTIVITY (derived) = 1.0;
+	    }
+	}
+      free (pair);
+      free (implied);
+      free (before);
+      return;
+    }
+
+  for (i = 0; i < n; i++)
+    {
+      pair[i] = -1;
+      implied[i] = -1.0;
+      before[i] = QO_TERM_SELECTIVITY (QO_ENV_TERM (env, i));
+    }
+
+  bitset_init (&taken, env);
+
+  /* pass 1: pair each derived term with the predicate that implies it, and collect what each
+   * origin is left accounting for */
+  for (i = 0; i < n; i++)
+    {
+      derived = QO_ENV_TERM (env, i);
+      if (!QO_TERM_IS_FLAGED (derived, QO_TERM_OR_DERIVED | QO_TERM_LIKE_DERIVED_RANGE)
+	  || QO_TERM_SELECTIVITY (derived) <= 0.0)
+	{
+	  continue;		/* an empty derived range leaves nothing to divide by */
+	}
+
+      origin = qo_derived_term_origin (env, derived, i, &taken);
+      if (origin == NULL || QO_TERM_SELECTIVITY (origin) < 0.0)
+	{
+	  /* No predicate to charge this duplicate against -- its origin was reshaped or folded
+	   * away by a later rewrite.  Every consumer multiplies the terms it holds, so leaving a
+	   * real selectivity here would charge the constraint a second time wherever both are
+	   * counted.  A selectivity of 1 makes the term inert in each of those products; keep it
+	   * out of key ranges too, the same treatment an OR-derived duplicate gets when it
+	   * rejects too few rows to pay for itself. */
+	  QO_TERM_SELECTIVITY (derived) = 1.0;
+	  QO_TERM_SET_FLAG (derived, QO_TERM_NON_IDX_SARG_COLL);
+	  QO_TERM_CAN_USE_INDEX (derived) = 0;
+	  continue;
+	}
+
+      j = QO_TERM_IDX (origin);
+      pair[i] = j;
+      bitset_add (&taken, j);
+      implied[j] = (implied[j] < 0.0) ? QO_TERM_SELECTIVITY (derived) : implied[j] * QO_TERM_SELECTIVITY (derived);
+    }
+
+  /* pass 2: one division per origin, against everything it implies at once.  Per-derived
+   * division would compare the next derived term against a selectivity already divided down,
+   * and correct a deficit that is not there -- the containment bound holds between each derived
+   * term and the origin as it was, not as it is left mid-way. */
+  for (j = 0; j < n; j++)
+    {
+      if (implied[j] < 0.0 || before[j] <= 0.0)
+	{
+	  continue;
+	}
+
+      if (implied[j] < before[j])
+	{
+	  /* Containment says the origin's rows are a subset of what its derived terms match, so
+	   * together they cannot come out more selective than it.  An estimate that says
+	   * otherwise is wrong on the derived side -- the origin is the predicate as written,
+	   * while a derived term is a widened stand-in the estimator probes indirectly (a prefix
+	   * range collapsing to one row is the case seen in practice).  Correct the deficit on
+	   * the first term paired here, which also keeps the division below at or under 1. */
+	  for (i = 0; i < n; i++)
+	    {
+	      if (pair[i] == j)
+		{
+		  derived = QO_ENV_TERM (env, i);
+		  QO_TERM_SELECTIVITY (derived) *= before[j] / implied[j];
+		  implied[j] = before[j];
+		  break;
+		}
+	    }
+	}
+
+      QO_TERM_SELECTIVITY (QO_ENV_TERM (env, j)) = before[j] / implied[j];
+      if (QO_TERM_SELECTIVITY (QO_ENV_TERM (env, j)) > 1.0)
+	{
+	  QO_TERM_SELECTIVITY (QO_ENV_TERM (env, j)) = 1.0;
+	}
+    }
+
+  bitset_delset (&taken);
+  free (pair);
+  free (implied);
+  free (before);
+}
+
+/*
  * qo_node_add_sarg () -
  *   return:
  *   node(in):
@@ -8788,14 +9015,11 @@ qo_node_add_sarg (QO_NODE * node, QO_TERM * sarg)
   double sel_limit;
 
   bitset_add (&(QO_NODE_SARGS (node)), QO_TERM_IDX (sarg));
-  /* Skip derived duplicates in row-count: a LIKE-derived range is subset-correlated with the
-   * retained LIKE, and an OR-derived restriction is implied by the multi-spec factor it was
-   * extracted from, so counting either would double count the same constraint.  Both stay in
-   * QO_NODE_SARGS for index key-range use. */
-  if (!QO_TERM_IS_FLAGED (sarg, QO_TERM_LIKE_DERIVED_RANGE | QO_TERM_OR_DERIVED))
-    {
-      QO_NODE_SELECTIVITY (node) *= QO_TERM_SELECTIVITY (sarg);
-    }
+  /* Every sarg counts here, derived duplicates included: this node's cardinality is where the
+   * filtering informs the join order and the access path.  qo_derived_term_compensate () has
+   * already reduced each origin predicate to what it rejects on top of the term it implies, so
+   * counting both sides charges the constraint exactly once. */
+  QO_NODE_SELECTIVITY (node) *= QO_TERM_SELECTIVITY (sarg);
   sel_limit = (QO_NODE_NCARD (node) == 0) ? 0 : (1.0 / (double) QO_NODE_NCARD (node));
   if (QO_NODE_SELECTIVITY (node) < sel_limit)
     {

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -191,7 +191,6 @@ static void qo_plan_compute_subquery_cost (PT_NODE *, double *, double *);
 static void qo_sscan_cost (QO_PLAN *);
 static void qo_iscan_cost (QO_PLAN *);
 static bool qo_index_forbids_key_filter (QO_INDEX_ENTRY *);
-static bool qo_get_like_derived_range_dup_sel (QO_PLAN *, double *, double *);
 static void qo_sort_cost (QO_PLAN *);
 static void qo_mjoin_cost (QO_PLAN *);
 static void qo_nljoin_cost (QO_PLAN *);
@@ -2115,86 +2114,6 @@ qo_index_scan_new (QO_INFO * info, QO_NODE * node, QO_NODE_INDEX_ENTRY * ni_entr
 }
 
 /*
- * qo_get_like_derived_range_dup_sel () - selectivities of the prefix-LIKE derived ranges that
- *   this index scan counts although the LIKEs they came from are counted too
- *   return: true when such a range takes part in this plan, false when there is none
- *   planp(in): index scan plan
- *   dup_sel(out): the selectivity to divide out of the key-range product
- *   kf_dup_sel(out): the selectivity to divide out of the key-filter product
- *
- * note: qo_rewrite_like_for_index_scan () keeps the original LIKE and adds a range derived
- *   from its fixed prefix, so one predicate turns into two terms. The rows matching the LIKE
- *   are a subset of that range, so once both terms are counted the range restricts nothing on
- *   top of the LIKE and the caller divides it back out. Which product holds the range depends
- *   on the plan, hence the two values: it is a key-range term where the scan ranges over it,
- *   and a key-filter term where another range took that place. The range and its LIKE are
- *   matched by segment rather than by identity, because qo_apply_range_intersection () may
- *   merge several derived ranges into a single term.
- *
- *   False is returned unless the LIKE became a key filter. A non-covering function index
- *   forbids key filters, and the LIKE then stays a data filter evaluated after the fetch -
- *   there the range really is the only restriction the fetch count may use.
- */
-static bool
-qo_get_like_derived_range_dup_sel (QO_PLAN * planp, double *dup_sel, double *kf_dup_sel)
-{
-  QO_ENV *env;
-  QO_TERM *termp;
-  BITSET_ITERATOR iter;
-  BITSET like_segs;
-  bool found = false;
-  int t;
-
-  *dup_sel = 1.0;
-  *kf_dup_sel = 1.0;
-
-  env = QO_NODE_ENV (planp->plan_un.scan.node);
-  bitset_init (&like_segs, env);
-
-  /* the LIKEs that a range was derived from and that ended up as key filters */
-  for (t = bitset_iterate (&(planp->plan_un.scan.kf_terms), &iter); t != -1; t = bitset_next_member (&iter))
-    {
-      termp = QO_ENV_TERM (env, t);
-      if (QO_TERM_IS_FLAGED (termp, QO_TERM_LIKE_HAS_DERIVED_RANGE))
-	{
-	  bitset_union (&like_segs, &(QO_TERM_SEGS (termp)));
-	}
-    }
-
-  if (!bitset_is_empty (&like_segs))
-    {
-      /* their derived ranges, each reported for the product that holds it. A zero selectivity
-       * is passed over: an empty range leaves nothing to divide by, and the estimate the caller
-       * already holds is as good as it gets. */
-      for (t = bitset_iterate (&(planp->plan_un.scan.terms), &iter); t != -1; t = bitset_next_member (&iter))
-	{
-	  termp = QO_ENV_TERM (env, t);
-	  if (QO_TERM_IS_FLAGED (termp, QO_TERM_LIKE_DERIVED_RANGE) && QO_TERM_SELECTIVITY (termp) > 0.0
-	      && bitset_intersects (&(QO_TERM_SEGS (termp)), &like_segs))
-	    {
-	      *dup_sel *= QO_TERM_SELECTIVITY (termp);
-	      found = true;
-	    }
-	}
-
-      for (t = bitset_iterate (&(planp->plan_un.scan.kf_terms), &iter); t != -1; t = bitset_next_member (&iter))
-	{
-	  termp = QO_ENV_TERM (env, t);
-	  if (QO_TERM_IS_FLAGED (termp, QO_TERM_LIKE_DERIVED_RANGE) && QO_TERM_SELECTIVITY (termp) > 0.0
-	      && bitset_intersects (&(QO_TERM_SEGS (termp)), &like_segs))
-	    {
-	      *kf_dup_sel *= QO_TERM_SELECTIVITY (termp);
-	      found = true;
-	    }
-	}
-    }
-
-  bitset_delset (&like_segs);
-
-  return found;
-}
-
-/*
  * qo_iscan_terms_all_measured () - did every key range term of this scan get its selectivity from
  *   the column histograms, rather than from an estimate the average key share has to stand in for?
  *   return: true when every term was measured
@@ -2255,7 +2174,7 @@ qo_iscan_cost (QO_PLAN * planp)
   double sel, sel_limit, height, leaves, opages, filter_sel, leaf_access, heap_access, heap_rows;
   double heap_fanout = 0.0, iss_leaves = 0.0, first_leaf = 0.0;
   double object_IO, index_IO;
-  double heap_sel, like_dup_sel, like_kf_dup_sel, sel_before_limit;
+  double heap_sel;
   QO_TERM *termp;
   BITSET_ITERATOR iter;
   int i, t, n, pkeys_num, index;
@@ -2328,7 +2247,6 @@ qo_iscan_cost (QO_PLAN * planp)
 
   /* check upper bound */
   sel = MIN (sel, 1.0);
-  sel_before_limit = sel;	/* the prefix-LIKE exception below divides this, not the bounded sel */
 
   sel_limit = 0.0;		/* init */
 
@@ -2396,15 +2314,10 @@ qo_iscan_cost (QO_PLAN * planp)
     }
 
   /* fraction of the rows that reach the heap: the key range and the key filter both run before
-   * the fetch */
+   * the fetch.  A derived duplicate needs no correction here: qo_derived_term_compensate ()
+   * reduced the predicate that implies it to the share it rejects on top of it, so whichever
+   * product each of the two lands in, together they charge the constraint once */
   heap_sel = sel * filter_sel;
-
-  /* exception - a prefix-LIKE rewrite counted its derived range above on top of the LIKE it
-   * came from; divide it back out of whichever product holds it */
-  if (qo_get_like_derived_range_dup_sel (planp, &like_dup_sel, &like_kf_dup_sel))
-    {
-      heap_sel = MAX (sel_before_limit / like_dup_sel, sel_limit) * (filter_sel / like_kf_dup_sel);
-    }
 
   /* number of leaf to be selected */
   leaf_access = sel * (double) QO_NODE_NCARD (nodep);
@@ -8136,11 +8049,10 @@ planner_visit_node (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM
 		}
 	      else
 		{
-		  /* Skip a LIKE-derived range and an OR-derived restriction in both the
-		   * row-count selectivity and the join hit probability: the former is
-		   * subset-correlated with the retained LIKE, the latter is implied by the
-		   * multi-spec factor it was extracted from, so counting either would double
-		   * count the same constraint. */
+		  /* A derived duplicate is already counted in its node's scan cardinality
+		   * (qo_node_add_sarg ()); counting it again here would charge the same
+		   * constraint twice.  Its origin predicate needs no exception: it carries the
+		   * conditional share qo_derived_term_compensate () left it with. */
 		  if (!QO_TERM_IS_FLAGED (term, QO_TERM_LIKE_DERIVED_RANGE | QO_TERM_OR_DERIVED))
 		    {
 		      double head_factor, tail_factor;

--- a/src/optimizer/rewriter/query_rewrite_term.c
+++ b/src/optimizer/rewriter/query_rewrite_term.c
@@ -4588,6 +4588,7 @@ qo_or_extract_is_cheap_restriction (PT_NODE * conjunct)
     case PT_BETWEEN:
     case PT_NOT_BETWEEN:
     case PT_LIKE:
+    case PT_IS_IN:
     case PT_IS_NULL:
     case PT_IS_NOT_NULL:
       break;
@@ -4616,6 +4617,22 @@ qo_or_extract_is_cheap_restriction (PT_NODE * conjunct)
 	{
 	  if (item->node_type != PT_EXPR || !qo_or_extract_is_constant_side (item->info.expr.arg1)
 	      || !qo_or_extract_is_constant_side (item->info.expr.arg2))
+	    {
+	      return false;
+	    }
+	}
+      return true;
+    }
+
+  if (conjunct->info.expr.op == PT_IS_IN)
+    {
+      /* the IN list: every element must be constant-like.  qo_rewrite_terms () then folds the
+       * derived copy into a RANGE term an index can adopt, exactly like a hand-written IN */
+      PT_NODE *item;
+
+      for (item = other; item != NULL; item = item->next)
+	{
+	  if (!qo_or_extract_is_constant_side (item))
 	    {
 	      return false;
 	    }
@@ -4784,12 +4801,15 @@ qo_or_extract_build_for_spec (PARSER_CONTEXT * parser, PT_NODE * disjunct, UINTP
  *	 part table gets no filter at all from the brand/container/size branches and every plan
  *	 has to carry the full table through the join.
  *
- *	 Because the derived factor is implied by the original one, it must not be counted a
- *	 second time in the row-count selectivity, and keeping it as a plain data filter only
- *	 pays off when it is no costlier than column-vs-constant compares.  Each derived factor
- *	 is therefore marked PT_EXPR_INFO_OR_DERIVED (plus _EXPENSIVE by shape); the marks reach
- *	 the plan as QO_TERM flags, where qo_node_add_sarg () skips the double count and
- *	 make_pred_from_plan () drops a costly copy that no index adopted.
+ *	 The derived factor's selectivity is counted at the node scan (qo_node_add_sarg ()), so
+ *	 the scan cardinality reflects the filter and the join order can react to it; to keep the
+ *	 join output estimate unchanged, the origin factor's join selectivity is discounted by
+ *	 the same share in qo_or_derived_compensate () -- the approach of PostgreSQL's
+ *	 consider_new_or_clause ().  Keeping the copy as a plain data filter only pays off when
+ *	 it is no costlier than column-vs-constant compares.  Each derived factor is therefore
+ *	 marked PT_EXPR_INFO_OR_DERIVED (plus _EXPENSIVE by shape) and linked to its origin
+ *	 factor; the marks reach the plan as QO_TERM flags, where make_pred_from_plan () drops a
+ *	 costly copy that no index adopted.
  */
 void
 qo_extract_or_restrictions (PARSER_CONTEXT * parser, PT_NODE * spec_list, PT_NODE ** wherep)
@@ -4953,9 +4973,9 @@ qo_extract_or_restrictions (PARSER_CONTEXT * parser, PT_NODE * spec_list, PT_NOD
       qo_rewrite_terms (parser, spec_list, &new_terms);
 
       /* mark what survived the rewrites: qo_analyze_term () carries the marks into the term
-       * flags, so the row-count selectivity skips these implied duplicates and
-       * make_pred_from_plan () drops the costly ones no index adopted.  Classify on the
-       * rewritten shape -- that is what a scan would actually evaluate */
+       * flags, so qo_or_derived_compensate () can pay the node-counted share back to the origin
+       * factor and make_pred_from_plan () can drop the costly ones no index adopted.  Classify
+       * on the rewritten shape -- that is what a scan would actually evaluate */
       for (derived = new_terms; derived != NULL; derived = derived->next)
 	{
 	  if (derived->node_type != PT_EXPR)

--- a/src/optimizer/rewriter/query_rewrite_term.c
+++ b/src/optimizer/rewriter/query_rewrite_term.c
@@ -4804,12 +4804,12 @@ qo_or_extract_build_for_spec (PARSER_CONTEXT * parser, PT_NODE * disjunct, UINTP
  *	 The derived factor's selectivity is counted at the node scan (qo_node_add_sarg ()), so
  *	 the scan cardinality reflects the filter and the join order can react to it; to keep the
  *	 join output estimate unchanged, the origin factor's join selectivity is discounted by
- *	 the same share in qo_or_derived_compensate () -- the approach of PostgreSQL's
+ *	 the same share in qo_derived_term_compensate () -- the approach of PostgreSQL's
  *	 consider_new_or_clause ().  Keeping the copy as a plain data filter only pays off when
  *	 it is no costlier than column-vs-constant compares.  Each derived factor is therefore
- *	 marked PT_EXPR_INFO_OR_DERIVED (plus _EXPENSIVE by shape) and linked to its origin
- *	 factor; the marks reach the plan as QO_TERM flags, where make_pred_from_plan () drops a
- *	 costly copy that no index adopted.
+ *	 marked PT_EXPR_INFO_OR_DERIVED (plus _EXPENSIVE by shape); the marks reach the plan as
+ *	 QO_TERM flags, where qo_derived_term_origin () re-identifies the origin structurally
+ *	 and make_pred_from_plan () drops a costly copy that no index adopted.
  */
 void
 qo_extract_or_restrictions (PARSER_CONTEXT * parser, PT_NODE * spec_list, PT_NODE ** wherep)
@@ -4973,7 +4973,7 @@ qo_extract_or_restrictions (PARSER_CONTEXT * parser, PT_NODE * spec_list, PT_NOD
       qo_rewrite_terms (parser, spec_list, &new_terms);
 
       /* mark what survived the rewrites: qo_analyze_term () carries the marks into the term
-       * flags, so qo_or_derived_compensate () can pay the node-counted share back to the origin
+       * flags, so qo_derived_term_compensate () can pay the node-counted share back to the origin
        * factor and make_pred_from_plan () can drop the costly ones no index adopted.  Classify
        * on the rewritten shape -- that is what a scan would actually evaluate */
       for (derived = new_terms; derived != NULL; derived = derived->next)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27306

## Purpose

옵티마이저의 두 재작성은 **이미 트리에 있는 술어가 함의하는 항**을 추가합니다.

- **CBRD-27171**: multi-spec OR 팩터에서 단일 spec 조건만 뽑아 스캔 필터로 추가 (`qo_extract_or_restrictions()`)
- **prefix-LIKE 재작성**: LIKE를 남긴 채 접두어 range를 추가 (`qo_rewrite_like_for_index_scan()`)

파생 항과 원본 술어가 같은 제약을 가리키므로 이중계산을 피해야 하는데, 현재는 **파생 항을 스캔 카디널리티에서 통째로 빼는** 방식입니다. 그래서 파생 필터로 크게 줄어드는 테이블이 옵티마이저에게는 원래 크기로 보이고, 그 테이블을 구동(outer)으로 두는 플랜이 실제보다 훨씬 비싸게 계산됩니다.

**TPC-H Q19**(SF=1, develop `f8f5b4401`)가 대표 사례입니다. part 구동 플랜은 실제로 8배 빠른데 비용은 11배 비싸게 계산되어 탈락합니다. 같은 술어를 사용자가 WHERE에 직접 쓰면 힌트 없이 뒤집히는 것으로, 파생 항의 선택도 미반영이 유일한 차단 요인임을 확인했습니다.

LIKE 쪽은 같은 미반영을 감수하는 대신 `qo_iscan_cost()`에서 **플랜마다** 되나누기로 보정합니다(`qo_get_like_derived_range_dup_sel()`, 세그먼트 매칭 60줄). 파생 range가 key-range에 앉았는지 key-filter에 앉았는지가 플랜마다 달라 출력이 둘 필요하고, 후보 인덱스 플랜을 볼 때마다 반복 실행됩니다.

또한 추출의 cheap 연산자 목록에 `PT_IS_IN`이 빠져 있어 Q19의 `p_container IN (...)`이 추출에서 누락되고, 파생 필터 통과 행이 485행이 아닌 4,826행이 되어 inner 프로브가 10배가 됩니다.

## Implementation

파생 항을 **노드 스캔에서 계수**하고, 그 origin은 **파생 항 위에서 추가로 걸러내는 몫만** 기여하게 합니다 — 조건부 선택도 `sel(origin)/sel(derived)`, 1.0 clamp. 두 재작성을 한 메커니즘으로 처리합니다.

- **`qo_derived_term_compensate()`** (신규, query_graph.c) — WHERE 항 분석 직후 1회. OR-derived와 LIKE-derived range를 함께 처리합니다.
- **`qo_derived_term_origin()`** (신규) — origin을 구조로 찾습니다. 파스 노드 링크는 추출과 이 지점 사이의 재작성 패스가 원본을 주석 미보존 재구성해 운반이 불가함을 실측으로 확인했습니다. OR은 "파생 항의 **세그먼트**를 포함하는, spec 2개 이상에 걸친 비파생 disjunction", LIKE는 "세그먼트가 겹치는 `QO_TERM_LIKE_HAS_DERIVED_RANGE` 항"(`qo_apply_range_intersection()`의 range 병합 대응).
- **후보가 동점일 때** — 한 컬럼에 LIKE가 둘이면 병합된 range 하나를 어느 쪽이 만들었는지 가릴 수 없고, 한 질의에 같은 테이블을 걸친 OR 팩터가 둘일 수도 있습니다. 어느 것을 골라도 됩니다: 모든 소비 지점이 항을 곱하므로 **어느 origin이 나눗셈을 흡수하든 곱은 같고**, 조인 단계별 배분만 달라집니다(선택된 origin이 파생 항을 함의한다는 전제입니다 — 원본 OR가 공통 conjunct로 CNF 분배되어 사라진 경우 파생 항은 그 분배 잔재와 짝지어질 수 있고, 이때 개별 항 선택도는 흔들려도 곱과 결과는 보존됩니다). 그래서 결정적으로 고르되(아직 짝이 없는 origin 우선) 건너뛰지는 않습니다. 후보가 아예 없는 파생 항은 **무해화**(선택도 1, 키 범위에서 제외)해 이중 과금을 구조적으로 막습니다.
- **origin당 나눗셈은 1회**, 그 origin이 함의하는 모든 파생 항의 곱으로 한 번에 나눕니다. 파생마다 즉시 나누면 다음 파생 항이 **이미 나눠진 잔여값**과 비교되어, 없는 부족분을 보정하며 실제 술어의 선택도를 부풀립니다.
- **포함관계 바운드** — origin의 행은 파생 항들이 매칭하는 행의 부분집합이므로, 파생 항들의 곱이 origin보다 선택적일 수 없습니다. 위반 시 **파생 쪽을 올립니다**(부족분을 파생 항 하나에 보정해 곱을 정확히 맞추므로 나눗셈이 1을 넘지 않습니다). origin은 질의에 쓰인 술어 그대로이고 파생 항은 추정기가 간접적으로 재는 넓힌 대역이라 파생 쪽이 틀렸다고 봅니다. 실측 근거(10만행): `a LIKE 'aaa%9'`는 10행(실제와 일치)으로 추정되는데 접두어 range는 1행으로 붕괴합니다(실제 100행). 반대 방향(origin을 낮춤)을 먼저 구현했다가 이 측정으로 폐기했습니다.
- **삭제** — `qo_node_add_sarg()`의 파생 항 제외 분기, `qo_get_like_derived_range_dup_sel()`과 `qo_iscan_cost()`의 되나누기 분기. 조인 row-count(`planner_visit_node()`)의 파생 항 skip은 **유지**합니다 — 파생 항은 노드 스캔에서 이미 계수되어 조인에서 또 곱하면 이중 과금이고, origin은 이미 조건부 몫으로 줄어 있어 별도 예외 없이 그대로 곱해도 제약이 한 번만 과금됩니다.
- `qo_or_extract_is_cheap_restriction()`에 원소 전부 상수류인 `PT_IS_IN` 허용(RANGE와 동일한 원소 단위 검사).

순증감 **+180/-114**.

## Remarks

TPC-H SF=1 (data_buffer 4G, 동일 저부하 창, 3회 median):

| | develop | 본 PR | PostgreSQL 16 |
|---|---|---|---|
| Q19 | 0.611s | **0.087s (7.0x)** | 0.078s |
| 22종 합계 | 24.4s | 24.3s | 16.8s |

- 플랜 덤프: part outer `card 495`(실제 485행), origin sel `0.000819 → 0.4937`로 조인 출력 card는 반영 전과 동일한 326 유지.
- **정합성 22/22 불변** (PostgreSQL 16 및 tpch-kit 공식 answer 대조).
- **Q19 외 21종 모두 ±11% 이내**이며, LIKE를 포함한 q09/q13/q14/q16/q20은 **플랜 덤프가 develop과 완전 동일**합니다.
- LIKE 경로는 TPC-H가 인덱스 있는 문자열 컬럼을 쓰지 않아 별도 합성 테스트(10만행, 접두어 100행)로 검증했습니다. 파생 range와 LIKE가 둘 다 남는 패턴에서 노드 카디널리티가 develop과 동일(10행 = 실제)이고, key-range 추정만 `1E-05 → 0.0001`로 실제(100행)에 가까워집니다.
- **multi-spec OR 팩터가 둘 이상인 질의**도 확인했습니다: 각 파생 항이 자기 팩터만 나누고, 전체 선택도는 develop과 동일하게 유지되면서(1.0099e-8 vs 1.00905e-8) 스캔 카디널리티만 필터를 반영합니다. 같은 컬럼에 LIKE가 둘인 질의(병합 range)도 develop의 `L1×L2` 회계와 일치합니다.
- 참고로 이 경로는 **CNF 분배를 넘긴 큰 OR**에서만 의미가 있습니다. 분배되는 OR은 단일 테이블 조건이 자연스럽게 분리되어 파생 항 자체가 생기지 않습니다(Q19가 분배 한계를 넘는 형태입니다).
- 두 재작성(CBRD-27171 / CBRD-27036)의 보정 방식을 함께 바꾸므로 양쪽 작성자 리뷰가 필요합니다.
- 회귀 테스트: CTP sql/medium 수행 예정입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

