### PR TITLE
[CBRD-27275] Orphan row remains in _db_trigger after CREATE TRIGGER failure, allowing duplicate trigger creation with the same name

### DIFF
--- a/src/object/trigger_manager.c
+++ b/src/object/trigger_manager.c
@@ -4062,16 +4062,12 @@ tr_create_trigger (const char *name, DB_TRIGGER_STATUS status, double priority, 
       goto error;
     }
 
-  if (TM_TRAN_ISOLATION () >= TRAN_REP_READ)
+  if (tran_system_savepoint (UNIQUE_SAVEPOINT_CREATE_TRIGGER) != NO_ERROR)
     {
-      /* protect against multiple flushes to server */
-      if (tran_system_savepoint (UNIQUE_SAVEPOINT_CREATE_TRIGGER) != NO_ERROR)
-	{
-	  goto error;
-	}
-
-      has_savepoint = true;
+      goto error;
     }
+
+  has_savepoint = true;
 
   /* from here down, the unwinding when errors are encountered gets rather complex */
 
@@ -4141,14 +4137,9 @@ error:
 
   if (trigger != NULL)
     {
-      if (object != NULL)
+      if (tr_object_map_added)
 	{
-	  if (tr_object_map_added)
-	    {
-	      (void) mht_rem (tr_object_map, trigger->object, NULL, NULL);
-	    }
-
-	  (void) trigger_table_drop (trigger->name);
+	  (void) mht_rem (tr_object_map, trigger->object, NULL, NULL);
 	}
       remove_trigger_list (&tr_Uncommitted_triggers, trigger);
       tr_drop_deferred_activities (trigger->object, NULL);
@@ -4399,18 +4390,21 @@ tr_drop_trigger_internal (TR_TRIGGER * trigger, int rollback, bool need_savepoin
 	       * if this isn't a rollback, delete the object, otherwise
 	       * it will already be marked as deleted as part of the normal transaction cleanup
 	       */
-	      db_drop (trigger->object);
-
-	      /*
-	       * flush, decache object; no need to check if the object was indeed deleted;
-	       * it is supposed that the last version of the object was locked and deleted
-	       * because only the last version can be locked; previous versions are in the log
-	       */
-	      error = locator_flush_instance (trigger->object);
-	      if (error == NO_ERROR)
+	      error = db_drop (trigger->object);
+	      /* if the object has been deleted, just ignore the error */
+	      if (error == NO_ERROR || error == ER_HEAP_UNKNOWN_OBJECT)
 		{
-		  ws_decache (trigger->object);
-		  ws_clear_hints (trigger->object, false);
+		  /*
+		   * flush, decache object; no need to check if the object was indeed deleted;
+		   * it is supposed that the last version of the object was locked and deleted
+		   * because only the last version can be locked; previous versions are in the log
+		   */
+		  error = locator_flush_instance (trigger->object);
+		  if (error == NO_ERROR)
+		    {
+		      ws_decache (trigger->object);
+		      ws_clear_hints (trigger->object, false);
+		    }
 		}
 	    }
 
@@ -4485,9 +4479,7 @@ tr_drop_trigger (DB_OBJECT * obj, bool call_from_api)
 
       if (error == NO_ERROR)
 	{
-	  bool need_savepoint = (TM_TRAN_ISOLATION () >= TRAN_REP_READ);
-
-	  error = tr_drop_trigger_internal (trigger, 0, need_savepoint);
+	  error = tr_drop_trigger_internal (trigger, 0, true);
 	}
     }
 
@@ -6818,14 +6810,10 @@ tr_rename_trigger (DB_OBJECT * trigger_object, const char *name, bool call_from_
 	}
       else
 	{
-	  if (TM_TRAN_ISOLATION () >= TRAN_REP_READ)
+	  error = tran_system_savepoint (UNIQUE_SAVEPOINT_RENAME_TRIGGER);
+	  if (error == NO_ERROR)
 	    {
-	      /* protect against multiple flushes to server */
-	      error = tran_system_savepoint (UNIQUE_SAVEPOINT_RENAME_TRIGGER);
-	      if (error == NO_ERROR)
-		{
-		  has_savepoint = true;
-		}
+	      has_savepoint = true;
 	    }
 
 	  if (error == NO_ERROR)
@@ -6836,31 +6824,18 @@ tr_rename_trigger (DB_OBJECT * trigger_object, const char *name, bool call_from_
 	  /* might need to abort the transaction here */
 	  if (error == NO_ERROR)
 	    {
-	      oldname = trigger->name;
-	      trigger->name = newname;
 	      db_make_string (&value, newname);
-	      newname = NULL;
 	      error = db_put_internal (trigger_object, TR_ATT_NAME, &value);
 	      if (error == NO_ERROR)
 		{
 		  error = locator_flush_instance (trigger_object);
 		}
 
-	      if (error != NO_ERROR)
+	      if (error == NO_ERROR)
 		{
-		  /*
-		   * hmm, couldn't set the new name, put the old one back,
-		   * we might need to abort the transaction here ?
-		   */
-		  ASSERT_ERROR ();
-		  newname = trigger->name;
-		  trigger->name = oldname;
-		  /* if we can't do this, the transaction better abort */
-		  (void) trigger_table_rename (trigger_object, oldname);
-		  oldname = NULL;
-		}
-	      if (oldname != NULL)
-		{
+		  oldname = trigger->name;
+		  trigger->name = newname;
+		  newname = NULL;
 		  free_and_init (oldname);
 		}
 	    }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27275

### Purpose
- `CREATE TRIGGER` 실패 시 `_db_trigger` 에 남는 orphan row 를 없애, 같은 이름의 트리거가 중복 생성되거나 `DROP TRIGGER` 로 지울 수 없는 트리거가 남는 것을 막는다.

### Implementation
- CREATE / DROP / RENAME TRIGGER 가 isolation 과 무관하게 savepoint 를 잡고, 실패하면 savepoint 로 rollback 한다.

### Remarks
- savepoint 의 isolation 조건은 CUBRIDSUS-14699 에서 붙은 것으로, 그 이슈가 다룬 충돌만 REPEATABLE READ 이상에서 생긴다.
- 11.4 / 11.3 / 11.0 / 10.2 backport 대상이다.
- _db_trigger 에 unique 제약을 추가하지 않은 이유, 트리거 조회를 _db_trigger 로 옮기지 않은 이유, savepoint 를 isolation 조건에서 분리한 근거는 jira를 참고하시기 바랍니다.

