### PR TITLE
[CBRD-27258] improving system view query spec definition

### DIFF
--- a/src/object/schema_information_schema_install.hpp
+++ b/src/object/schema_information_schema_install.hpp
@@ -53,24 +53,24 @@ namespace cubschema
   };
 }
 
-const char *sm_define_view_column_privileges_spec (void);
-const char *sm_define_view_columns_spec (void);
-const char *sm_define_view_domains_spec (void);
-const char *sm_define_view_foreign_servers_spec (void);
-const char *sm_define_view_key_column_usage_spec (void);
-const char *sm_define_view_parameters_spec (void);
-const char *sm_define_view_partitions_spec (void);
-const char *sm_define_view_referential_constraints_spec (void);
-const char *sm_define_view_routine_privileges_spec (void);
-const char *sm_define_view_routines_spec (void);
-const char *sm_define_view_schemata_spec (void);
-const char *sm_define_view_sequences_spec (void);
-const char *sm_define_view_statistics_spec (void);
-const char *sm_define_view_synonyms_spec (void);
-const char *sm_define_view_table_constraints_spec (void);
-const char *sm_define_view_table_privileges_spec (void);
-const char *sm_define_view_tables_spec (void);
-const char *sm_define_view_triggers_spec (void);
-const char *sm_define_view_views_spec (void);
+std::string sm_define_view_column_privileges_spec (void);
+std::string sm_define_view_columns_spec (void);
+std::string sm_define_view_domains_spec (void);
+std::string sm_define_view_foreign_servers_spec (void);
+std::string sm_define_view_key_column_usage_spec (void);
+std::string sm_define_view_parameters_spec (void);
+std::string sm_define_view_partitions_spec (void);
+std::string sm_define_view_referential_constraints_spec (void);
+std::string sm_define_view_routine_privileges_spec (void);
+std::string sm_define_view_routines_spec (void);
+std::string sm_define_view_schemata_spec (void);
+std::string sm_define_view_sequences_spec (void);
+std::string sm_define_view_statistics_spec (void);
+std::string sm_define_view_synonyms_spec (void);
+std::string sm_define_view_table_constraints_spec (void);
+std::string sm_define_view_table_privileges_spec (void);
+std::string sm_define_view_tables_spec (void);
+std::string sm_define_view_triggers_spec (void);
+std::string sm_define_view_views_spec (void);
 
 #endif /* _SCHEMA_INFORMATION_SCHEMA_INSTALL_HPP_ */

--- a/src/object/schema_information_schema_install_query_spec.cpp
+++ b/src/object/schema_information_schema_install_query_spec.cpp
@@ -152,7 +152,7 @@ const char *sm_define_view_column_privileges_spec (void)
   static char stmt [2048];
 
   // *INDENT-OFF*
-  snprintf (stmt, sizeof (stmt),
+  int n = snprintf (stmt, sizeof (stmt),
     "SELECT "
       "NULL AS [grantor], "
       "NULL AS [grantee], "
@@ -167,6 +167,7 @@ const char *sm_define_view_column_privileges_spec (void)
     "WHERE "
       "FALSE",
     CT_DUAL_NAME);
+  assert(n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -177,7 +178,7 @@ const char *sm_define_view_columns_spec (void)
   static char stmt [8192];
 
   // *INDENT-OFF*
-  snprintf (stmt, sizeof (stmt),
+  int n = snprintf (stmt, sizeof (stmt),
     "SELECT "
       "CAST (DATABASE () AS VARCHAR (255)) AS [table_catalog], " /* string -> varchar(255) */
       "[cls].[owner].[name] AS [table_schema], "
@@ -298,6 +299,7 @@ const char *sm_define_view_columns_spec (void)
     CT_COLLATION_NAME,
     CT_INDEXKEY_NAME,
     CT_INDEX_NAME);
+  assert(n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -311,7 +313,7 @@ const char *sm_define_view_domains_spec (void)
   static char stmt [2048];
 
   // *INDENT-OFF*
-  snprintf (stmt, sizeof (stmt),
+  int n = snprintf (stmt, sizeof (stmt),
     "SELECT "
       "NULL AS [domain_catalog], "
       "NULL AS [domain_schema], "
@@ -341,6 +343,7 @@ const char *sm_define_view_domains_spec (void)
     "WHERE "
       "FALSE",
     CT_DUAL_NAME);
+  assert(n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -351,7 +354,7 @@ const char *sm_define_view_foreign_servers_spec (void)
   static char stmt [4096];
 
   // *INDENT-OFF*
-  snprintf (stmt, sizeof (stmt),
+  int n = snprintf (stmt, sizeof (stmt),
     "SELECT "
       "CAST (DATABASE () AS VARCHAR (255)) AS [foreign_server_catalog], " /* string -> varchar(255) */
       "[srv].[link_name] AS [foreign_server_name], "
@@ -374,6 +377,7 @@ const char *sm_define_view_foreign_servers_spec (void)
     "WHERE "
       AUTH_CHECK_OBJECT_ANY("[srv].[owner].[name]", "[srv]"),
     CT_SERVER_NAME);
+  assert(n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -384,7 +388,7 @@ const char *sm_define_view_key_column_usage_spec (void)
   static char stmt [4096];
 
   // *INDENT-OFF*
-  snprintf (stmt, sizeof (stmt),
+  int n = snprintf (stmt, sizeof (stmt),
     "SELECT "
       "CAST (DATABASE () AS VARCHAR (255)) AS [constraint_catalog], " /* string -> varchar(255) */
       "[idx].[class_of].[owner].[name] AS [constraint_schema], "
@@ -412,6 +416,7 @@ const char *sm_define_view_key_column_usage_spec (void)
     CT_INDEXKEY_NAME,
     CT_INDEX_NAME,
     CT_INDEXKEY_NAME);
+  assert(n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -422,7 +427,7 @@ const char *sm_define_view_parameters_spec (void)
   static char stmt [4096];
 
   // *INDENT-OFF*
-  snprintf (stmt, sizeof (stmt),
+  int n = snprintf (stmt, sizeof (stmt),
     "SELECT "
       "CAST (DATABASE () AS VARCHAR (255)) AS [specific_catalog], " /* string -> varchar(255) */
       "[sp_args].[sp_of].[owner].[name] AS [specific_schema], "
@@ -466,6 +471,7 @@ const char *sm_define_view_parameters_spec (void)
     SP_TYPE_PROCEDURE, SP_TYPE_FUNCTION,
     CT_STORED_PROC_ARGS_NAME,
     CT_DATATYPE_NAME);
+  assert(n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -476,7 +482,7 @@ const char *sm_define_view_partitions_spec (void)
   static char stmt [4096];
 
   // *INDENT-OFF*
-  snprintf (stmt, sizeof (stmt),
+  int n = snprintf (stmt, sizeof (stmt),
     "SELECT "
       "CAST (DATABASE () AS VARCHAR (255)) AS [table_catalog], " /* string -> varchar(255) */
       "[super].[owner].[name] AS [table_schema], "
@@ -516,6 +522,7 @@ const char *sm_define_view_partitions_spec (void)
     DB_PARTITION_LIST,
     CT_PARTITION_NAME,
     CT_CLASS_NAME);
+  assert(n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -526,7 +533,7 @@ const char *sm_define_view_referential_constraints_spec (void)
   static char stmt [4096];
 
   // *INDENT-OFF*
-  snprintf (stmt, sizeof (stmt),
+  int n = snprintf (stmt, sizeof (stmt),
     "SELECT "
       "CAST (DATABASE () AS VARCHAR (255)) AS [constraint_catalog], " /* string -> varchar(255) */
       "[idx].[class_of].[owner].[name] AS [constraint_schema], "
@@ -559,6 +566,7 @@ const char *sm_define_view_referential_constraints_spec (void)
     SM_FOREIGN_KEY_NO_ACTION,
     SM_FOREIGN_KEY_SET_NULL,
     CT_INDEX_NAME);
+  assert(n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -569,7 +577,7 @@ const char *sm_define_view_routine_privileges_spec (void)
   static char stmt [4096];
 
   // *INDENT-OFF*
-  snprintf (stmt, sizeof (stmt),
+  int n = snprintf (stmt, sizeof (stmt),
     "SELECT "
       "[auth].[grantor].[name] AS [grantor], "
       "[auth].[grantee].[name] AS [grantee], "
@@ -593,6 +601,7 @@ const char *sm_define_view_routine_privileges_spec (void)
     CT_CLASSAUTH_NAME,
     CT_STORED_PROC_NAME,
     DB_OBJECT_PROCEDURE);
+  assert(n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -603,7 +612,7 @@ const char *sm_define_view_routines_spec (void)
   static char stmt [4096];
 
   // *INDENT-OFF*
-  snprintf (stmt, sizeof (stmt),
+  int n = snprintf (stmt, sizeof (stmt),
     "SELECT "
       "CAST (DATABASE () AS VARCHAR (255)) AS [specific_catalog], " /* string -> varchar(255) */
       "[sp].[owner].[name] AS [specific_schema], "
@@ -692,6 +701,7 @@ const char *sm_define_view_routines_spec (void)
     CT_STORED_PROC_CODE_NAME,
     CT_ROOT_NAME,
     CT_CHARSET_NAME);
+  assert(n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -702,7 +712,7 @@ const char *sm_define_view_schemata_spec (void)
   static char stmt [2048];
 
   // *INDENT-OFF*
-  snprintf (stmt, sizeof (stmt),
+  int n = snprintf (stmt, sizeof (stmt),
     "SELECT "
       "CAST (DATABASE () AS VARCHAR (255)) AS [catalog_name], " /* string -> varchar(255) */
       "[usr].[name] AS [schema_name], "
@@ -726,6 +736,7 @@ const char *sm_define_view_schemata_spec (void)
     AU_USER_CLASS_NAME,
     CT_ROOT_NAME,
     CT_CHARSET_NAME);
+  assert(n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -736,7 +747,7 @@ const char *sm_define_view_sequences_spec (void)
   static char stmt [2048];
 
   // *INDENT-OFF*
-  snprintf (stmt, sizeof (stmt),
+  int n = snprintf (stmt, sizeof (stmt),
     "SELECT "
       "CAST (DATABASE () AS VARCHAR (255)) AS [sequence_catalog], " /* string -> varchar(255) */
       "[serial].[owner].[name] AS [sequence_schema], "
@@ -765,6 +776,7 @@ const char *sm_define_view_sequences_spec (void)
     DB_MAX_NUMERIC_PRECISION,
     DB_DEFAULT_NUMERIC_SCALE,
     CT_SERIAL_NAME);
+  assert(n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -775,7 +787,7 @@ const char *sm_define_view_statistics_spec (void)
   static char stmt [4096];
 
   // *INDENT-OFF*
-  snprintf (stmt, sizeof (stmt),
+  int n = snprintf (stmt, sizeof (stmt),
     "SELECT "
       "CAST (DATABASE () AS VARCHAR (255)) AS [table_catalog], " /* string -> varchar(255) */
       "[cls].[owner].[name] AS [table_schema], "
@@ -825,6 +837,7 @@ const char *sm_define_view_statistics_spec (void)
     CT_INDEX_NAME,
     CT_CLASS_NAME,
     CT_ATTRIBUTE_NAME);
+  assert(n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -835,7 +848,7 @@ const char *sm_define_view_synonyms_spec (void)
   static char stmt [4096];
 
   // *INDENT-OFF*
-  snprintf (stmt, sizeof (stmt),
+  int n = snprintf (stmt, sizeof (stmt),
     "SELECT "
       "CAST (DATABASE () AS VARCHAR (255)) AS [synonym_catalog], " /* string -> varchar(255) */
       "[syn].[owner].[name] AS [synonym_schema], "
@@ -853,6 +866,7 @@ const char *sm_define_view_synonyms_spec (void)
     "WHERE "
       AUTH_CHECK_SYNONYM("[syn].[is_public]", "[syn].[owner].[name]"),
     CT_SYNONYM_NAME);
+  assert(n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -863,7 +877,7 @@ const char *sm_define_view_table_constraints_spec (void)
   static char stmt [4096];
 
   // *INDENT-OFF*
-  snprintf (stmt, sizeof (stmt),
+  int n = snprintf (stmt, sizeof (stmt),
     "SELECT "
       "CAST (DATABASE () AS VARCHAR (255)) AS [constraint_catalog], " /* string -> varchar(255) */
       "[idx].[class_of].[owner].[name] AS [constraint_schema], "
@@ -887,6 +901,7 @@ const char *sm_define_view_table_constraints_spec (void)
       AUTH_CHECK_OBJECT_WRITE("[idx].[class_of].[owner].[name]", "[idx].[class_of].[class_of]") " "
       "AND ([idx].[is_primary_key] = 1 OR [idx].[is_unique] = 1 OR [idx].[is_foreign_key] = 1)",
     CT_INDEX_NAME);
+  assert(n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -897,7 +912,7 @@ const char *sm_define_view_table_privileges_spec (void)
   static char stmt [4096];
 
   // *INDENT-OFF*
-  snprintf (stmt, sizeof (stmt),
+  int n = snprintf (stmt, sizeof (stmt),
     "SELECT "
       "[auth].[grantor].[name] AS [grantor], "
       "[auth].[grantee].[name] AS [grantee], "
@@ -918,6 +933,7 @@ const char *sm_define_view_table_privileges_spec (void)
     CT_CLASSAUTH_NAME,
     CT_CLASS_NAME,
     DB_OBJECT_CLASS);
+  assert(n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -928,7 +944,7 @@ const char *sm_define_view_tables_spec (void)
   static char stmt [4096];
 
   // *INDENT-OFF*
-  snprintf (stmt, sizeof (stmt),
+  int n = snprintf (stmt, sizeof (stmt),
     "SELECT "
       "CAST (DATABASE () AS VARCHAR (255)) AS [table_catalog], " /* string -> varchar(255) */
       "[cls].[owner].[name] AS [table_schema], "
@@ -988,6 +1004,7 @@ const char *sm_define_view_tables_spec (void)
     CT_CLASS_NAME,
     CT_COLLATION_NAME,
     CT_SERIAL_NAME);
+  assert(n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -998,7 +1015,7 @@ const char *sm_define_view_triggers_spec (void)
   static char stmt [4096];
 
   // *INDENT-OFF*
-  snprintf (stmt, sizeof (stmt),
+  int n = snprintf (stmt, sizeof (stmt),
     "SELECT "
       "CAST (DATABASE () AS VARCHAR (255)) AS [trigger_catalog], " /* string -> varchar(255) */
       "[tr].[owner].[name] AS [trigger_schema], "
@@ -1051,6 +1068,7 @@ const char *sm_define_view_triggers_spec (void)
     TR_CLASS_NAME,
     CT_CLASS_NAME,
     TR_EVENT_UPDATE, TR_EVENT_STATEMENT_INSERT);
+  assert(n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -1061,7 +1079,7 @@ const char *sm_define_view_views_spec (void)
   static char stmt [4096];
 
   // *INDENT-OFF*
-  snprintf (stmt, sizeof (stmt),
+  int n = snprintf (stmt, sizeof (stmt),
     "SELECT "
       "CAST (DATABASE () AS VARCHAR (255)) AS [table_catalog], " /* string -> varchar(255) */
       "[q].[class_of].[owner].[name] AS [table_schema], "
@@ -1087,6 +1105,7 @@ const char *sm_define_view_views_spec (void)
     SM_CLASSFLAG_WITHCHECKOPTION,
     SM_CLASSFLAG_LOCALCHECKOPTION,
     CT_QUERYSPEC_NAME);
+  assert(n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;

--- a/src/object/schema_information_schema_install_query_spec.cpp
+++ b/src/object/schema_information_schema_install_query_spec.cpp
@@ -168,8 +168,8 @@ sm_define_view_column_privileges_spec (void)
     "WHERE "
       "FALSE",
     CT_DUAL_NAME);
-  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
+  assert (n > 0 && n < (int) sizeof (stmt));
 
   return stmt;
 }
@@ -301,8 +301,8 @@ sm_define_view_columns_spec (void)
     CT_COLLATION_NAME,
     CT_INDEXKEY_NAME,
     CT_INDEX_NAME);
-  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
+  assert (n > 0 && n < (int) sizeof (stmt));
 
   return stmt;
 }
@@ -346,8 +346,8 @@ sm_define_view_domains_spec (void)
     "WHERE "
       "FALSE",
     CT_DUAL_NAME);
-  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
+  assert (n > 0 && n < (int) sizeof (stmt));
 
   return stmt;
 }
@@ -381,8 +381,8 @@ sm_define_view_foreign_servers_spec (void)
     "WHERE "
       AUTH_CHECK_OBJECT_ANY("[srv].[owner].[name]", "[srv]"),
     CT_SERVER_NAME);
-  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
+  assert (n > 0 && n < (int) sizeof (stmt));
 
   return stmt;
 }
@@ -421,8 +421,8 @@ sm_define_view_key_column_usage_spec (void)
     CT_INDEXKEY_NAME,
     CT_INDEX_NAME,
     CT_INDEXKEY_NAME);
-  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
+  assert (n > 0 && n < (int) sizeof (stmt));
 
   return stmt;
 }
@@ -477,8 +477,8 @@ sm_define_view_parameters_spec (void)
     SP_TYPE_PROCEDURE, SP_TYPE_FUNCTION,
     CT_STORED_PROC_ARGS_NAME,
     CT_DATATYPE_NAME);
-  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
+  assert (n > 0 && n < (int) sizeof (stmt));
 
   return stmt;
 }
@@ -529,8 +529,8 @@ sm_define_view_partitions_spec (void)
     DB_PARTITION_LIST,
     CT_PARTITION_NAME,
     CT_CLASS_NAME);
-  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
+  assert (n > 0 && n < (int) sizeof (stmt));
 
   return stmt;
 }
@@ -574,8 +574,8 @@ sm_define_view_referential_constraints_spec (void)
     SM_FOREIGN_KEY_NO_ACTION,
     SM_FOREIGN_KEY_SET_NULL,
     CT_INDEX_NAME);
-  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
+  assert (n > 0 && n < (int) sizeof (stmt));
 
   return stmt;
 }
@@ -610,8 +610,8 @@ sm_define_view_routine_privileges_spec (void)
     CT_CLASSAUTH_NAME,
     CT_STORED_PROC_NAME,
     DB_OBJECT_PROCEDURE);
-  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
+  assert (n > 0 && n < (int) sizeof (stmt));
 
   return stmt;
 }
@@ -711,8 +711,8 @@ sm_define_view_routines_spec (void)
     CT_STORED_PROC_CODE_NAME,
     CT_ROOT_NAME,
     CT_CHARSET_NAME);
-  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
+  assert (n > 0 && n < (int) sizeof (stmt));
 
   return stmt;
 }
@@ -747,8 +747,8 @@ sm_define_view_schemata_spec (void)
     AU_USER_CLASS_NAME,
     CT_ROOT_NAME,
     CT_CHARSET_NAME);
-  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
+  assert (n > 0 && n < (int) sizeof (stmt));
 
   return stmt;
 }
@@ -788,8 +788,8 @@ sm_define_view_sequences_spec (void)
     DB_MAX_NUMERIC_PRECISION,
     DB_DEFAULT_NUMERIC_SCALE,
     CT_SERIAL_NAME);
-  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
+  assert (n > 0 && n < (int) sizeof (stmt));
 
   return stmt;
 }
@@ -850,8 +850,8 @@ sm_define_view_statistics_spec (void)
     CT_INDEX_NAME,
     CT_CLASS_NAME,
     CT_ATTRIBUTE_NAME);
-  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
+  assert (n > 0 && n < (int) sizeof (stmt));
 
   return stmt;
 }
@@ -880,8 +880,8 @@ sm_define_view_synonyms_spec (void)
     "WHERE "
       AUTH_CHECK_SYNONYM("[syn].[is_public]", "[syn].[owner].[name]"),
     CT_SYNONYM_NAME);
-  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
+  assert (n > 0 && n < (int) sizeof (stmt));
 
   return stmt;
 }
@@ -916,8 +916,8 @@ sm_define_view_table_constraints_spec (void)
       AUTH_CHECK_OBJECT_WRITE("[idx].[class_of].[owner].[name]", "[idx].[class_of].[class_of]") " "
       "AND ([idx].[is_primary_key] = 1 OR [idx].[is_unique] = 1 OR [idx].[is_foreign_key] = 1)",
     CT_INDEX_NAME);
-  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
+  assert (n > 0 && n < (int) sizeof (stmt));
 
   return stmt;
 }
@@ -949,8 +949,8 @@ sm_define_view_table_privileges_spec (void)
     CT_CLASSAUTH_NAME,
     CT_CLASS_NAME,
     DB_OBJECT_CLASS);
-  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
+  assert (n > 0 && n < (int) sizeof (stmt));
 
   return stmt;
 }
@@ -1021,8 +1021,8 @@ sm_define_view_tables_spec (void)
     CT_CLASS_NAME,
     CT_COLLATION_NAME,
     CT_SERIAL_NAME);
-  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
+  assert (n > 0 && n < (int) sizeof (stmt));
 
   return stmt;
 }
@@ -1086,8 +1086,8 @@ sm_define_view_triggers_spec (void)
     TR_CLASS_NAME,
     CT_CLASS_NAME,
     TR_EVENT_UPDATE, TR_EVENT_STATEMENT_INSERT);
-  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
+  assert (n > 0 && n < (int) sizeof (stmt));
 
   return stmt;
 }
@@ -1124,8 +1124,8 @@ sm_define_view_views_spec (void)
     SM_CLASSFLAG_WITHCHECKOPTION,
     SM_CLASSFLAG_LOCALCHECKOPTION,
     CT_QUERYSPEC_NAME);
-  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
+  assert (n > 0 && n < (int) sizeof (stmt));
 
   return stmt;
 }

--- a/src/object/schema_information_schema_install_query_spec.cpp
+++ b/src/object/schema_information_schema_install_query_spec.cpp
@@ -147,9 +147,10 @@
 /* CUBRID does not currently support column privilege.
  * This view returns empty results until column privilege support is implemented.
  */
-const char *sm_define_view_column_privileges_spec (void)
+std::string
+sm_define_view_column_privileges_spec (void)
 {
-  static char stmt [2048];
+  char stmt [2048];
 
   // *INDENT-OFF*
   int n = snprintf (stmt, sizeof (stmt),
@@ -173,9 +174,10 @@ const char *sm_define_view_column_privileges_spec (void)
   return stmt;
 }
 
-const char *sm_define_view_columns_spec (void)
+std::string
+sm_define_view_columns_spec (void)
 {
-  static char stmt [8192];
+  char stmt [8192];
 
   // *INDENT-OFF*
   int n = snprintf (stmt, sizeof (stmt),
@@ -308,9 +310,10 @@ const char *sm_define_view_columns_spec (void)
 /* CUBRID does not currently support domains.
  * This view returns empty results until domain support is implemented.
  */
-const char *sm_define_view_domains_spec (void)
+std::string
+sm_define_view_domains_spec (void)
 {
-  static char stmt [2048];
+  char stmt [2048];
 
   // *INDENT-OFF*
   int n = snprintf (stmt, sizeof (stmt),
@@ -349,9 +352,10 @@ const char *sm_define_view_domains_spec (void)
   return stmt;
 }
 
-const char *sm_define_view_foreign_servers_spec (void)
+std::string
+sm_define_view_foreign_servers_spec (void)
 {
-  static char stmt [4096];
+  char stmt [4096];
 
   // *INDENT-OFF*
   int n = snprintf (stmt, sizeof (stmt),
@@ -383,9 +387,10 @@ const char *sm_define_view_foreign_servers_spec (void)
   return stmt;
 }
 
-const char *sm_define_view_key_column_usage_spec (void)
+std::string
+sm_define_view_key_column_usage_spec (void)
 {
-  static char stmt [4096];
+  char stmt [4096];
 
   // *INDENT-OFF*
   int n = snprintf (stmt, sizeof (stmt),
@@ -422,9 +427,10 @@ const char *sm_define_view_key_column_usage_spec (void)
   return stmt;
 }
 
-const char *sm_define_view_parameters_spec (void)
+std::string
+sm_define_view_parameters_spec (void)
 {
-  static char stmt [4096];
+  char stmt [4096];
 
   // *INDENT-OFF*
   int n = snprintf (stmt, sizeof (stmt),
@@ -477,9 +483,10 @@ const char *sm_define_view_parameters_spec (void)
   return stmt;
 }
 
-const char *sm_define_view_partitions_spec (void)
+std::string
+sm_define_view_partitions_spec (void)
 {
-  static char stmt [4096];
+  char stmt [4096];
 
   // *INDENT-OFF*
   int n = snprintf (stmt, sizeof (stmt),
@@ -528,9 +535,10 @@ const char *sm_define_view_partitions_spec (void)
   return stmt;
 }
 
-const char *sm_define_view_referential_constraints_spec (void)
+std::string
+sm_define_view_referential_constraints_spec (void)
 {
-  static char stmt [4096];
+  char stmt [4096];
 
   // *INDENT-OFF*
   int n = snprintf (stmt, sizeof (stmt),
@@ -572,9 +580,10 @@ const char *sm_define_view_referential_constraints_spec (void)
   return stmt;
 }
 
-const char *sm_define_view_routine_privileges_spec (void)
+std::string
+sm_define_view_routine_privileges_spec (void)
 {
-  static char stmt [4096];
+  char stmt [4096];
 
   // *INDENT-OFF*
   int n = snprintf (stmt, sizeof (stmt),
@@ -607,9 +616,10 @@ const char *sm_define_view_routine_privileges_spec (void)
   return stmt;
 }
 
-const char *sm_define_view_routines_spec (void)
+std::string
+sm_define_view_routines_spec (void)
 {
-  static char stmt [4096];
+  char stmt [4096];
 
   // *INDENT-OFF*
   int n = snprintf (stmt, sizeof (stmt),
@@ -707,9 +717,10 @@ const char *sm_define_view_routines_spec (void)
   return stmt;
 }
 
-const char *sm_define_view_schemata_spec (void)
+std::string
+sm_define_view_schemata_spec (void)
 {
-  static char stmt [2048];
+  char stmt [2048];
 
   // *INDENT-OFF*
   int n = snprintf (stmt, sizeof (stmt),
@@ -742,9 +753,10 @@ const char *sm_define_view_schemata_spec (void)
   return stmt;
 }
 
-const char *sm_define_view_sequences_spec (void)
+std::string
+sm_define_view_sequences_spec (void)
 {
-  static char stmt [2048];
+  char stmt [2048];
 
   // *INDENT-OFF*
   int n = snprintf (stmt, sizeof (stmt),
@@ -782,9 +794,10 @@ const char *sm_define_view_sequences_spec (void)
   return stmt;
 }
 
-const char *sm_define_view_statistics_spec (void)
+std::string
+sm_define_view_statistics_spec (void)
 {
-  static char stmt [4096];
+  char stmt [4096];
 
   // *INDENT-OFF*
   int n = snprintf (stmt, sizeof (stmt),
@@ -843,9 +856,10 @@ const char *sm_define_view_statistics_spec (void)
   return stmt;
 }
 
-const char *sm_define_view_synonyms_spec (void)
+std::string
+sm_define_view_synonyms_spec (void)
 {
-  static char stmt [4096];
+  char stmt [4096];
 
   // *INDENT-OFF*
   int n = snprintf (stmt, sizeof (stmt),
@@ -872,9 +886,10 @@ const char *sm_define_view_synonyms_spec (void)
   return stmt;
 }
 
-const char *sm_define_view_table_constraints_spec (void)
+std::string
+sm_define_view_table_constraints_spec (void)
 {
-  static char stmt [4096];
+  char stmt [4096];
 
   // *INDENT-OFF*
   int n = snprintf (stmt, sizeof (stmt),
@@ -907,9 +922,10 @@ const char *sm_define_view_table_constraints_spec (void)
   return stmt;
 }
 
-const char *sm_define_view_table_privileges_spec (void)
+std::string
+sm_define_view_table_privileges_spec (void)
 {
-  static char stmt [4096];
+  char stmt [4096];
 
   // *INDENT-OFF*
   int n = snprintf (stmt, sizeof (stmt),
@@ -939,9 +955,10 @@ const char *sm_define_view_table_privileges_spec (void)
   return stmt;
 }
 
-const char *sm_define_view_tables_spec (void)
+std::string
+sm_define_view_tables_spec (void)
 {
-  static char stmt [4096];
+  char stmt [4096];
 
   // *INDENT-OFF*
   int n = snprintf (stmt, sizeof (stmt),
@@ -1010,9 +1027,10 @@ const char *sm_define_view_tables_spec (void)
   return stmt;
 }
 
-const char *sm_define_view_triggers_spec (void)
+std::string
+sm_define_view_triggers_spec (void)
 {
-  static char stmt [4096];
+  char stmt [4096];
 
   // *INDENT-OFF*
   int n = snprintf (stmt, sizeof (stmt),
@@ -1074,9 +1092,10 @@ const char *sm_define_view_triggers_spec (void)
   return stmt;
 }
 
-const char *sm_define_view_views_spec (void)
+std::string
+sm_define_view_views_spec (void)
 {
-  static char stmt [4096];
+  char stmt [4096];
 
   // *INDENT-OFF*
   int n = snprintf (stmt, sizeof (stmt),

--- a/src/object/schema_information_schema_install_query_spec.cpp
+++ b/src/object/schema_information_schema_install_query_spec.cpp
@@ -168,7 +168,7 @@ sm_define_view_column_privileges_spec (void)
     "WHERE "
       "FALSE",
     CT_DUAL_NAME);
-  assert(n < sizeof(stmt));
+  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -301,7 +301,7 @@ sm_define_view_columns_spec (void)
     CT_COLLATION_NAME,
     CT_INDEXKEY_NAME,
     CT_INDEX_NAME);
-  assert(n < sizeof(stmt));
+  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -346,7 +346,7 @@ sm_define_view_domains_spec (void)
     "WHERE "
       "FALSE",
     CT_DUAL_NAME);
-  assert(n < sizeof(stmt));
+  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -381,7 +381,7 @@ sm_define_view_foreign_servers_spec (void)
     "WHERE "
       AUTH_CHECK_OBJECT_ANY("[srv].[owner].[name]", "[srv]"),
     CT_SERVER_NAME);
-  assert(n < sizeof(stmt));
+  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -421,7 +421,7 @@ sm_define_view_key_column_usage_spec (void)
     CT_INDEXKEY_NAME,
     CT_INDEX_NAME,
     CT_INDEXKEY_NAME);
-  assert(n < sizeof(stmt));
+  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -477,7 +477,7 @@ sm_define_view_parameters_spec (void)
     SP_TYPE_PROCEDURE, SP_TYPE_FUNCTION,
     CT_STORED_PROC_ARGS_NAME,
     CT_DATATYPE_NAME);
-  assert(n < sizeof(stmt));
+  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -529,7 +529,7 @@ sm_define_view_partitions_spec (void)
     DB_PARTITION_LIST,
     CT_PARTITION_NAME,
     CT_CLASS_NAME);
-  assert(n < sizeof(stmt));
+  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -574,7 +574,7 @@ sm_define_view_referential_constraints_spec (void)
     SM_FOREIGN_KEY_NO_ACTION,
     SM_FOREIGN_KEY_SET_NULL,
     CT_INDEX_NAME);
-  assert(n < sizeof(stmt));
+  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -610,7 +610,7 @@ sm_define_view_routine_privileges_spec (void)
     CT_CLASSAUTH_NAME,
     CT_STORED_PROC_NAME,
     DB_OBJECT_PROCEDURE);
-  assert(n < sizeof(stmt));
+  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -711,7 +711,7 @@ sm_define_view_routines_spec (void)
     CT_STORED_PROC_CODE_NAME,
     CT_ROOT_NAME,
     CT_CHARSET_NAME);
-  assert(n < sizeof(stmt));
+  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -747,7 +747,7 @@ sm_define_view_schemata_spec (void)
     AU_USER_CLASS_NAME,
     CT_ROOT_NAME,
     CT_CHARSET_NAME);
-  assert(n < sizeof(stmt));
+  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -788,7 +788,7 @@ sm_define_view_sequences_spec (void)
     DB_MAX_NUMERIC_PRECISION,
     DB_DEFAULT_NUMERIC_SCALE,
     CT_SERIAL_NAME);
-  assert(n < sizeof(stmt));
+  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -850,7 +850,7 @@ sm_define_view_statistics_spec (void)
     CT_INDEX_NAME,
     CT_CLASS_NAME,
     CT_ATTRIBUTE_NAME);
-  assert(n < sizeof(stmt));
+  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -880,7 +880,7 @@ sm_define_view_synonyms_spec (void)
     "WHERE "
       AUTH_CHECK_SYNONYM("[syn].[is_public]", "[syn].[owner].[name]"),
     CT_SYNONYM_NAME);
-  assert(n < sizeof(stmt));
+  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -916,7 +916,7 @@ sm_define_view_table_constraints_spec (void)
       AUTH_CHECK_OBJECT_WRITE("[idx].[class_of].[owner].[name]", "[idx].[class_of].[class_of]") " "
       "AND ([idx].[is_primary_key] = 1 OR [idx].[is_unique] = 1 OR [idx].[is_foreign_key] = 1)",
     CT_INDEX_NAME);
-  assert(n < sizeof(stmt));
+  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -949,7 +949,7 @@ sm_define_view_table_privileges_spec (void)
     CT_CLASSAUTH_NAME,
     CT_CLASS_NAME,
     DB_OBJECT_CLASS);
-  assert(n < sizeof(stmt));
+  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -1021,7 +1021,7 @@ sm_define_view_tables_spec (void)
     CT_CLASS_NAME,
     CT_COLLATION_NAME,
     CT_SERIAL_NAME);
-  assert(n < sizeof(stmt));
+  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -1086,7 +1086,7 @@ sm_define_view_triggers_spec (void)
     TR_CLASS_NAME,
     CT_CLASS_NAME,
     TR_EVENT_UPDATE, TR_EVENT_STATEMENT_INSERT);
-  assert(n < sizeof(stmt));
+  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -1124,7 +1124,7 @@ sm_define_view_views_spec (void)
     SM_CLASSFLAG_WITHCHECKOPTION,
     SM_CLASSFLAG_LOCALCHECKOPTION,
     CT_QUERYSPEC_NAME);
-  assert(n < sizeof(stmt));
+  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;

--- a/src/object/schema_system_catalog_install.hpp
+++ b/src/object/schema_system_catalog_install.hpp
@@ -146,30 +146,30 @@ namespace cubschema
 } // namespace cubschema
 
 // TODO: move them to proper place
-const char *sm_define_view_class_spec (void);
-const char *sm_define_view_direct_super_class_spec (void);
-const char *sm_define_view_vclass_spec (void);
-const char *sm_define_view_attribute_spec (void);
-const char *sm_define_view_attr_setdomain_elm_spec (void);
-const char *sm_define_view_method_spec (void);
-const char *sm_define_view_method_arg_spec (void);
-const char *sm_define_view_meth_arg_setdomain_elm_spec (void);
-const char *sm_define_view_meth_file_spec (void);
-const char *sm_define_view_index_spec (void);
-const char *sm_define_view_index_key_spec (void);
-const char *sm_define_view_auth_spec (void);
-const char *sm_define_view_trigger_spec (void);
-const char *sm_define_view_partition_spec (void);
-const char *sm_define_view_stored_procedure_spec (void);
-const char *sm_define_view_stored_procedure_args_spec (void);
-const char *sm_define_view_serial_spec (void);
-const char *sm_define_view_ha_apply_info_spec (void);
-const char *sm_define_view_collation_spec (void);
-const char *sm_define_view_user_spec (void);
-const char *sm_define_view_authorization_spec (void);
-const char *sm_define_view_charset_spec (void);
-const char *sm_define_view_synonym_spec (void);
-const char *sm_define_view_server_spec (void);
-const char *sm_define_view_histogram_spec (void);
+std::string sm_define_view_class_spec (void);
+std::string sm_define_view_direct_super_class_spec (void);
+std::string sm_define_view_vclass_spec (void);
+std::string sm_define_view_attribute_spec (void);
+std::string sm_define_view_attr_setdomain_elm_spec (void);
+std::string sm_define_view_method_spec (void);
+std::string sm_define_view_method_arg_spec (void);
+std::string sm_define_view_meth_arg_setdomain_elm_spec (void);
+std::string sm_define_view_meth_file_spec (void);
+std::string sm_define_view_index_spec (void);
+std::string sm_define_view_index_key_spec (void);
+std::string sm_define_view_auth_spec (void);
+std::string sm_define_view_trigger_spec (void);
+std::string sm_define_view_partition_spec (void);
+std::string sm_define_view_stored_procedure_spec (void);
+std::string sm_define_view_stored_procedure_args_spec (void);
+std::string sm_define_view_serial_spec (void);
+std::string sm_define_view_ha_apply_info_spec (void);
+std::string sm_define_view_collation_spec (void);
+std::string sm_define_view_user_spec (void);
+std::string sm_define_view_authorization_spec (void);
+std::string sm_define_view_charset_spec (void);
+std::string sm_define_view_synonym_spec (void);
+std::string sm_define_view_server_spec (void);
+std::string sm_define_view_histogram_spec (void);
 
 #endif /* _SCHEMA_SYSTEM_CATALOG_INSTALL_HPP_ */

--- a/src/object/schema_system_catalog_install_query_spec.cpp
+++ b/src/object/schema_system_catalog_install_query_spec.cpp
@@ -142,8 +142,8 @@ sm_define_view_class_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
-  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
+  assert (n > 0 && n < (int) sizeof (stmt));
 
   return stmt;
 }
@@ -205,8 +205,8 @@ sm_define_view_direct_super_class_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
-  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
+  assert (n > 0 && n < (int) sizeof (stmt));
 
   return stmt;
 }
@@ -278,8 +278,8 @@ sm_define_view_vclass_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
-  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
+  assert (n > 0 && n < (int) sizeof (stmt));
 
   return stmt;
 }
@@ -389,8 +389,8 @@ sm_define_view_attribute_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
-  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
+  assert (n > 0 && n < (int) sizeof (stmt));
 
   return stmt;
 }
@@ -472,8 +472,8 @@ sm_define_view_attr_setdomain_elm_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
-  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
+  assert (n > 0 && n < (int) sizeof (stmt));
 
   return stmt;
 }
@@ -545,8 +545,8 @@ sm_define_view_method_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
-  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
+  assert (n > 0 && n < (int) sizeof (stmt));
 
   return stmt;
 }
@@ -629,8 +629,8 @@ sm_define_view_method_arg_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
-  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
+  assert (n > 0 && n < (int) sizeof (stmt));
 
   return stmt;
 }
@@ -713,8 +713,8 @@ sm_define_view_meth_arg_setdomain_elm_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
-  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
+  assert (n > 0 && n < (int) sizeof (stmt));
 
   return stmt;
 }
@@ -777,8 +777,8 @@ sm_define_view_meth_file_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
-  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
+  assert (n > 0 && n < (int) sizeof (stmt));
 
   return stmt;
 }
@@ -908,8 +908,8 @@ sm_define_view_index_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
-  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
+  assert (n > 0 && n < (int) sizeof (stmt));
 
   return stmt;
 }
@@ -981,8 +981,8 @@ sm_define_view_index_key_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
-  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
+  assert (n > 0 && n < (int) sizeof (stmt));
 
   return stmt;
 }
@@ -1057,8 +1057,8 @@ sm_define_view_auth_spec (void)
         CT_STORED_PROC_NAME,
 	AU_USER_CLASS_NAME
         );
-  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
+  assert (n > 0 && n < (int) sizeof (stmt));
 
   return stmt;
 }
@@ -1130,8 +1130,8 @@ sm_define_view_trigger_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
-  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
+  assert (n > 0 && n < (int) sizeof (stmt));
 
   return stmt;
 }
@@ -1210,8 +1210,8 @@ sm_define_view_partition_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
-  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
+  assert (n > 0 && n < (int) sizeof (stmt));
 
   return stmt;
 }
@@ -1327,8 +1327,8 @@ sm_define_view_stored_procedure_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
-  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
+  assert (n > 0 && n < (int) sizeof (stmt));
 
   return stmt;
 }
@@ -1407,8 +1407,8 @@ sm_define_view_stored_procedure_args_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
-  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
+  assert (n > 0 && n < (int) sizeof (stmt));
 
   return stmt;
 }
@@ -1443,8 +1443,8 @@ sm_define_view_serial_spec (void)
         "WHERE "
           "[serial].[class_name] IS NULL",
         CT_SERIAL_NAME);
-  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
+  assert (n > 0 && n < (int) sizeof (stmt));
 
   return stmt;
 }
@@ -1487,8 +1487,8 @@ sm_define_view_ha_apply_info_spec (void)
 	  /* CT_HA_APPLY_INFO_NAME */
           "[%s] AS [log_stat] ",
         CT_HA_APPLY_INFO_NAME);
-  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
+  assert (n > 0 && n < (int) sizeof (stmt));
 
   return stmt;
 }
@@ -1525,8 +1525,8 @@ sm_define_view_collation_spec (void)
 	  "[coll].[coll_id]",
 	CT_COLLATION_NAME,
 	CT_CHARSET_NAME);
-  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
+  assert (n > 0 && n < (int) sizeof (stmt));
 
   return stmt;
 }
@@ -1568,8 +1568,8 @@ sm_define_view_user_spec (void)
 	  ") SETNEQ {}",
 	CT_USER_NAME,
 	CT_USER_NAME);
-  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
+  assert (n > 0 && n < (int) sizeof (stmt));
 
   return stmt;
 }
@@ -1599,8 +1599,8 @@ sm_define_view_authorization_spec (void)
 	  ") SETNEQ {}",
 	CT_AUTHORIZATION_NAME,
 	AU_USER_CLASS_NAME);
-  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
+  assert (n > 0 && n < (int) sizeof (stmt));
 
   return stmt;
 }
@@ -1628,8 +1628,8 @@ sm_define_view_charset_spec (void)
 	  "[ch].[charset_id]",
 	CT_CHARSET_NAME,
 	CT_COLLATION_NAME);
-  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
+  assert (n > 0 && n < (int) sizeof (stmt));
 
   return stmt;
 }
@@ -1679,8 +1679,8 @@ sm_define_view_synonym_spec (void)
 	CT_SYNONYM_NAME,
 	AU_USER_CLASS_NAME,
 	AU_USER_CLASS_NAME);
-  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
+  assert (n > 0 && n < (int) sizeof (stmt));
 
   return stmt;
 }
@@ -1750,8 +1750,8 @@ sm_define_view_server_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
-  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
+  assert (n > 0 && n < (int) sizeof (stmt));
 
   return stmt;
 }
@@ -1775,8 +1775,8 @@ sm_define_view_histogram_spec (void)
 	  "[h].[class_of], "
 	  "[h].[key_attr]",
 	CT_HISTOGRAM_NAME);
-  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
+  assert (n > 0 && n < (int) sizeof (stmt));
 
   return stmt;
 }

--- a/src/object/schema_system_catalog_install_query_spec.cpp
+++ b/src/object/schema_system_catalog_install_query_spec.cpp
@@ -65,7 +65,7 @@ sm_define_view_class_spec (void)
   static char stmt [2048];
 
   // *INDENT-OFF*
-  sprintf (stmt,
+  snprintf (stmt, sizeof(stmt),
 	"SELECT "
 	  "[c].[class_name] AS [class_name], "
 	  "[c].[owner].[name] AS [owner_name], "
@@ -153,7 +153,7 @@ sm_define_view_direct_super_class_spec (void)
   static char stmt [2048];
 
   // *INDENT-OFF*
-  sprintf (stmt,
+  snprintf (stmt, sizeof(stmt),
 	"SELECT "
 	  "[c].[class_name] AS [class_name], "
 	  "[c].[owner].[name] AS [owner_name], "
@@ -215,7 +215,7 @@ sm_define_view_vclass_spec (void)
   static char stmt [2048];
 
   // *INDENT-OFF*
-  sprintf (stmt,
+  snprintf (stmt, sizeof(stmt),
 	"SELECT "
 	  "[q].[class_of].[class_name] AS [vclass_name], "
 	  "[q].[class_of].[owner].[name] AS [owner_name], "
@@ -287,7 +287,7 @@ sm_define_view_attribute_spec (void)
   static char stmt [4096];
 
   // *INDENT-OFF*
-  sprintf (stmt,
+  snprintf (stmt, sizeof(stmt),
 	"SELECT "
 	  "[a].[attr_name] AS [attr_name], "
 	  "[c].[class_name] AS [class_name], "
@@ -397,7 +397,7 @@ sm_define_view_attr_setdomain_elm_spec (void)
   static char stmt [2048];
 
   // *INDENT-OFF*
-  sprintf (stmt,
+  snprintf (stmt, sizeof(stmt),
 	"SELECT "
 	  "[a].[attr_name] AS [attr_name], "
 	  "[c].[class_name] AS [class_name], "
@@ -479,7 +479,7 @@ sm_define_view_method_spec (void)
   static char stmt [2048];
 
   // *INDENT-OFF*
-  sprintf (stmt,
+  snprintf (stmt, sizeof(stmt),
 	"SELECT "
 	  "[m].[meth_name] AS [meth_name], "
 	  "[m].[class_of].[class_name] AS [class_name], "
@@ -551,7 +551,7 @@ sm_define_view_method_arg_spec (void)
   static char stmt [2048];
 
   // *INDENT-OFF*
-  sprintf (stmt,
+  snprintf (stmt, sizeof(stmt),
 	"SELECT "
 	  "[s].[meth_of].[meth_name] AS [meth_name], "
 	  "[s].[meth_of].[class_of].[class_name] AS [class_name], "
@@ -634,7 +634,7 @@ sm_define_view_meth_arg_setdomain_elm_spec (void)
   static char stmt [2048];
 
   // *INDENT-OFF*
-  sprintf (stmt,
+  snprintf (stmt, sizeof(stmt),
 	"SELECT "
 	  "[s].[meth_of].[meth_name] AS [meth_name], "
 	  "[s].[meth_of].[class_of].[class_name] AS [class_name], "
@@ -717,7 +717,7 @@ sm_define_view_meth_file_spec (void)
   static char stmt [2048];
 
   // *INDENT-OFF*
-  sprintf (stmt,
+  snprintf (stmt, sizeof(stmt),
 	"SELECT "
 	  "[f].[class_of].[class_name] AS [class_name], "
 	  "[f].[class_of].[owner].[name] AS [owner_name], "
@@ -780,7 +780,7 @@ sm_define_view_index_spec (void)
   static char stmt [4096];
 
   // *INDENT-OFF*
-  sprintf (stmt,
+  snprintf (stmt, sizeof(stmt),
 	"SELECT "
 	  "[i].[index_name] AS [index_name], "
 	  "CASE [i].[is_unique] WHEN 0 THEN 'NO' ELSE 'YES' END AS [is_unique], "
@@ -910,7 +910,7 @@ sm_define_view_index_key_spec (void)
   static char stmt [2048];
 
   // *INDENT-OFF*
-  sprintf (stmt,
+  snprintf (stmt, sizeof(stmt),
 	"SELECT "
 	  "[k].[index_of].[index_name] AS [index_name], "
 	  "[k].[index_of].[class_of].[class_name] AS [class_name], "
@@ -982,7 +982,7 @@ sm_define_view_auth_spec (void)
   static char stmt [4096];
 
   // *INDENT-OFF*
-  sprintf (stmt,
+  snprintf (stmt, sizeof(stmt),
 	"SELECT "
 	  "[a].[grantor].[name] AS [grantor_name], "
 	  "[a].[grantee].[name] AS [grantee_name], "
@@ -1057,7 +1057,7 @@ sm_define_view_trigger_spec (void)
   static char stmt [2048];
 
   // *INDENT-OFF*
-  sprintf (stmt,
+  snprintf (stmt, sizeof(stmt),
 	"SELECT "
 	  "CAST ([t].[name] AS VARCHAR (255)) AS [trigger_name], " /* string -> varchar(255) */
 	  "[t].[owner].[name] AS [owner_name], "
@@ -1129,7 +1129,7 @@ sm_define_view_partition_spec (void)
   static char stmt [2048];
 
   // *INDENT-OFF*
-  sprintf (stmt,
+  snprintf (stmt, sizeof(stmt),
 	"SELECT "
 	  "[s].[class_name] AS [class_name], "
 	  "[s].[owner].[name] AS [owner_name], "
@@ -1208,7 +1208,7 @@ sm_define_view_stored_procedure_spec (void)
   static char stmt [4096];
 
   // *INDENT-OFF*
-  sprintf (stmt,
+  snprintf (stmt, sizeof(stmt),
 	"SELECT "
 	  "[sp].[sp_name] AS [sp_name], "
           "[sp].[pkg_name] AS [pkg_name], "
@@ -1324,7 +1324,7 @@ sm_define_view_stored_procedure_args_spec (void)
   static char stmt [2048];
 
   // *INDENT-OFF*
-  sprintf (stmt,
+  snprintf (stmt, sizeof(stmt),
 	"SELECT "
 	  "[sp].[sp_of].[sp_name] AS [sp_name], "
 	  "[sp].[sp_of].[owner].[name] AS [sp_owner_name], "
@@ -1403,7 +1403,7 @@ sm_define_view_serial_spec (void)
   static char stmt [2048];
 
   // *INDENT-OFF*
-  sprintf (stmt,
+  snprintf (stmt, sizeof(stmt),
         "SELECT "
           "[serial].[unique_name] AS [unique_name], "
           "[serial].[name] AS [name], "
@@ -1438,7 +1438,7 @@ sm_define_view_ha_apply_info_spec (void)
   static char stmt [2048];
 
   // *INDENT-OFF*
-  sprintf (stmt,
+  snprintf (stmt, sizeof(stmt),
         "SELECT "
           "[log_stat].[db_name] AS [db_name], "
           "[log_stat].[db_creation_time] AS [db_creation_time], "
@@ -1481,7 +1481,7 @@ sm_define_view_collation_spec (void)
   static char stmt [2048];
 
   // *INDENT-OFF*
-  sprintf (stmt,
+  snprintf (stmt, sizeof(stmt),
 	"SELECT "
 	  "[coll].[coll_id] AS [coll_id], "
 	  "[coll].[coll_name] AS [coll_name], "
@@ -1518,7 +1518,7 @@ sm_define_view_user_spec (void)
   static char stmt [2048];
 
   // *INDENT-OFF*
-  sprintf (stmt,
+  snprintf (stmt, sizeof(stmt),
 	"SELECT "
 	  "[u].[name] AS [name], "
 	  "[u].[id] AS [id], "
@@ -1560,7 +1560,7 @@ sm_define_view_authorization_spec (void)
   static char stmt [2048];
 
   // *INDENT-OFF*
-  sprintf (stmt,
+  snprintf (stmt, sizeof(stmt),
 	"SELECT "
 	  "[a].[owner].[name] AS [owner], "
 	  "[a].[grants] AS [grants] "
@@ -1590,7 +1590,7 @@ sm_define_view_charset_spec (void)
   static char stmt [2048];
 
   // *INDENT-OFF*
-  sprintf (stmt,
+  snprintf (stmt, sizeof(stmt),
 	"SELECT "
 	  "[ch].[charset_id] AS [charset_id], "
 	  "[ch].[charset_name] AS [charset_name], "
@@ -1618,7 +1618,7 @@ sm_define_view_synonym_spec (void)
   static char stmt [2048];
 
   // *INDENT-OFF*
-  sprintf (stmt,
+  snprintf (stmt, sizeof(stmt),
 	"SELECT "
 	  "[s].[name] AS [synonym_name], "
 	  "[s].[owner].[name] AS [synonym_owner_name], "
@@ -1668,7 +1668,7 @@ sm_define_view_server_spec (void)
   static char stmt [2048];
 
   // *INDENT-OFF*
-  sprintf (stmt,
+  snprintf (stmt, sizeof(stmt),
 	"SELECT "
 	  "[ds].[link_name] AS [link_name], "
 	  "[ds].[host] AS [host], "
@@ -1738,7 +1738,7 @@ sm_define_view_histogram_spec (void)
   static char stmt [2048];
 
   // *INDENT-OFF*
-  sprintf (stmt,
+  snprintf (stmt, sizeof(stmt),
 	"SELECT "
 	  "[h].[class_of] AS [class_name], "
 	  "[h].[key_attr] AS [key_attr], "

--- a/src/object/schema_system_catalog_install_query_spec.cpp
+++ b/src/object/schema_system_catalog_install_query_spec.cpp
@@ -60,7 +60,6 @@
  */
 
 std::string
-
 sm_define_view_class_spec (void)
 {
   char stmt [2048];
@@ -150,7 +149,6 @@ sm_define_view_class_spec (void)
 }
 
 std::string
-
 sm_define_view_direct_super_class_spec (void)
 {
   char stmt [2048];
@@ -214,7 +212,6 @@ sm_define_view_direct_super_class_spec (void)
 }
 
 std::string
-
 sm_define_view_vclass_spec (void)
 {
   char stmt [2048];
@@ -288,7 +285,6 @@ sm_define_view_vclass_spec (void)
 }
 
 std::string
-
 sm_define_view_attribute_spec (void)
 {
   char stmt [4096];
@@ -400,7 +396,6 @@ sm_define_view_attribute_spec (void)
 }
 
 std::string
-
 sm_define_view_attr_setdomain_elm_spec (void)
 {
   char stmt [2048];
@@ -484,7 +479,6 @@ sm_define_view_attr_setdomain_elm_spec (void)
 }
 
 std::string
-
 sm_define_view_method_spec (void)
 {
   char stmt [2048];
@@ -558,7 +552,6 @@ sm_define_view_method_spec (void)
 }
 
 std::string
-
 sm_define_view_method_arg_spec (void)
 {
   char stmt [2048];
@@ -643,7 +636,6 @@ sm_define_view_method_arg_spec (void)
 }
 
 std::string
-
 sm_define_view_meth_arg_setdomain_elm_spec (void)
 {
   char stmt [2048];
@@ -728,7 +720,6 @@ sm_define_view_meth_arg_setdomain_elm_spec (void)
 }
 
 std::string
-
 sm_define_view_meth_file_spec (void)
 {
   char stmt [2048];
@@ -793,7 +784,6 @@ sm_define_view_meth_file_spec (void)
 }
 
 std::string
-
 sm_define_view_index_spec (void)
 {
   char stmt [4096];
@@ -925,7 +915,6 @@ sm_define_view_index_spec (void)
 }
 
 std::string
-
 sm_define_view_index_key_spec (void)
 {
   char stmt [2048];
@@ -999,7 +988,6 @@ sm_define_view_index_key_spec (void)
 }
 
 std::string
-
 sm_define_view_auth_spec (void)
 {
   char stmt [4096];
@@ -1076,7 +1064,6 @@ sm_define_view_auth_spec (void)
 }
 
 std::string
-
 sm_define_view_trigger_spec (void)
 {
   char stmt [2048];
@@ -1150,7 +1137,6 @@ sm_define_view_trigger_spec (void)
 }
 
 std::string
-
 sm_define_view_partition_spec (void)
 {
   char stmt [2048];
@@ -1231,7 +1217,6 @@ sm_define_view_partition_spec (void)
 }
 
 std::string
-
 sm_define_view_stored_procedure_spec (void)
 {
   char stmt [4096];
@@ -1349,7 +1334,6 @@ sm_define_view_stored_procedure_spec (void)
 }
 
 std::string
-
 sm_define_view_stored_procedure_args_spec (void)
 {
   char stmt [2048];
@@ -1430,7 +1414,6 @@ sm_define_view_stored_procedure_args_spec (void)
 }
 
 std::string
-
 sm_define_view_serial_spec (void)
 {
   char stmt [2048];
@@ -1467,7 +1450,6 @@ sm_define_view_serial_spec (void)
 }
 
 std::string
-
 sm_define_view_ha_apply_info_spec (void)
 {
   char stmt [2048];
@@ -1512,7 +1494,6 @@ sm_define_view_ha_apply_info_spec (void)
 }
 
 std::string
-
 sm_define_view_collation_spec (void)
 {
   char stmt [2048];
@@ -1551,7 +1532,6 @@ sm_define_view_collation_spec (void)
 }
 
 std::string
-
 sm_define_view_user_spec (void)
 {
   char stmt [2048];
@@ -1595,7 +1575,6 @@ sm_define_view_user_spec (void)
 }
 
 std::string
-
 sm_define_view_authorization_spec (void)
 {
   char stmt [2048];
@@ -1627,7 +1606,6 @@ sm_define_view_authorization_spec (void)
 }
 
 std::string
-
 sm_define_view_charset_spec (void)
 {
   char stmt [2048];
@@ -1657,7 +1635,6 @@ sm_define_view_charset_spec (void)
 }
 
 std::string
-
 sm_define_view_synonym_spec (void)
 {
   char stmt [2048];
@@ -1709,7 +1686,6 @@ sm_define_view_synonym_spec (void)
 }
 
 std::string
-
 sm_define_view_server_spec (void)
 {
   char stmt [2048];
@@ -1781,7 +1757,6 @@ sm_define_view_server_spec (void)
 }
 
 std::string
-
 sm_define_view_histogram_spec (void)
 {
   char stmt [2048];

--- a/src/object/schema_system_catalog_install_query_spec.cpp
+++ b/src/object/schema_system_catalog_install_query_spec.cpp
@@ -65,7 +65,7 @@ sm_define_view_class_spec (void)
   static char stmt [2048];
 
   // *INDENT-OFF*
-  snprintf (stmt, sizeof(stmt),
+  int n = snprintf (stmt, sizeof(stmt),
 	"SELECT "
 	  "[c].[class_name] AS [class_name], "
 	  "[c].[owner].[name] AS [owner_name], "
@@ -142,6 +142,7 @@ sm_define_view_class_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
+  assert(n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -153,7 +154,7 @@ sm_define_view_direct_super_class_spec (void)
   static char stmt [2048];
 
   // *INDENT-OFF*
-  snprintf (stmt, sizeof(stmt),
+  int n = snprintf (stmt, sizeof(stmt),
 	"SELECT "
 	  "[c].[class_name] AS [class_name], "
 	  "[c].[owner].[name] AS [owner_name], "
@@ -204,6 +205,7 @@ sm_define_view_direct_super_class_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
+  assert(n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -215,7 +217,7 @@ sm_define_view_vclass_spec (void)
   static char stmt [2048];
 
   // *INDENT-OFF*
-  snprintf (stmt, sizeof(stmt),
+  int n = snprintf (stmt, sizeof(stmt),
 	"SELECT "
 	  "[q].[class_of].[class_name] AS [vclass_name], "
 	  "[q].[class_of].[owner].[name] AS [owner_name], "
@@ -276,6 +278,7 @@ sm_define_view_vclass_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
+  assert(n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -287,7 +290,7 @@ sm_define_view_attribute_spec (void)
   static char stmt [4096];
 
   // *INDENT-OFF*
-  snprintf (stmt, sizeof(stmt),
+  int n = snprintf (stmt, sizeof(stmt),
 	"SELECT "
 	  "[a].[attr_name] AS [attr_name], "
 	  "[c].[class_name] AS [class_name], "
@@ -386,6 +389,7 @@ sm_define_view_attribute_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
+  assert(n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -397,7 +401,7 @@ sm_define_view_attr_setdomain_elm_spec (void)
   static char stmt [2048];
 
   // *INDENT-OFF*
-  snprintf (stmt, sizeof(stmt),
+  int n = snprintf (stmt, sizeof(stmt),
 	"SELECT "
 	  "[a].[attr_name] AS [attr_name], "
 	  "[c].[class_name] AS [class_name], "
@@ -468,6 +472,7 @@ sm_define_view_attr_setdomain_elm_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
+  assert(n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -479,7 +484,7 @@ sm_define_view_method_spec (void)
   static char stmt [2048];
 
   // *INDENT-OFF*
-  snprintf (stmt, sizeof(stmt),
+  int n = snprintf (stmt, sizeof(stmt),
 	"SELECT "
 	  "[m].[meth_name] AS [meth_name], "
 	  "[m].[class_of].[class_name] AS [class_name], "
@@ -540,6 +545,7 @@ sm_define_view_method_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
+  assert(n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -551,7 +557,7 @@ sm_define_view_method_arg_spec (void)
   static char stmt [2048];
 
   // *INDENT-OFF*
-  snprintf (stmt, sizeof(stmt),
+  int n = snprintf (stmt, sizeof(stmt),
 	"SELECT "
 	  "[s].[meth_of].[meth_name] AS [meth_name], "
 	  "[s].[meth_of].[class_of].[class_name] AS [class_name], "
@@ -623,6 +629,7 @@ sm_define_view_method_arg_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
+  assert(n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -634,7 +641,7 @@ sm_define_view_meth_arg_setdomain_elm_spec (void)
   static char stmt [2048];
 
   // *INDENT-OFF*
-  snprintf (stmt, sizeof(stmt),
+  int n = snprintf (stmt, sizeof(stmt),
 	"SELECT "
 	  "[s].[meth_of].[meth_name] AS [meth_name], "
 	  "[s].[meth_of].[class_of].[class_name] AS [class_name], "
@@ -706,6 +713,7 @@ sm_define_view_meth_arg_setdomain_elm_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
+  assert(n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -717,7 +725,7 @@ sm_define_view_meth_file_spec (void)
   static char stmt [2048];
 
   // *INDENT-OFF*
-  snprintf (stmt, sizeof(stmt),
+  int n = snprintf (stmt, sizeof(stmt),
 	"SELECT "
 	  "[f].[class_of].[class_name] AS [class_name], "
 	  "[f].[class_of].[owner].[name] AS [owner_name], "
@@ -769,6 +777,7 @@ sm_define_view_meth_file_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
+  assert(n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -780,7 +789,7 @@ sm_define_view_index_spec (void)
   static char stmt [4096];
 
   // *INDENT-OFF*
-  snprintf (stmt, sizeof(stmt),
+  int n = snprintf (stmt, sizeof(stmt),
 	"SELECT "
 	  "[i].[index_name] AS [index_name], "
 	  "CASE [i].[is_unique] WHEN 0 THEN 'NO' ELSE 'YES' END AS [is_unique], "
@@ -899,6 +908,7 @@ sm_define_view_index_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
+  assert(n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -910,7 +920,7 @@ sm_define_view_index_key_spec (void)
   static char stmt [2048];
 
   // *INDENT-OFF*
-  snprintf (stmt, sizeof(stmt),
+  int n = snprintf (stmt, sizeof(stmt),
 	"SELECT "
 	  "[k].[index_of].[index_name] AS [index_name], "
 	  "[k].[index_of].[class_of].[class_name] AS [class_name], "
@@ -971,6 +981,7 @@ sm_define_view_index_key_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
+  assert(n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -982,7 +993,7 @@ sm_define_view_auth_spec (void)
   static char stmt [4096];
 
   // *INDENT-OFF*
-  snprintf (stmt, sizeof(stmt),
+  int n = snprintf (stmt, sizeof(stmt),
 	"SELECT "
 	  "[a].[grantor].[name] AS [grantor_name], "
 	  "[a].[grantee].[name] AS [grantee_name], "
@@ -1046,6 +1057,7 @@ sm_define_view_auth_spec (void)
         CT_STORED_PROC_NAME,
 	AU_USER_CLASS_NAME
         );
+  assert(n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -1057,7 +1069,7 @@ sm_define_view_trigger_spec (void)
   static char stmt [2048];
 
   // *INDENT-OFF*
-  snprintf (stmt, sizeof(stmt),
+  int n = snprintf (stmt, sizeof(stmt),
 	"SELECT "
 	  "CAST ([t].[name] AS VARCHAR (255)) AS [trigger_name], " /* string -> varchar(255) */
 	  "[t].[owner].[name] AS [owner_name], "
@@ -1118,6 +1130,7 @@ sm_define_view_trigger_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
+  assert(n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -1129,7 +1142,7 @@ sm_define_view_partition_spec (void)
   static char stmt [2048];
 
   // *INDENT-OFF*
-  snprintf (stmt, sizeof(stmt),
+  int n = snprintf (stmt, sizeof(stmt),
 	"SELECT "
 	  "[s].[class_name] AS [class_name], "
 	  "[s].[owner].[name] AS [owner_name], "
@@ -1197,6 +1210,7 @@ sm_define_view_partition_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
+  assert(n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -1208,7 +1222,7 @@ sm_define_view_stored_procedure_spec (void)
   static char stmt [4096];
 
   // *INDENT-OFF*
-  snprintf (stmt, sizeof(stmt),
+  int n = snprintf (stmt, sizeof(stmt),
 	"SELECT "
 	  "[sp].[sp_name] AS [sp_name], "
           "[sp].[pkg_name] AS [pkg_name], "
@@ -1313,6 +1327,7 @@ sm_define_view_stored_procedure_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
+  assert(n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -1324,7 +1339,7 @@ sm_define_view_stored_procedure_args_spec (void)
   static char stmt [2048];
 
   // *INDENT-OFF*
-  snprintf (stmt, sizeof(stmt),
+  int n = snprintf (stmt, sizeof(stmt),
 	"SELECT "
 	  "[sp].[sp_of].[sp_name] AS [sp_name], "
 	  "[sp].[sp_of].[owner].[name] AS [sp_owner_name], "
@@ -1392,6 +1407,7 @@ sm_define_view_stored_procedure_args_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
+  assert(n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -1403,7 +1419,7 @@ sm_define_view_serial_spec (void)
   static char stmt [2048];
 
   // *INDENT-OFF*
-  snprintf (stmt, sizeof(stmt),
+  int n = snprintf (stmt, sizeof(stmt),
         "SELECT "
           "[serial].[unique_name] AS [unique_name], "
           "[serial].[name] AS [name], "
@@ -1427,6 +1443,7 @@ sm_define_view_serial_spec (void)
         "WHERE "
           "[serial].[class_name] IS NULL",
         CT_SERIAL_NAME);
+  assert(n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -1438,7 +1455,7 @@ sm_define_view_ha_apply_info_spec (void)
   static char stmt [2048];
 
   // *INDENT-OFF*
-  snprintf (stmt, sizeof(stmt),
+  int n = snprintf (stmt, sizeof(stmt),
         "SELECT "
           "[log_stat].[db_name] AS [db_name], "
           "[log_stat].[db_creation_time] AS [db_creation_time], "
@@ -1470,6 +1487,7 @@ sm_define_view_ha_apply_info_spec (void)
 	  /* CT_HA_APPLY_INFO_NAME */
           "[%s] AS [log_stat] ",
         CT_HA_APPLY_INFO_NAME);
+  assert(n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -1481,7 +1499,7 @@ sm_define_view_collation_spec (void)
   static char stmt [2048];
 
   // *INDENT-OFF*
-  snprintf (stmt, sizeof(stmt),
+  int n = snprintf (stmt, sizeof(stmt),
 	"SELECT "
 	  "[coll].[coll_id] AS [coll_id], "
 	  "[coll].[coll_name] AS [coll_name], "
@@ -1507,6 +1525,7 @@ sm_define_view_collation_spec (void)
 	  "[coll].[coll_id]",
 	CT_COLLATION_NAME,
 	CT_CHARSET_NAME);
+  assert(n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -1518,7 +1537,7 @@ sm_define_view_user_spec (void)
   static char stmt [2048];
 
   // *INDENT-OFF*
-  snprintf (stmt, sizeof(stmt),
+  int n = snprintf (stmt, sizeof(stmt),
 	"SELECT "
 	  "[u].[name] AS [name], "
 	  "[u].[id] AS [id], "
@@ -1549,6 +1568,7 @@ sm_define_view_user_spec (void)
 	  ") SETNEQ {}",
 	CT_USER_NAME,
 	CT_USER_NAME);
+  assert(n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -1560,7 +1580,7 @@ sm_define_view_authorization_spec (void)
   static char stmt [2048];
 
   // *INDENT-OFF*
-  snprintf (stmt, sizeof(stmt),
+  int n = snprintf (stmt, sizeof(stmt),
 	"SELECT "
 	  "[a].[owner].[name] AS [owner], "
 	  "[a].[grants] AS [grants] "
@@ -1579,6 +1599,7 @@ sm_define_view_authorization_spec (void)
 	  ") SETNEQ {}",
 	CT_AUTHORIZATION_NAME,
 	AU_USER_CLASS_NAME);
+  assert(n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -1590,7 +1611,7 @@ sm_define_view_charset_spec (void)
   static char stmt [2048];
 
   // *INDENT-OFF*
-  snprintf (stmt, sizeof(stmt),
+  int n = snprintf (stmt, sizeof(stmt),
 	"SELECT "
 	  "[ch].[charset_id] AS [charset_id], "
 	  "[ch].[charset_name] AS [charset_name], "
@@ -1607,6 +1628,7 @@ sm_define_view_charset_spec (void)
 	  "[ch].[charset_id]",
 	CT_CHARSET_NAME,
 	CT_COLLATION_NAME);
+  assert(n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -1618,7 +1640,7 @@ sm_define_view_synonym_spec (void)
   static char stmt [2048];
 
   // *INDENT-OFF*
-  snprintf (stmt, sizeof(stmt),
+  int n = snprintf (stmt, sizeof(stmt),
 	"SELECT "
 	  "[s].[name] AS [synonym_name], "
 	  "[s].[owner].[name] AS [synonym_owner_name], "
@@ -1657,6 +1679,7 @@ sm_define_view_synonym_spec (void)
 	CT_SYNONYM_NAME,
 	AU_USER_CLASS_NAME,
 	AU_USER_CLASS_NAME);
+  assert(n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -1668,7 +1691,7 @@ sm_define_view_server_spec (void)
   static char stmt [2048];
 
   // *INDENT-OFF*
-  snprintf (stmt, sizeof(stmt),
+  int n = snprintf (stmt, sizeof(stmt),
 	"SELECT "
 	  "[ds].[link_name] AS [link_name], "
 	  "[ds].[host] AS [host], "
@@ -1727,6 +1750,7 @@ sm_define_view_server_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
+  assert(n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -1738,7 +1762,7 @@ sm_define_view_histogram_spec (void)
   static char stmt [2048];
 
   // *INDENT-OFF*
-  snprintf (stmt, sizeof(stmt),
+  int n = snprintf (stmt, sizeof(stmt),
 	"SELECT "
 	  "[h].[class_of] AS [class_name], "
 	  "[h].[key_attr] AS [key_attr], "
@@ -1751,6 +1775,7 @@ sm_define_view_histogram_spec (void)
 	  "[h].[class_of], "
 	  "[h].[key_attr]",
 	CT_HISTOGRAM_NAME);
+  assert(n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;

--- a/src/object/schema_system_catalog_install_query_spec.cpp
+++ b/src/object/schema_system_catalog_install_query_spec.cpp
@@ -59,10 +59,11 @@
  *
  */
 
-const char *
+std::string
+
 sm_define_view_class_spec (void)
 {
-  static char stmt [2048];
+  char stmt [2048];
 
   // *INDENT-OFF*
   int n = snprintf (stmt, sizeof(stmt),
@@ -148,10 +149,11 @@ sm_define_view_class_spec (void)
   return stmt;
 }
 
-const char *
+std::string
+
 sm_define_view_direct_super_class_spec (void)
 {
-  static char stmt [2048];
+  char stmt [2048];
 
   // *INDENT-OFF*
   int n = snprintf (stmt, sizeof(stmt),
@@ -211,10 +213,11 @@ sm_define_view_direct_super_class_spec (void)
   return stmt;
 }
 
-const char *
+std::string
+
 sm_define_view_vclass_spec (void)
 {
-  static char stmt [2048];
+  char stmt [2048];
 
   // *INDENT-OFF*
   int n = snprintf (stmt, sizeof(stmt),
@@ -284,10 +287,11 @@ sm_define_view_vclass_spec (void)
   return stmt;
 }
 
-const char *
+std::string
+
 sm_define_view_attribute_spec (void)
 {
-  static char stmt [4096];
+  char stmt [4096];
 
   // *INDENT-OFF*
   int n = snprintf (stmt, sizeof(stmt),
@@ -395,10 +399,11 @@ sm_define_view_attribute_spec (void)
   return stmt;
 }
 
-const char *
+std::string
+
 sm_define_view_attr_setdomain_elm_spec (void)
 {
-  static char stmt [2048];
+  char stmt [2048];
 
   // *INDENT-OFF*
   int n = snprintf (stmt, sizeof(stmt),
@@ -478,10 +483,11 @@ sm_define_view_attr_setdomain_elm_spec (void)
   return stmt;
 }
 
-const char *
+std::string
+
 sm_define_view_method_spec (void)
 {
-  static char stmt [2048];
+  char stmt [2048];
 
   // *INDENT-OFF*
   int n = snprintf (stmt, sizeof(stmt),
@@ -551,10 +557,11 @@ sm_define_view_method_spec (void)
   return stmt;
 }
 
-const char *
+std::string
+
 sm_define_view_method_arg_spec (void)
 {
-  static char stmt [2048];
+  char stmt [2048];
 
   // *INDENT-OFF*
   int n = snprintf (stmt, sizeof(stmt),
@@ -635,10 +642,11 @@ sm_define_view_method_arg_spec (void)
   return stmt;
 }
 
-const char *
+std::string
+
 sm_define_view_meth_arg_setdomain_elm_spec (void)
 {
-  static char stmt [2048];
+  char stmt [2048];
 
   // *INDENT-OFF*
   int n = snprintf (stmt, sizeof(stmt),
@@ -719,10 +727,11 @@ sm_define_view_meth_arg_setdomain_elm_spec (void)
   return stmt;
 }
 
-const char *
+std::string
+
 sm_define_view_meth_file_spec (void)
 {
-  static char stmt [2048];
+  char stmt [2048];
 
   // *INDENT-OFF*
   int n = snprintf (stmt, sizeof(stmt),
@@ -783,10 +792,11 @@ sm_define_view_meth_file_spec (void)
   return stmt;
 }
 
-const char *
+std::string
+
 sm_define_view_index_spec (void)
 {
-  static char stmt [4096];
+  char stmt [4096];
 
   // *INDENT-OFF*
   int n = snprintf (stmt, sizeof(stmt),
@@ -914,10 +924,11 @@ sm_define_view_index_spec (void)
   return stmt;
 }
 
-const char *
+std::string
+
 sm_define_view_index_key_spec (void)
 {
-  static char stmt [2048];
+  char stmt [2048];
 
   // *INDENT-OFF*
   int n = snprintf (stmt, sizeof(stmt),
@@ -987,10 +998,11 @@ sm_define_view_index_key_spec (void)
   return stmt;
 }
 
-const char *
+std::string
+
 sm_define_view_auth_spec (void)
 {
-  static char stmt [4096];
+  char stmt [4096];
 
   // *INDENT-OFF*
   int n = snprintf (stmt, sizeof(stmt),
@@ -1063,10 +1075,11 @@ sm_define_view_auth_spec (void)
   return stmt;
 }
 
-const char *
+std::string
+
 sm_define_view_trigger_spec (void)
 {
-  static char stmt [2048];
+  char stmt [2048];
 
   // *INDENT-OFF*
   int n = snprintf (stmt, sizeof(stmt),
@@ -1136,10 +1149,11 @@ sm_define_view_trigger_spec (void)
   return stmt;
 }
 
-const char *
+std::string
+
 sm_define_view_partition_spec (void)
 {
-  static char stmt [2048];
+  char stmt [2048];
 
   // *INDENT-OFF*
   int n = snprintf (stmt, sizeof(stmt),
@@ -1216,10 +1230,11 @@ sm_define_view_partition_spec (void)
   return stmt;
 }
 
-const char *
+std::string
+
 sm_define_view_stored_procedure_spec (void)
 {
-  static char stmt [4096];
+  char stmt [4096];
 
   // *INDENT-OFF*
   int n = snprintf (stmt, sizeof(stmt),
@@ -1333,10 +1348,11 @@ sm_define_view_stored_procedure_spec (void)
   return stmt;
 }
 
-const char *
+std::string
+
 sm_define_view_stored_procedure_args_spec (void)
 {
-  static char stmt [2048];
+  char stmt [2048];
 
   // *INDENT-OFF*
   int n = snprintf (stmt, sizeof(stmt),
@@ -1413,10 +1429,11 @@ sm_define_view_stored_procedure_args_spec (void)
   return stmt;
 }
 
-const char *
+std::string
+
 sm_define_view_serial_spec (void)
 {
-  static char stmt [2048];
+  char stmt [2048];
 
   // *INDENT-OFF*
   int n = snprintf (stmt, sizeof(stmt),
@@ -1449,10 +1466,11 @@ sm_define_view_serial_spec (void)
   return stmt;
 }
 
-const char *
+std::string
+
 sm_define_view_ha_apply_info_spec (void)
 {
-  static char stmt [2048];
+  char stmt [2048];
 
   // *INDENT-OFF*
   int n = snprintf (stmt, sizeof(stmt),
@@ -1493,10 +1511,11 @@ sm_define_view_ha_apply_info_spec (void)
   return stmt;
 }
 
-const char *
+std::string
+
 sm_define_view_collation_spec (void)
 {
-  static char stmt [2048];
+  char stmt [2048];
 
   // *INDENT-OFF*
   int n = snprintf (stmt, sizeof(stmt),
@@ -1531,10 +1550,11 @@ sm_define_view_collation_spec (void)
   return stmt;
 }
 
-const char *
+std::string
+
 sm_define_view_user_spec (void)
 {
-  static char stmt [2048];
+  char stmt [2048];
 
   // *INDENT-OFF*
   int n = snprintf (stmt, sizeof(stmt),
@@ -1574,10 +1594,11 @@ sm_define_view_user_spec (void)
   return stmt;
 }
 
-const char *
+std::string
+
 sm_define_view_authorization_spec (void)
 {
-  static char stmt [2048];
+  char stmt [2048];
 
   // *INDENT-OFF*
   int n = snprintf (stmt, sizeof(stmt),
@@ -1605,10 +1626,11 @@ sm_define_view_authorization_spec (void)
   return stmt;
 }
 
-const char *
+std::string
+
 sm_define_view_charset_spec (void)
 {
-  static char stmt [2048];
+  char stmt [2048];
 
   // *INDENT-OFF*
   int n = snprintf (stmt, sizeof(stmt),
@@ -1634,10 +1656,11 @@ sm_define_view_charset_spec (void)
   return stmt;
 }
 
-const char *
+std::string
+
 sm_define_view_synonym_spec (void)
 {
-  static char stmt [2048];
+  char stmt [2048];
 
   // *INDENT-OFF*
   int n = snprintf (stmt, sizeof(stmt),
@@ -1685,10 +1708,11 @@ sm_define_view_synonym_spec (void)
   return stmt;
 }
 
-const char *
+std::string
+
 sm_define_view_server_spec (void)
 {
-  static char stmt [2048];
+  char stmt [2048];
 
   // *INDENT-OFF*
   int n = snprintf (stmt, sizeof(stmt),
@@ -1756,10 +1780,11 @@ sm_define_view_server_spec (void)
   return stmt;
 }
 
-const char *
+std::string
+
 sm_define_view_histogram_spec (void)
 {
-  static char stmt [2048];
+  char stmt [2048];
 
   // *INDENT-OFF*
   int n = snprintf (stmt, sizeof(stmt),

--- a/src/object/schema_system_catalog_install_query_spec.cpp
+++ b/src/object/schema_system_catalog_install_query_spec.cpp
@@ -143,7 +143,7 @@ sm_define_view_class_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
-  assert(n < sizeof(stmt));
+  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -207,7 +207,7 @@ sm_define_view_direct_super_class_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
-  assert(n < sizeof(stmt));
+  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -281,7 +281,7 @@ sm_define_view_vclass_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
-  assert(n < sizeof(stmt));
+  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -393,7 +393,7 @@ sm_define_view_attribute_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
-  assert(n < sizeof(stmt));
+  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -477,7 +477,7 @@ sm_define_view_attr_setdomain_elm_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
-  assert(n < sizeof(stmt));
+  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -551,7 +551,7 @@ sm_define_view_method_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
-  assert(n < sizeof(stmt));
+  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -636,7 +636,7 @@ sm_define_view_method_arg_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
-  assert(n < sizeof(stmt));
+  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -721,7 +721,7 @@ sm_define_view_meth_arg_setdomain_elm_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
-  assert(n < sizeof(stmt));
+  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -786,7 +786,7 @@ sm_define_view_meth_file_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
-  assert(n < sizeof(stmt));
+  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -918,7 +918,7 @@ sm_define_view_index_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
-  assert(n < sizeof(stmt));
+  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -992,7 +992,7 @@ sm_define_view_index_key_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
-  assert(n < sizeof(stmt));
+  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -1069,7 +1069,7 @@ sm_define_view_auth_spec (void)
         CT_STORED_PROC_NAME,
 	AU_USER_CLASS_NAME
         );
-  assert(n < sizeof(stmt));
+  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -1143,7 +1143,7 @@ sm_define_view_trigger_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
-  assert(n < sizeof(stmt));
+  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -1224,7 +1224,7 @@ sm_define_view_partition_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
-  assert(n < sizeof(stmt));
+  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -1342,7 +1342,7 @@ sm_define_view_stored_procedure_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
-  assert(n < sizeof(stmt));
+  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -1423,7 +1423,7 @@ sm_define_view_stored_procedure_args_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
-  assert(n < sizeof(stmt));
+  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -1460,7 +1460,7 @@ sm_define_view_serial_spec (void)
         "WHERE "
           "[serial].[class_name] IS NULL",
         CT_SERIAL_NAME);
-  assert(n < sizeof(stmt));
+  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -1505,7 +1505,7 @@ sm_define_view_ha_apply_info_spec (void)
 	  /* CT_HA_APPLY_INFO_NAME */
           "[%s] AS [log_stat] ",
         CT_HA_APPLY_INFO_NAME);
-  assert(n < sizeof(stmt));
+  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -1544,7 +1544,7 @@ sm_define_view_collation_spec (void)
 	  "[coll].[coll_id]",
 	CT_COLLATION_NAME,
 	CT_CHARSET_NAME);
-  assert(n < sizeof(stmt));
+  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -1588,7 +1588,7 @@ sm_define_view_user_spec (void)
 	  ") SETNEQ {}",
 	CT_USER_NAME,
 	CT_USER_NAME);
-  assert(n < sizeof(stmt));
+  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -1620,7 +1620,7 @@ sm_define_view_authorization_spec (void)
 	  ") SETNEQ {}",
 	CT_AUTHORIZATION_NAME,
 	AU_USER_CLASS_NAME);
-  assert(n < sizeof(stmt));
+  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -1650,7 +1650,7 @@ sm_define_view_charset_spec (void)
 	  "[ch].[charset_id]",
 	CT_CHARSET_NAME,
 	CT_COLLATION_NAME);
-  assert(n < sizeof(stmt));
+  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -1702,7 +1702,7 @@ sm_define_view_synonym_spec (void)
 	CT_SYNONYM_NAME,
 	AU_USER_CLASS_NAME,
 	AU_USER_CLASS_NAME);
-  assert(n < sizeof(stmt));
+  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -1774,7 +1774,7 @@ sm_define_view_server_spec (void)
 	AU_USER_CLASS_NAME,
 	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME);
-  assert(n < sizeof(stmt));
+  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;
@@ -1800,7 +1800,7 @@ sm_define_view_histogram_spec (void)
 	  "[h].[class_of], "
 	  "[h].[key_attr]",
 	CT_HISTOGRAM_NAME);
-  assert(n < sizeof(stmt));
+  assert(n > 0 && n < sizeof(stmt));
   // *INDENT-ON*
 
   return stmt;


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27258>

### Purpose

시스템 뷰 쿼리 스펙 정의 함수의 두 가지 문제를 개선합니다. 

- 버퍼 크기를 넘는지 검사 추가
- 버퍼를 한번 사용하면서도 static 으로 선언되어 실행시간 메모리를 상시 점유하는 문제.

### Implementation

- 검사 과정 추가
- 쿼리 스펙 정의 함수의 리턴타입을 const char * 에서 std::string 으로 전환함으로써 버퍼의 생존 기간을 static 대신 함수 scope으로 전환

### 추가 (2026-08-28)
위 문제 중 두 번 째 "실행시간 메모리 상시 점유" 에 관해서 - DBMS 실행시에는 참조되지 않는 메모리 영역이라 일반적인 virtual memory 환경에서 물리 메모리를 점유하지 않을 것이므로 실제 큰 문제는 아니라는 논의가 있었다. 해당 영역은 짧은 시간 실행되는 createdb 에서 사용되는 메모리 영역이다. (아래 댓글 논의 참고)
