### PR TITLE
[CBRD-27179] Fix a fatal archive read while recording the volume CDC needs

### DIFF
--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -1028,6 +1028,7 @@ extern LOG_PHY_PAGEID logpb_to_physical_pageid (LOG_PAGEID logical_pageid);
 extern bool logpb_is_page_in_archive (LOG_PAGEID pageid);
 extern bool logpb_is_smallest_lsa_in_archive (THREAD_ENTRY * thread_p);
 extern int logpb_get_archive_number (THREAD_ENTRY * thread_p, LOG_PAGEID pageid);
+extern int logpb_get_archive_num_for_pageid (THREAD_ENTRY * thread_p, LOG_PAGEID pageid);
 extern void logpb_decache_archive_info (THREAD_ENTRY * thread_p);
 extern LOG_PAGE *logpb_fetch_from_archive (THREAD_ENTRY * thread_p, LOG_PAGEID pageid, LOG_PAGE * log_pgptr,
 					   int *ret_arv_num, LOG_ARV_HEADER * arv_hdr, bool is_fatal);

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -14217,7 +14217,7 @@ cdc_update_arv_num_to_keep (THREAD_ENTRY * thread_p, const LOG_LSA * bundle_star
        * the archive descriptor with LOG_ARCHIVE_CS. Keeping every volume that is left would also be correct, but
        * nothing can narrow that down before a client reconnects, so a restart in between would leave the header
        * naming the oldest volume alive and stop archive removal altogether. */
-      arv_num = logpb_get_archive_number (thread_p, bundle_start_lsa->pageid);
+      arv_num = logpb_get_archive_num_for_pageid (thread_p, bundle_start_lsa->pageid);
       if (arv_num < 0)
 	{
 	  /* Could not be read. Keep every volume that is left rather than give one up. */

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -5121,6 +5121,17 @@ logpb_get_archive_num_for_pageid (THREAD_ENTRY * thread_p, LOG_PAGEID pageid)
       fileio_close (vdes);
 
       arv_hdr = (LOG_ARV_HEADER *) log_pgptr->area;
+
+      if (log_Gl.append.vdes != NULL_VOLDES
+	  && difftime64 ((time_t) arv_hdr->db_creation, (time_t) log_Gl.hdr.db_creation) != 0)
+	{
+	  /* Not an archive of this database - a leftover, or another database's file sitting under the name
+	   * this one would use. Its page range says nothing about where the page is, so it must neither be
+	   * matched against nor end the walk. logpb_fetch_from_archive () makes the same check before it
+	   * trusts an archive header. */
+	  continue;
+	}
+
       if (arv_hdr->fpageid <= pageid && pageid < arv_hdr->fpageid + arv_hdr->npages)
 	{
 	  found = arv_num;

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -5069,6 +5069,74 @@ logpb_strip_cdc_arv_num_from_header_page (void *page_ptr)
 }
 
 /*
+ * logpb_get_archive_num_for_pageid - Archive volume that holds a page, without going through the
+ *                                    shared archive descriptor
+ *
+ * return: archive number, or -1 when no surviving volume holds the page
+ *
+ *   pageid(in): the page to look for
+ *
+ * NOTE: logpb_get_archive_number () answers the same question through logpb_fetch_from_archive (),
+ *       which works from log_Gl.archive.vdes - a descriptor other paths mount and dismount under it.
+ *       Asking from a client request thread has been seen to read through a descriptor another thread
+ *       had already closed: a FATAL ER_LOG_READ against volume "(null)", and the volume left marked
+ *       unavailable for the rest of the server's life. Only the archive header is needed to answer
+ *       this, so each candidate is opened with its own read-only descriptor and closed again, and no
+ *       shared state is involved. logpb_fetch_header_from_active_log () reads a backup the same way.
+ */
+int
+logpb_get_archive_num_for_pageid (THREAD_ENTRY * thread_p, LOG_PAGEID pageid)
+{
+  char arv_name[PATH_MAX];
+  char page_buf[IO_MAX_PAGE_SIZE + MAX_ALIGNMENT];
+  LOG_PAGE *log_pgptr;
+  LOG_ARV_HEADER *arv_hdr;
+  int arv_num, vdes, found = -1;
+
+  log_pgptr = (LOG_PAGE *) PTR_ALIGN (page_buf, MAX_ALIGNMENT);
+
+  for (arv_num = log_Gl.hdr.last_deleted_arv_num + 1; arv_num < log_Gl.hdr.nxarv_num; arv_num++)
+    {
+      fileio_make_log_archive_name (arv_name, log_Archive_path, log_Prefix, arv_num);
+      if (fileio_is_volume_exist (arv_name) == false)
+	{
+	  continue;
+	}
+
+      vdes = fileio_open (arv_name, O_RDONLY, 0);
+      if (vdes == NULL_VOLDES)
+	{
+	  continue;
+	}
+
+      if (fileio_read (thread_p, vdes, log_pgptr, 0, LOG_PAGESIZE) == NULL)
+	{
+	  /* One unreadable candidate is not a reason to give up on the others, and it is not fatal:
+	   * the caller falls back to keeping every volume that is left. */
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_LOG_READ, 3, 0LL, 0LL, arv_name);
+	  fileio_close (vdes);
+	  continue;
+	}
+
+      fileio_close (vdes);
+
+      arv_hdr = (LOG_ARV_HEADER *) log_pgptr->area;
+      if (arv_hdr->fpageid <= pageid && pageid < arv_hdr->fpageid + arv_hdr->npages)
+	{
+	  found = arv_num;
+	  break;
+	}
+      if (arv_hdr->fpageid > pageid)
+	{
+	  /* volumes are numbered in page order, so nothing further along can hold it either */
+	  break;
+	}
+    }
+
+  return found;
+}
+
+/*
  * logpb_get_cdc_arv_num_for_pageid - Archive volume holding a page CDC still needs
  *
  * return: archive number, or -1 when it could not be worked out
@@ -5093,7 +5161,7 @@ logpb_get_cdc_arv_num_for_pageid (THREAD_ENTRY * thread_p, LOG_PAGEID pageid)
       return last_arv_num;
     }
 
-  last_arv_num = logpb_get_archive_number (thread_p, pageid);
+  last_arv_num = logpb_get_archive_num_for_pageid (thread_p, pageid);
   last_pageid = (last_arv_num >= 0) ? pageid : NULL_PAGEID;
 
   return last_arv_num;


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27179>

### Purpose

CBRD-27179 로 추가한 `cdc_update_arv_num_to_keep()` 이 보호할 볼륨 번호를 구할 때
`logpb_get_archive_number()` 를 호출한다. 그 함수는 `logpb_fetch_from_archive()` 를 타고
아카이브 볼륨을 `LOG_DBLOG_ARCHIVE_VOLID` 로 mount 하는데, 이 조회는 CDC 클라이언트의
요청 스레드(`scdc_get_loginfo_metadata`)에서 일어난다.

부하 상황에서 mount 로 받은 디스크립터가 다음 읽기 시점에 이미 무효인 것이 실측으로 확인됐다.
`fileio_mount()` 는 파일을 열면서 내부 볼륨 목록에도 등록하고, 에러 보고는 그 목록에서
디스크립터로 볼륨 이름을 찾는다. 볼륨 이름이 `"(null)"` 로 찍힌 것은 등록이 이미 사라졌다는 뜻이다.

```
scdc_get_loginfo_metadata            (network_interface_sr.c)
  cdc_update_arv_num_to_keep         (log_manager.c)
    logpb_get_archive_number         (log_page_buffer.c)
      logpb_fetch_from_archive
        fileio_read         ERROR -13   Bad file descriptor, volume "(null)"
        fileio_synchronize  FATAL -599  Bad file descriptor, volume "Unknown"
        er_set              FATAL -78   ER_LOG_READ, page 253 of "(null)"
```

서버가 죽지는 않는다. `logpb_get_archive_number()` 는 `is_fatal=false` 로 호출하므로
`logpb_fatal_error()` 까지 가지 않는다. 다만 세 가지가 남는다.

* 해당 CDC 추출 요청이 실패한다. 클라이언트는 `-30` 을 받고 재시도한다
* FATAL 심각도 항목이 서버 에러 로그에 남아, 요청 하나 실패가 장애로 보인다
* `logpb_set_unavailable_archive()` 가 그 볼륨을 서버 수명 내내 사용 불가로 표시한다.
  이후 vacuum / flashback / CDC 의 정당한 아카이브 읽기까지 거부될 수 있다

이 조회는 원래 요청 스레드에서 하지 않기로 했다가, 리뷰 의견(`LOG_CS` 를 잡고 있으므로 안전하다)에
따라 되살린 것이다. `LOG_CS` 와 `LOG_ARCHIVE_CS` 를 모두 잡아도 증상이 재현되므로 그 전제는
성립하지 않는다.

### Implementation

공유 볼륨 목록을 거치지 않고 볼륨 번호를 구하는 `logpb_get_archive_num_for_pageid()` 를 추가한다.

```c
  for (arv_num = log_Gl.hdr.last_deleted_arv_num + 1; arv_num < log_Gl.hdr.nxarv_num; arv_num++)
    {
      fileio_make_log_archive_name (arv_name, log_Archive_path, log_Prefix, arv_num);
      ...
      vdes = fileio_open (arv_name, O_RDONLY, 0);
      ...
      fileio_read (thread_p, vdes, log_pgptr, 0, LOG_PAGESIZE)
      fileio_close (vdes);

      arv_hdr = (LOG_ARV_HEADER *) log_pgptr->area;
      if (arv_hdr->fpageid <= pageid && pageid < arv_hdr->fpageid + arv_hdr->npages)
	{
	  found = arv_num;
	  break;
	}
```

* 후보 볼륨을 각각 **전용 read-only 디스크립터**로 열어 아카이브 헤더만 읽고 바로 닫는다.
  `fileio_mount()` 를 쓰지 않으므로 공유 볼륨 목록에 등록하지 않고, 다른 경로가 그 목록을
  어떻게 다루든 영향을 받지 않는다
* 볼륨은 페이지 순서로 번호가 매겨지므로, `fpageid` 가 찾는 페이지를 지나치면 조기 종료한다
* 한 볼륨을 읽지 못해도 치명적으로 올리지 않고 다음 후보로 넘어간다. 전부 실패해 `-1` 이면
  호출자가 기존대로 살아있는 볼륨 전부를 보호하는 값으로 물러난다
* `logpb_fetch_header_from_active_log()` 가 백업의 액티브 로그를 읽는 방식과 같다.
  CBRD-27166 도 같은 이유로 아카이브 전송에 전용 디스크립터를 쓴다

호출 지점 두 곳을 새 함수로 바꿨다.

| 호출 지점 | 이유 |
|---|---|
| `cdc_update_arv_num_to_keep()` | 증상이 발생한 자리. 클라이언트 요청 스레드에서 조회한다 |
| `logpb_get_cdc_arv_num_for_pageid()` | 삭제 경로의 같은 조회. 동일한 노출이 있던 자리 |

### Test

증상을 잡아낸 부하 스크립트를 수정 전/후 동일 조건으로 실행했다. 8 라운드 동안 insert 와 CDC
추출을 동시에 진행한다.

| 항목 | 수정 전 | 수정 후 |
|---|---|---|
| `cdc_update_arv_num_to_keep` 경유 FATAL | 3 건 | 0 건 |
| 클라이언트 실오류 | 1 라운드에서 발생 | 없음 |
| 서버 생존 | 생존 | 생존 |
| 소비한 id 연속성 | 1..12814 유실 0 | 1..11753 유실 0 |
| core 파일 | 0 | 0 |

수정 전 스택은 Purpose 에 적은 것과 같다. 수정 후에는 해당 스택이 나타나지 않는다.

이 외에 CBRD-27179 의 수용 시나리오 8 건(비정상 종료 / 서버 크래시 / 정상 종료 / 정상 종료 시
연결 유무별 / 백업 복구 / 백업 경로 액티브 로그 복구)과 정확 볼륨 기록, 되감기 반복 부하,
스탠드얼론 모드, 잘못된 값 주입을 함께 재실행하여 회귀가 없음을 확인했다.

검증 스위트는 `run_all.sh` 하나로 전체를 실행할 수 있게 정리해 두었다. 어떤 환경에서든
`$CUBRID` 만 설정되어 있으면 동작하고, 데이터베이스와 설정 구획을 스스로 만들고 되돌린다.

"아카이브가 남아 있다" 는 관찰만으로는 근거가 되지 않으므로, 보존을 주장하는 항목은 삭제가
**정확히 워터마크 바로 아래에서 멈췄는지** 와 **다른 게이트(crash recovery / vacuum / flashback /
백업 핀 / `log_max_archives`) 는 더 지울 수 있었는지** 를 함께 단정한다. 구분되지 않는 경우에는
워터마크만 지우고 같은 라운드를 반복하여 아카이브가 삭제되는지로 귀속을 확정한다.

### Remarks

원인 규명이 끝나지 않았다. 확인된 것은 mount 로 받은 등록이 다음 읽기 전에 사라졌다는 사실이고,
어느 경로가 그것을 해제하는지는 특정하지 못했다. 이 수정은 공유 목록을 아예 쓰지 않으므로 그
경로와 무관하게 증상이 사라지지만, 근본 원인은 별도로 다룰 필요가 있다.

조사 과정에서 확인한 인접 사항이다. `logpb_archive_active_log()` 는 `LOG_ARCHIVE_CS` 를
함수 끝에서 아카이브 캐시 정보를 갱신하는 구간에만 사용하고, `LOG_DBLOG_ARCHIVE_VOLID` 로
mount 하는 지점은 그 밖에 있다. `develop` 도 같은 구조이므로 백포트로 해소되는 사항은 아니다.
현재는 상위 `LOG_CS` 로 대부분 가려져 있으나, 아카이브를 읽는 다른 기능(vacuum, flashback,
복구, 백업)도 같은 목록을 공유한다.
