### PR TITLE
[CBRD-27310] Keep constant-true HAVING without GROUP BY so its plan-cache key does not collide with the plain query

### DIFF
--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -8011,7 +8011,17 @@ pt_eval_type (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_
 	  node->info.query.q.select.connect_by = pt_where_type_keep_true (parser, node->info.query.q.select.connect_by);
 	  node->info.query.q.select.start_with = pt_where_type (parser, node->info.query.q.select.start_with);
 	  node->info.query.q.select.after_cb_filter = pt_where_type (parser, node->info.query.q.select.after_cb_filter);
-	  node->info.query.q.select.having = pt_where_type (parser, node->info.query.q.select.having);
+	  if (node->info.query.q.select.group_by == NULL)
+	    {
+	      /* HAVING without GROUP BY makes the query a single-group aggregate; if a constant-true
+	       * HAVING were dropped here, the rewritten text (xasl cache key) would collide with the
+	       * plain query's although their results differ. Keep a TRUE marker instead. */
+	      node->info.query.q.select.having = pt_where_type_keep_true (parser, node->info.query.q.select.having);
+	    }
+	  else
+	    {
+	      node->info.query.q.select.having = pt_where_type (parser, node->info.query.q.select.having);
+	    }
 	  node->info.query.orderby_for = pt_where_type (parser, node->info.query.orderby_for);
 	}
       break;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27310

### Purpose
`SELECT 1 FROM t WHERE a > 0 HAVING 1=1`(GROUP BY 없는 HAVING → 단일그룹 집계, 1행)과 `SELECT 1 FROM t WHERE a > 0`(조건 통과 전체 행, N행)의 rewrite 결과 텍스트가 같아져 **plan-cache 키가 충돌**한다. 먼저 컴파일된 플랜을 뒤 쿼리가 재사용하므로, 같은 쿼리가 캐시 상태(실행 순서)에 따라 다른 행 수를 반환한다.

```sql
select 1 from t1 where a > 0;             -- 5행, BUILDLIST 플랜 캐시
select 1 from t1 where a > 0 having 1=1;  -- 위 플랜 재사용 -> 5행 (오답, 1행이어야)

select 1 from t2 where a > 0 having 1=1;  -- 1행, BUILDVALUE 플랜 캐시
select 1 from t2 where a > 0;             -- 위 플랜 재사용 -> 1행 (오답, 5행이어야)
```

### Implementation
원인은 다음 순서로 발생한다.

1. `pt_semantic_check_local()` → `pt_check_group_by()` → `pt_has_aggregate()`가 HAVING 절이 존재한다는 것만으로 `PT_SELECT_INFO_HAS_AGG` 플래그를 세운다.
2. 이후 `pt_semantic_type()` → `pt_eval_type()`에서 `1=1`이 상수 TRUE로 fold되고, `pt_where_type()`이 TRUE 항을 잘라내 `having == NULL`이 된다.
3. 플래그는 남아 있어 BUILDVALUE 플랜이 만들어지지만, `do_prepare_select()`는 이 시점 이후의 트리를 출력해 캐시 키(`alias_print`)를 만들기 때문에 HAVING 없는 쿼리와 텍스트가 같아진다.

수정: `src/parser/type_checking.c`의 `pt_eval_type()` `PT_SELECT` 분기에서, **GROUP BY가 없는 경우** HAVING을 `pt_where_type()` 대신 `pt_where_type_keep_true()`로 처리한다(`connect_by`가 이미 같은 이유로 사용하는 헬퍼). 상수-참 HAVING이 TRUE 값 노드로 남아 rewrite 텍스트가 `... having 1 <> 0`이 되고, 별도의 캐시 엔트리를 갖게 된다.

GROUP BY가 있으면 텍스트에 `group by`가 이미 포함되어 충돌이 없고, HAVING 유무로 결과 카디널리티도 달라지지 않으므로 기존처럼 TRUE 항을 제거한다.

### Remarks
검증 (debug 빌드, CS 모드):

| 쿼리 | 수정 전 | 수정 후 |
|---|---|---|
| plain 먼저 → `HAVING 1=1` | 5 / **5** | 5 / 1 |
| `HAVING 1=1` 먼저 → plain | 1 / **1** | 1 / 5 |
| `HAVING 1=1 OR 2=2`, `HAVING 1=1 AND 1=1` | – | 1행 |
| `HAVING 1=0` | – | 0행 |
| `count(*) ... HAVING 1=1 [AND count(*) > 10]` | – | 1행 / 0행 |
| `GROUP BY a HAVING 1=1` / `HAVING 1=0` | – | 5행 / 0행 |
| 뷰, derived table, PREPARE/EXECUTE의 `HAVING 1=1` | – | 1행 |

- 수정 전 재현은 수정 전 `type_checking.c`로 링크한 `libcubridcs`를 `LD_PRELOAD`로 실행해 확인했고, rewritten query에 HAVING이 사라진 것과 오답을 그대로 재현했다.
- Jira 첨부 `plan_cache_having_alias_repro.sql`이 양방향 모두 정상 통과한다.
