### PR TITLE
[CBRD-27187] 조인이 있는 GROUP BY 문장에서 group-by-skip 인덱스 스캔 플랜이 후보가 되지 않는 문제 개선

### DIFF
--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -301,10 +301,13 @@ static bool qo_check_groupby_skip_descending (QO_PLAN * plan, PT_NODE * list);
 static int qo_walk_plan_tree (QO_PLAN * plan, QO_WALK_FUNCTION f, void *arg);
 static void qo_set_use_desc (QO_PLAN * plan);
 static int qo_set_orderby_skip (QO_PLAN * plan, void *arg);
+static void qo_set_groupby_skip (QO_PLAN * plan);
 static int qo_unset_hint_use_desc_idx (QO_PLAN * plan, void *arg);
 static int qo_validate_indexes_for_orderby (QO_PLAN * plan, void *arg);
 static int qo_unset_multi_range_optimization (QO_PLAN * plan, void *arg);
 static bool qo_plan_is_orderby_skip_candidate (QO_PLAN * plan);
+static bool qo_plan_is_groupby_skip_candidate (QO_PLAN * plan);
+static void qo_apply_join_groupby_skip (QO_ENV * env, QO_PLAN * plan);
 static bool qo_is_sort_limit (QO_PLAN * plan);
 static int qo_check_like_recompile_candidate (QO_PLAN * plan, void *arg);
 
@@ -522,6 +525,7 @@ qo_plan_malloc (QO_ENV * env)
 
   plan->parallel_opt_use = PLAN_PARALLEL_OPT_NO;
   plan->skip_orderby_opt = QO_PLAN_SKIP_ORDERBY_NO;
+  plan->skip_groupby_opt = QO_PLAN_SKIP_GROUPBY_NO;
 
   plan->has_sort_limit = false;
   plan->use_iscan_descending = false;
@@ -1014,6 +1018,58 @@ qo_set_orderby_skip (QO_PLAN * plan, void *arg)
   return NO_ERROR;
 }
 
+/*
+ * qo_set_groupby_skip () - sets the groupby_skip index flag on the scan that
+ *			    actually supplies the GROUP BY ordering
+ *
+ * return: nothing
+ * plan(in): plan to walk down from
+ *
+ * note: Only the outer (order-preserving) spine is walked, the very same spine
+ *	 that qo_plan_compute_iscan_sort_list () follows to derive the
+ *	 interesting order.  An inner plan never dictates the order of the join
+ *	 result, so marking it would be wrong.
+ *	 A QO_PLANTYPE_SORT is deliberately not walked through: the only sort
+ *	 that can sit here is the SORT_TEMP that qo_join_new puts above a merge
+ *	 join, and that one re-sorts by the join column.
+ *	 A join that null-supplies its outer side does not hand the index order
+ *	 on, so the walk stops on such joins as well.
+ */
+static void
+qo_set_groupby_skip (QO_PLAN * plan)
+{
+  if (plan == NULL)
+    {
+      return;
+    }
+
+  switch (plan->plan_type)
+    {
+    case QO_PLANTYPE_SCAN:
+      if (plan->plan_un.scan.index != NULL && plan->plan_un.scan.index->head != NULL)
+	{
+	  plan->plan_un.scan.index->head->groupby_skip = true;
+	  plan->skip_groupby_opt = QO_PLAN_SKIP_GROUPBY_USE;
+	}
+      break;
+
+    case QO_PLANTYPE_JOIN:
+      if (plan->plan_un.join.join_type == NO_JOIN || plan->plan_un.join.join_type == JOIN_INNER
+	  || plan->plan_un.join.join_type == JOIN_LEFT)
+	{
+	  qo_set_groupby_skip (plan->plan_un.join.outer);
+	}
+      break;
+
+    case QO_PLANTYPE_FOLLOW:
+      qo_set_groupby_skip (plan->plan_un.follow.head);
+      break;
+
+    default:
+      break;
+    }
+}
+
 static int
 qo_unset_hint_use_desc_idx (QO_PLAN * plan, void *arg)
 {
@@ -1169,6 +1225,20 @@ qo_top_plan_new (QO_PLAN * plan)
 	      parser_free_node (parser, group_sort_list);
 	    }
 
+	  if (groupby_skip && plan->need_final_sort)
+	    {
+	      /*
+	       * The interesting order comes from the outermost index scan, but a hash/merge join
+	       * above it (for which qo_join_new sets need_final_sort) does not hand that order on:
+	       * a hash join may not preserve the order of its probe input when partitioned or run
+	       * in parallel, and a merge join re-sorts both inputs by the join column in S_ASC
+	       * order regardless of direction. qexec_groupby_index () trusts its input to be
+	       * grouped and has no fallback, so a broken order would silently split groups.
+	       * Give up the skip here and let the GROUP BY sort be costed in below.
+	       */
+	      groupby_skip = false;
+	    }
+
 	  if (groupby_skip)
 	    {
 	      /* if the plan is index_groupby, we validate the plan */
@@ -1181,10 +1251,20 @@ qo_top_plan_new (QO_PLAN * plan)
 		      return plan;
 		    }
 		}
-	      /* if all goes well, we have an indexed plan with group by skip! */
-	      if (plan->plan_type == QO_PLANTYPE_SCAN && plan->plan_un.scan.index)
+	      /*
+	       * If all goes well, we have an indexed plan with group by skip!
+	       * Only a single scan top plan raises the flag here.  For a join top plan the
+	       * QO_INDEX_ENTRY is shared by every candidate plan on that node, and this
+	       * function runs for every complete plan built during the join enumeration:
+	       * a candidate whose join preserves the index order and a candidate whose join
+	       * does not would fight over the same flag, while the executor decides to skip
+	       * the group-by sort from that very flag (through the INDX_INFO of the first
+	       * access spec).  So for joins the flag is applied only to the chosen plan,
+	       * after the search - see qo_apply_join_groupby_skip ().
+	       */
+	      if (plan->plan_type == QO_PLANTYPE_SCAN)
 		{
-		  plan->plan_un.scan.index->head->groupby_skip = true;
+		  qo_set_groupby_skip (plan);
 		}
 	    }
 	  else
@@ -6222,8 +6302,12 @@ qo_check_plan_on_info (QO_INFO * info, QO_PLAN * plan)
       return 0;
     }
 
-  /* if the plan is of type QO_SCANMETHOD_INDEX_GRUOPBY_SCAN but it doesn't skip the groupby, we release the plan. */
-  if (qo_is_iscan_from_groupby (plan) && !plan->plan_un.scan.index->head->groupby_skip)
+  /* if the plan is of type QO_SCANMETHOD_INDEX_GRUOPBY_SCAN but it doesn't skip the groupby, we release the plan.
+   * The groupby_skip flag is only raised once a plan is top-rooted, so before that - while joins are still being
+   * enumerated - judge the plan by the candidate predicate instead, exactly as the ORDER BY branch above does.
+   * Otherwise no group-by skip index scan could ever survive in a statement that has a join. */
+  if (qo_is_iscan_from_groupby (plan)
+      && !(plan->top_rooted ? plan->plan_un.scan.index->head->groupby_skip : qo_plan_is_groupby_skip_candidate (plan)))
     {
       qo_plan_release (plan);
       return 0;
@@ -9562,6 +9646,8 @@ qo_search_planner (QO_PLANNER * planner)
     {
       goto end;
     }
+
+  qo_apply_join_groupby_skip (planner->env, plan);
 
   if (plan->use_iscan_descending == true && qo_plan_multi_range_opt (plan) == false)
     {
@@ -13014,6 +13100,204 @@ cleanup:
     }
 
   return is_orderby_skip;
+}
+
+/*
+ * qo_plan_is_groupby_skip_candidate () - verify if a plan is a candidate for
+ *					  groupby skip
+ * return : true/false
+ * plan (in) : plan to verify
+ *
+ * note: This is the GROUP BY counterpart of qo_plan_is_orderby_skip_candidate ().
+ *	 It is needed because the groupby_skip flag on the index entry is only raised
+ *	 by qo_top_plan_new () once a plan covers the whole query, so during join
+ *	 enumeration the flag is still down and cannot be used to admit a candidate.
+ */
+static bool
+qo_plan_is_groupby_skip_candidate (QO_PLAN * plan)
+{
+  PARSER_CONTEXT *parser;
+  PT_NODE *group_by, *statement, *entity, *group_sort_list;
+  QO_ENV *env;
+  bool is_prefix = false, is_groupby_skip = false;
+
+  if (plan == NULL || plan->info == NULL)
+    {
+      assert (false);
+      return false;
+    }
+
+  env = plan->info->env;
+
+  switch (plan->skip_groupby_opt)
+    {
+    case QO_PLAN_SKIP_GROUPBY_USE:
+    case QO_PLAN_SKIP_GROUPBY_CAN_USE:
+      return true;
+
+    case QO_PLAN_SKIP_GROUPBY_CANNOT_USE:
+      return false;
+
+    case QO_PLAN_SKIP_GROUPBY_NO:
+      /* need check */
+      break;
+
+    default:
+      /* impossible case */
+      assert (false);
+
+      /* need check */
+      break;
+    }
+
+  parser = QO_ENV_PARSER (env);
+  statement = QO_ENV_PT_TREE (env);
+  group_by = statement->info.query.q.select.group_by;
+
+  /* WITH ROLLUP needs every group boundary materialized, so the sort cannot be skipped. */
+  if (group_by == NULL || group_by->flag.with_rollup)
+    {
+      goto end;
+    }
+
+  group_sort_list = qo_plan_compute_iscan_sort_list (plan, group_by, &is_prefix, false);
+  if (group_sort_list == NULL)
+    {
+      goto end;
+    }
+
+  if (is_prefix)
+    {
+      parser_free_tree (parser, group_sort_list);
+      goto end;
+    }
+
+  is_groupby_skip = pt_sort_spec_cover_groupby (parser, group_sort_list, group_by, statement);
+  if (!is_groupby_skip && qo_is_interesting_order_scan (plan))
+    {
+      /* the index may still cover the grouping when it is scanned descending */
+      is_groupby_skip = qo_check_groupby_skip_descending (plan, group_sort_list);
+    }
+
+  parser_free_tree (parser, group_sort_list);
+
+  /*
+   * In RIGHT OUTER JOIN, all leading tables are used as null-supplying,
+   * so skip GROUP BY cannot be applied.
+   * This mirrors the check in qo_plan_is_orderby_skip_candidate ().
+   */
+  if (is_groupby_skip && qo_is_iscan_from_groupby (plan))
+    {
+      entity = QO_NODE_ENTITY_SPEC (plan->plan_un.scan.node)->next;
+      for (; entity != NULL; entity = entity->next)
+	{
+	  if (entity->info.spec.join_type == PT_JOIN_RIGHT_OUTER)
+	    {
+	      is_groupby_skip = false;
+	      break;
+	    }
+	}
+    }
+
+end:
+  if (is_groupby_skip)
+    {
+      plan->skip_groupby_opt = QO_PLAN_SKIP_GROUPBY_CAN_USE;
+    }
+  else
+    {
+      plan->skip_groupby_opt = QO_PLAN_SKIP_GROUPBY_CANNOT_USE;
+    }
+
+  return is_groupby_skip;
+}
+
+/*
+ * qo_apply_join_groupby_skip () - marks the outermost index scan of the
+ *				   chosen join plan with the groupby_skip
+ *				   flag when the join preserves its order
+ * return : nothing
+ * env (in) : optimizer environment
+ * plan (in) : the final top plan chosen by the planner
+ *
+ * note: for a single scan top plan, qo_top_plan_new sets the groupby_skip
+ *	 flag of the index directly.  For a join top plan the flag cannot be
+ *	 set during the enumeration, because the QO_INDEX_ENTRY is shared by
+ *	 every candidate plan on that node: a candidate whose join preserves
+ *	 the index order and a candidate whose join does not would fight over
+ *	 the same flag, and the executor skips the group-by sort based on it
+ *	 (through the INDX_INFO of the first access spec).  So the flag is
+ *	 applied here, only for the plan that was actually chosen.
+ *
+ *	 The absence of a SORT_GROUPBY node above the join means that
+ *	 qo_top_plan_new verified that the index sort list of the outermost
+ *	 scan covers the GROUP BY columns for this very plan; this function
+ *	 additionally requires that every join on the outer spine keeps the
+ *	 outer side order-preserved before setting the flag.
+ */
+static void
+qo_apply_join_groupby_skip (QO_ENV * env, QO_PLAN * plan)
+{
+  PT_NODE *tree, *group_by;
+  QO_PLAN *node_plan;
+
+  if (plan == NULL || env == NULL)
+    {
+      return;
+    }
+
+  tree = QO_ENV_PT_TREE (env);
+  if (tree == NULL || tree->node_type != PT_SELECT)
+    {
+      return;
+    }
+
+  group_by = tree->info.query.q.select.group_by;
+
+  /* the sorted-input group-by path of the executor does not handle rollup */
+  if (group_by == NULL || group_by->flag.with_rollup)
+    {
+      return;
+    }
+
+  if (qo_plan_multi_range_opt (plan))
+    {
+      return;
+    }
+
+  /*
+   * Walk through the final sorts appended above the group-by result.
+   * A SORT_GROUPBY node means qo_top_plan_new decided that the grouping
+   * needs a sort; any other sort type than the final ORDER BY / DISTINCT
+   * sorts re-orders the rows before the grouping, so give up on both.
+   */
+  node_plan = plan;
+  while (node_plan != NULL && node_plan->plan_type == QO_PLANTYPE_SORT)
+    {
+      if (node_plan->plan_un.sort.sort_type != SORT_ORDERBY && node_plan->plan_un.sort.sort_type != SORT_DISTINCT)
+	{
+	  return;
+	}
+      node_plan = node_plan->plan_un.sort.subplan;
+    }
+
+  /* single scan top plans are already handled by qo_top_plan_new */
+  if (node_plan == NULL || node_plan->plan_type != QO_PLANTYPE_JOIN)
+    {
+      return;
+    }
+
+  /* a hash or merge join on the outer spine re-orders the rows */
+  if (node_plan->need_final_sort)
+    {
+      return;
+    }
+
+  /* walk down the outer spine of the join and mark the scan that supplies the
+   * GROUP BY ordering; the walk stops on a join that null-supplies its outer
+   * side, since such a join does not hand the index order on
+   */
+  qo_set_groupby_skip (node_plan);
 }
 
 /*

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -525,7 +525,6 @@ qo_plan_malloc (QO_ENV * env)
 
   plan->parallel_opt_use = PLAN_PARALLEL_OPT_NO;
   plan->skip_orderby_opt = QO_PLAN_SKIP_ORDERBY_NO;
-  plan->skip_groupby_opt = QO_PLAN_SKIP_GROUPBY_NO;
 
   plan->has_sort_limit = false;
   plan->use_iscan_descending = false;
@@ -1049,7 +1048,6 @@ qo_set_groupby_skip (QO_PLAN * plan)
       if (plan->plan_un.scan.index != NULL && plan->plan_un.scan.index->head != NULL)
 	{
 	  plan->plan_un.scan.index->head->groupby_skip = true;
-	  plan->skip_groupby_opt = QO_PLAN_SKIP_GROUPBY_USE;
 	}
       break;
 
@@ -13129,27 +13127,6 @@ qo_plan_is_groupby_skip_candidate (QO_PLAN * plan)
 
   env = plan->info->env;
 
-  switch (plan->skip_groupby_opt)
-    {
-    case QO_PLAN_SKIP_GROUPBY_USE:
-    case QO_PLAN_SKIP_GROUPBY_CAN_USE:
-      return true;
-
-    case QO_PLAN_SKIP_GROUPBY_CANNOT_USE:
-      return false;
-
-    case QO_PLAN_SKIP_GROUPBY_NO:
-      /* need check */
-      break;
-
-    default:
-      /* impossible case */
-      assert (false);
-
-      /* need check */
-      break;
-    }
-
   parser = QO_ENV_PARSER (env);
   statement = QO_ENV_PT_TREE (env);
   group_by = statement->info.query.q.select.group_by;
@@ -13172,12 +13149,9 @@ qo_plan_is_groupby_skip_candidate (QO_PLAN * plan)
       goto end;
     }
 
+  /* no descending retry here; qo_top_plan_new () does not retry descending on a join plan, so such a candidate could
+   * never skip the group by anyway */
   is_groupby_skip = pt_sort_spec_cover_groupby (parser, group_sort_list, group_by, statement);
-  if (!is_groupby_skip && qo_is_interesting_order_scan (plan))
-    {
-      /* the index may still cover the grouping when it is scanned descending */
-      is_groupby_skip = qo_check_groupby_skip_descending (plan, group_sort_list);
-    }
 
   parser_free_tree (parser, group_sort_list);
 
@@ -13200,15 +13174,6 @@ qo_plan_is_groupby_skip_candidate (QO_PLAN * plan)
     }
 
 end:
-  if (is_groupby_skip)
-    {
-      plan->skip_groupby_opt = QO_PLAN_SKIP_GROUPBY_CAN_USE;
-    }
-  else
-    {
-      plan->skip_groupby_opt = QO_PLAN_SKIP_GROUPBY_CANNOT_USE;
-    }
-
   return is_groupby_skip;
 }
 

--- a/src/optimizer/query_planner.h
+++ b/src/optimizer/query_planner.h
@@ -110,6 +110,14 @@ typedef enum
   QO_PLAN_SKIP_ORDERBY_CAN_USE = -2,
 } QO_PLAN_SKIP_ORDERBY_OPT;
 
+typedef enum
+{
+  QO_PLAN_SKIP_GROUPBY_USE = 1,
+  QO_PLAN_SKIP_GROUPBY_NO = 0,
+  QO_PLAN_SKIP_GROUPBY_CANNOT_USE = -1,
+  QO_PLAN_SKIP_GROUPBY_CAN_USE = -2,
+} QO_PLAN_SKIP_GROUPBY_OPT;
+
 #define DEFAULT_NULL_SELECTIVITY (double) 0.01
 #define DEFAULT_EXISTS_SELECTIVITY (double) 0.1
 #define DEFAULT_SELECTIVITY (double) 0.1
@@ -235,6 +243,7 @@ struct qo_plan
   QO_PLAN_PARALLEL_OPT_USE parallel_opt_use;	/* used to determine if this plan uses parallel opt */
   QO_PLAN_MULTI_RANGE_OPT_USE multi_range_opt_use;	/* used to determine if this plan uses multi range opt */
   QO_PLAN_SKIP_ORDERBY_OPT skip_orderby_opt;	/* used to determine if this plan uses skip orderby opt */
+  QO_PLAN_SKIP_GROUPBY_OPT skip_groupby_opt;	/* used to determine if this plan uses skip groupby opt */
   // *INDENT-OFF*
   cubxasl::analytic_eval_type *analytic_eval_list;	/* analytic evaluation list */
   // *INDENT-ON*

--- a/src/optimizer/query_planner.h
+++ b/src/optimizer/query_planner.h
@@ -110,14 +110,6 @@ typedef enum
   QO_PLAN_SKIP_ORDERBY_CAN_USE = -2,
 } QO_PLAN_SKIP_ORDERBY_OPT;
 
-typedef enum
-{
-  QO_PLAN_SKIP_GROUPBY_USE = 1,
-  QO_PLAN_SKIP_GROUPBY_NO = 0,
-  QO_PLAN_SKIP_GROUPBY_CANNOT_USE = -1,
-  QO_PLAN_SKIP_GROUPBY_CAN_USE = -2,
-} QO_PLAN_SKIP_GROUPBY_OPT;
-
 #define DEFAULT_NULL_SELECTIVITY (double) 0.01
 #define DEFAULT_EXISTS_SELECTIVITY (double) 0.1
 #define DEFAULT_SELECTIVITY (double) 0.1
@@ -243,7 +235,6 @@ struct qo_plan
   QO_PLAN_PARALLEL_OPT_USE parallel_opt_use;	/* used to determine if this plan uses parallel opt */
   QO_PLAN_MULTI_RANGE_OPT_USE multi_range_opt_use;	/* used to determine if this plan uses multi range opt */
   QO_PLAN_SKIP_ORDERBY_OPT skip_orderby_opt;	/* used to determine if this plan uses skip orderby opt */
-  QO_PLAN_SKIP_GROUPBY_OPT skip_groupby_opt;	/* used to determine if this plan uses skip groupby opt */
   // *INDENT-OFF*
   cubxasl::analytic_eval_type *analytic_eval_list;	/* analytic evaluation list */
   // *INDENT-ON*


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27187>

### Purpose

GROUP BY 컬럼에 검색 조건이 없어도 인덱스가 그루핑 순서를 제공한다는 이유만으로
만들어지는 인덱스 스캔 플랜이, 조인이 있는 문장에서는 후보로 살아남지 못한다.
옵티마이저가 이 플랜을 후보로 인정하는 조건이 "최종 플랜이 조인 없는 단일
스캔일 때"만 성립할 수 있는 구조여서, 조인 열거 도중에는 플랜이 만들어지자마자
버려진다. 명시적 index hint를 줘도 후보 인정 단계에서 잘리므로 복구되지 않는다.

그 결과 해당 테이블은 순차 스캔만 남고 조인 결과 위에 GROUP BY 정렬이 무조건
삽입되어, 정렬 없이 그루핑하는 실행 경로가 조인 뒤에서는 도달 불가능하다.
같은 GROUP BY라도 조인이 없으면 정렬 없이 수행되지만, 결과에 영향을 주지 않는
1행 cross join 하나만 추가해도 정렬 플랜으로 뒤집힌다.

### Implementation

N/A

### Remarks

N/A
