### PR TITLE
[CUBRIDQA-1539] Include submodule bump PRs in TC branch sync and finalize

### DIFF
--- a/.github/workflows/tc-branch-finalize.yml
+++ b/.github/workflows/tc-branch-finalize.yml
@@ -29,7 +29,6 @@ env:
 jobs:
   finalize-tc-branch:
     name: Finalize TC (${{ matrix.tc-repo }})
-    if: github.event.pull_request.user.login != 'cubrid-submodule-bot[bot]'   # skip automated submodule-bump PRs
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/tc-branch-sync.yml
+++ b/.github/workflows/tc-branch-sync.yml
@@ -25,7 +25,6 @@ jobs:
   # Parse PR metadata: type, header, original PR number
   detect-pr-type:
     name: Detect PR Type
-    if: github.event.pull_request.user.login != 'cubrid-submodule-bot[bot]'   # skip automated submodule-bump PRs
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions: {}


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRDIDQA-1539>

### Purpose
CUBRIDQA-1432에서 봇 PR을 `tc-branch-sync`, `tc-branch-finalize` 대상에서 제외했는데, 운영해보니 서브모듈 변경이 TC 답지 수정을 요구하거나 TC 변경이 없는 bump까지 깨지는 문제가 나옵니다.
`tc/pr-<N>` 브랜치가 생기면 TC 상태가 PR 오픈 시점에 고정되어 두 문제가 함께 해결되므로, 제외 조건을 제거합니다.

### Implementation
 - 두 워크플로에서 봇 제외 `if` 조건 제거
 - 봇 PR도 일반 PR과 동일하게 `tc/pr-<N>` 브랜치와 draft PR을 갖고, PR 종료 시 정리됨

### Remarks

N/A
