### PR TITLE
[CBRD-27320] Fix the non-monotonic append_lsa update in logpb_next_append_page

### DIFF
--- a/src/base/porting.h
+++ b/src/base/porting.h
@@ -881,6 +881,51 @@ template <typename T, typename V> inline T ATOMIC_TAS_64 (volatile T *ptr, V amo
 #endif
 }
 
+/*
+ * Plain atomic load/store with acquire/release ordering.
+ * Unlike the ATOMIC_LOAD_64/ATOMIC_STORE_64 macros below (integer-only, read-modify-write),
+ * these accept any 64bit trivially-copyable type.
+ */
+template <typename T> inline T ATOMIC_LOAD_64_ACQUIRE (volatile T *ptr)
+{
+  static_assert (sizeof (T) == sizeof (UINT64), "Not 64bit");
+  static_assert (alignof (T) == sizeof (UINT64), "Not 64bit aligned");
+  static_assert (std::is_trivially_copyable <T>::value, "Not trivially copyable");
+#if defined (_WIN64)
+  union { T value; INT64 word; } ret;
+  ret.word = InterlockedOr64 (reinterpret_cast <volatile INT64 *>(ptr), 0);
+  return ret.value;
+#elif defined(WINDOWS)
+  union { T value; UINT64 word; } ret;
+  ret.word = win32_exchange_add64 (reinterpret_cast <volatile UINT64 *>(ptr), 0);
+  return ret.value;
+#else
+  static_assert (__atomic_always_lock_free (sizeof (UINT64), 0), "Not lock-free");
+  T ret;
+  __atomic_load (ptr, &ret, __ATOMIC_ACQUIRE);
+  return ret;
+#endif
+}
+
+template <typename T> inline void ATOMIC_STORE_64_RELEASE (volatile T *ptr, T new_val)
+{
+  static_assert (sizeof (T) == sizeof (UINT64), "Not 64bit");
+  static_assert (alignof (T) == sizeof (UINT64), "Not 64bit aligned");
+  static_assert (std::is_trivially_copyable <T>::value, "Not trivially copyable");
+#if defined (_WIN64)
+  union { T value; INT64 word; } tmp;
+  tmp.value = new_val;
+  InterlockedExchange64 (reinterpret_cast <volatile INT64 *>(ptr), tmp.word);
+#elif defined(WINDOWS)
+  union { T value; UINT64 word; } tmp;
+  tmp.value = new_val;
+  win32_exchange64 (reinterpret_cast <volatile UINT64 *>(ptr), tmp.word);
+#else
+  static_assert (__atomic_always_lock_free (sizeof (UINT64), 0), "Not lock-free");
+  __atomic_store (ptr, &new_val, __ATOMIC_RELEASE);
+#endif
+}
+
 namespace dispatch
 {
   template <bool B> struct Bool2Type

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -25179,14 +25179,14 @@ heap_get_visible_version_from_log (THREAD_ENTRY * thread_p, RECDES * recdes, LOG
     }
 
   /* make sure prev_version_lsa is flushed from prior lsa list - wake up log flush thread if it's not flushed */
-  oldest_prior_lsa = *log_get_append_lsa ();	/* TODO: fix atomicity issue on x86 */
+  oldest_prior_lsa = log_get_append_lsa ();
   if (LSA_LT (&oldest_prior_lsa, previous_version_lsa))
     {
       LOG_CS_ENTER (thread_p);
       logpb_prior_lsa_append_all_list (thread_p);
       LOG_CS_EXIT (thread_p);
 
-      oldest_prior_lsa = *log_get_append_lsa ();
+      oldest_prior_lsa = log_get_append_lsa ();
       assert (!LSA_LT (&oldest_prior_lsa, previous_version_lsa));
     }
 

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -11733,7 +11733,7 @@ xrepl_set_info (THREAD_ENTRY * thread_p, REPL_INFO * repl_info)
 LOG_LSA *
 xrepl_log_get_append_lsa (void)
 {
-  return log_get_append_lsa ();
+  return (&log_Gl.hdr.append_lsa);
 }
 
 /*

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -593,16 +593,18 @@ log_get_crash_point_lsa (void)
 }
 
 /*
- * log_find_find_lsa -
+ * log_get_append_lsa -
  *
- * return:
+ * return: a snapshot of log_Gl.hdr.append_lsa
  *
- * NOTE:
+ * NOTE: the append lsa is advanced without a lock shared with its readers,
+ *       so it is copied with one atomic load;
+ *       a piecewise copy could observe a concurrent update halfway.
  */
-LOG_LSA *
+LOG_LSA
 log_get_append_lsa (void)
 {
-  return (&log_Gl.hdr.append_lsa);
+  return ATOMIC_LOAD_64_ACQUIRE (&log_Gl.hdr.append_lsa);
 }
 
 /*
@@ -9829,7 +9831,7 @@ log_get_undo_record (THREAD_ENTRY * thread_p, LOG_PAGE * log_page_p, LOG_LSA pro
   bool area_was_mallocated = false;
 
   /* assert log record is not in prior list */
-  oldest_prior_lsa = *log_get_append_lsa ();
+  oldest_prior_lsa = log_get_append_lsa ();
   assert (LSA_LT (&process_lsa, &oldest_prior_lsa));
 
   log_rec_header = LOG_GET_LOG_RECORD_HEADER (log_page_p, &process_lsa);

--- a/src/transaction/log_manager.h
+++ b/src/transaction/log_manager.h
@@ -63,7 +63,7 @@ extern bool log_is_in_crash_recovery (void);
 extern bool log_is_in_crash_recovery_and_not_yet_completes_redo (void);
 extern LOG_LSA *log_get_restart_lsa (void);
 extern LOG_LSA *log_get_crash_point_lsa (void);
-extern LOG_LSA *log_get_append_lsa (void);
+extern LOG_LSA log_get_append_lsa (void);
 extern LOG_LSA *log_get_eof_lsa (void);
 extern bool log_is_logged_since_restart (const LOG_LSA * lsa_ptr);
 extern int log_get_db_start_parameters (INT64 * db_creation, LOG_LSA * chkpt_lsa);

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -1748,7 +1748,7 @@ logpb_fetch_page (THREAD_ENTRY * thread_p, const LOG_LSA * req_lsa, LOG_CS_ACCES
 
   logpb_log ("called logpb_fetch_page with pageid = %lld\n", (long long int) req_lsa->pageid);
 
-  LSA_COPY (&append_lsa, &log_Gl.hdr.append_lsa);
+  append_lsa = log_get_append_lsa ();
   LSA_COPY (&append_prev_lsa, &log_Gl.append.prev_lsa);
 
   /*
@@ -2630,6 +2630,7 @@ static void
 logpb_next_append_page (THREAD_ENTRY * thread_p, LOG_SETDIRTY current_setdirty)
 {
   LOG_FLUSH_INFO *flush_info = &log_Gl.flush_info;
+  LOG_LSA next_append_lsa;
   bool need_flush;
 #if defined(SERVER_MODE)
   int rv;
@@ -2655,8 +2656,13 @@ logpb_next_append_page (THREAD_ENTRY * thread_p, LOG_SETDIRTY current_setdirty)
 
   log_Gl.append.log_pgptr = NULL;
 
-  log_Gl.hdr.append_lsa.pageid++;
-  log_Gl.hdr.append_lsa.offset = 0;
+  /* Advance append_lsa to the next page with one atomic store.
+   * Lock-free readers treat append_lsa as the upper bound of the log already copied into the log page buffer;
+   * a two-step update (pageid++, then offset = 0) exposes a transient value larger than the settled one,
+   * which breaks the monotonicity those readers rely on. */
+  next_append_lsa.pageid = log_Gl.hdr.append_lsa.pageid + 1;
+  next_append_lsa.offset = 0;
+  ATOMIC_STORE_64_RELEASE (&log_Gl.hdr.append_lsa, next_append_lsa);
 
   /*
    * Is the next logical page to archive, currently located at the physical


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27320

### Purpose

`logpb_next_append_page ()` 가 `append_lsa` 를 두 번의 store(`pageid++` 후 `offset = 0`)로 갱신하고, `append_lsa` 를 잠금 없이 읽는 MVCC 리더도 이 값을 한 번에 읽지 않는다. 그래서 리더가 실재한 적 없는 혼합값을 관측한다 -- 쓰기 쪽은 확정값 (P+1, 0) 보다 큰 (P+1, 이전 offset) 을 노출하고, 읽기 쪽은 `pageid` 와 `offset` 을 따로 적재해 두 시점의 값을 섞는다. 관측된 abort 는 뒤엣것으로, `log_get_undo_record ()` 의 진입 assert 를 오발동시킨다. 이 변경은 갱신을 단일 원자 store 로, 리더의 읽기를 원자 load 로 바꿔 두 혼합값을 모두 없앤다.

### Implementation

- `logpb_next_append_page ()`: 다음 append lsa 를 지역 변수에 구성한 뒤 `ATOMIC_STORE_64_RELEASE` (release) 한 번으로 반영한다.
- `log_get_append_lsa ()`: 포인터 대신 값을 반환하고, 내부에서 `ATOMIC_LOAD_64_ACQUIRE` (acquire)로 스냅샷을 복사한다. `append_lsa` 를 잠금 없이 읽는 3지점(`heap_get_visible_version_from_log ()`, `logpb_fetch_page ()`, `log_get_undo_record ()`)이 모두 이 함수를 거치게 되며, 해소된 `TODO: fix atomicity issue on x86` 주석은 제거한다.
- `porting.h`: `ATOMIC_LOAD_64_ACQUIRE` / `ATOMIC_STORE_64_RELEASE` 템플릿을 추가한다. 기존 정수 전용 매크로 `ATOMIC_LOAD_64` / `ATOMIC_STORE_64` (read-modify-write 기반)와 달리 순수 load/store 이고, `log_lsa` 비트필드 구조체 같은 64비트 trivially-copyable 타입을 받는다 (`static_assert` 로 크기/정렬/복사 가능성을 강제).
- `xrepl_log_get_append_lsa ()`: 포인터 반환 계약을 유지하기 위해 위임 대신 `log_Gl.hdr.append_lsa` 를 직접 참조한다. 변경 전 `log_get_append_lsa ()` 도 같은 전역의 포인터를 반환했으므로 이 자리의 동작은 변경 전후가 같다.

### Remarks

- 두 변경은 서로 다른 혼합값을 없애므로 어느 하나만으로는 레이스가 남는다. 관측된 abort 는 읽기 쪽 혼합값에서 온다. 쓰기 쪽 중간값이 진입 가드를 속이는 경로는 `logpb_fetch_page ()` 의 `append.prev_lsa` 조건이 막고, 관측된 적도 없다.
- 그 `append.prev_lsa` 읽기는 평문으로 남는다. 실제보다 큰 값으로 찢어져 읽히면 위 조건의 보호가 성립하지 않는다. 이번 범위 밖이다.
- 수정본에서 이 abort 가 사라지는지는 확인하지 않았다. 머지 후 CI 관찰로 판정한다.
- 밖에서 보이는 동작 변화는 없다. 리더가 관측하는 값의 시퀀스가 참값의 증가와 같아질 뿐, 디스크 포맷과 잠금 구조는 그대로다.
- append 경로의 다른 `offset += size` 갱신들은 의도적으로 평문 store 로 남긴다. LOG_CS 소유자의 단일 워드 단조 증가라 확정값보다 큰 값을 노출할 수 없기 때문이다. 다만 C++ 메모리 모델 기준으로는 새 원자 load 와의 형식적 데이터 레이스가 남으며, append 경로 전체의 원자화는 별도 정리로 남긴다.
- `xrepl_log_get_append_lsa ()` 는 복제 위치 조회용으로 잠금 없이 필드 단위로 읽는 코드로 남는다. 이 변경으로 페이지 전환이 만들던 중간값 관측은 제거되지만, 이 함수의 계약 자체는 바꾸지 않았다.
