### PR TITLE
[CUBRIDQA-1245] CI: cap core files at 4GB and collect ERROR_BACKUP on failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,7 +334,7 @@ commands:
           shell: /bin/bash
           no_output_timeout: 45m
           command: |
-            ulimit -c 10485760   # limit core files to 10mb
+            ulimit -c 4194304   # limit core files to 4GB (ulimit -c counts 1024-byte blocks)
             /entrypoint.sh test
       - run:
           name: Collect Logs
@@ -349,6 +349,10 @@ commands:
               mv -f cubrid-testtools/CTP/sql/log /tmp/logs/ctp_log || true
             fi
             [ -e CUBRID/log/coredump ] && mv -f CUBRID/log/coredump /tmp/logs/coredump || true
+            # CTP shell saves a failure snapshot (AUTO_*.tar.gz: CUBRID copy, case dir,
+            # core) under $HOME/ERROR_BACKUP. The entrypoint runs CTP with HOME=/home,
+            # which is this working directory, so keep everything it left there.
+            [ -e ERROR_BACKUP ] && mv -f ERROR_BACKUP /tmp/logs/ || true
             mv -f tc.list /tmp/logs/ || true
       - store_test_results:
           path: /tmp/tests


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBRIDQA-1245>

### Purpose

- shell 테스트 pod에서 테스트 케이스가 실패하면 CTP가 `ERROR_BACKUP/AUTO_*.tar.gz`로 실패 스냅샷을 남긴다. 스냅샷에는 CUBRID 디렉터리 복사본, 케이스 디렉터리, core 파일이 들어 있다.
- 그런데 `Collect Logs` 단계가 이 디렉터리를 수집하지 않는다. core 파일은 CTP가 스냅샷에 담은 뒤 원본을 지운다. 그래서 지금은 CircleCI artifact에 core가 남지 않는다.
- core 파일 크기 제한 `ulimit -c 10485760`의 주석은 10MB라고 적혀 있다. 그러나 `ulimit -c`의 단위는 1024바이트 블록이다. 실제 제한은 10GB였다. shell pod는 ramdisk 위에서 돈다.

### Implementation

- `Run tests` 단계의 core 파일 크기 제한을 4GB(`ulimit -c 4194304`)로 바꿨다. 주석도 단위를 포함해 고쳤다.
- `Collect Logs` 단계가 작업 디렉터리(`/home`)의 `ERROR_BACKUP`을 `/tmp/logs/`로 옮긴다. 이 단계는 실패 시에만 돈다.
- 결과로 실패한 shell 테스트의 artifact에 `ERROR_BACKUP/AUTO_*.tar.gz`가 함께 남는다. `ERROR_BACKUP`이 없으면 이 단계는 아무 일도 하지 않는다.

### Remarks

- artifact 크기가 늘어난다. 스냅샷 하나에 `$CUBRID` 전체 복사본이 들어간다. 실패 케이스마다 스냅샷이 하나씩 생긴다.
- 컨테이너 entrypoint(`cubridci` 이미지)도 자체로 `ulimit -c 10485760`을 실행한다. pod가 privileged면 root가 hard limit을 다시 올릴 수 있다. 그 경우 실제 제한은 entrypoint 값(10GB)이 된다. 이 PR은 `config.yml`만 다룬다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016LSkX9jvST3srqT5nyVF4q
