### PR TITLE
[CBRD-27275] Revert: Orphan row remains in _db_trigger after CREATE TRIGGER failure, allowing duplicate trigger creation with the same name

### DIFF
--- a/src/object/trigger_manager.c
+++ b/src/object/trigger_manager.c
@@ -4087,12 +4087,16 @@ tr_create_trigger (const char *name, DB_TRIGGER_STATUS status, double priority, 
       goto error;
     }
 
-  if (tran_system_savepoint (UNIQUE_SAVEPOINT_CREATE_TRIGGER) != NO_ERROR)
+  if (TM_TRAN_ISOLATION () >= TRAN_REP_READ)
     {
-      goto error;
-    }
+      /* protect against multiple flushes to server */
+      if (tran_system_savepoint (UNIQUE_SAVEPOINT_CREATE_TRIGGER) != NO_ERROR)
+	{
+	  goto error;
+	}
 
-  has_savepoint = true;
+      has_savepoint = true;
+    }
 
   /* from here down, the unwinding when errors are encountered gets rather complex */
 
@@ -4162,9 +4166,14 @@ error:
 
   if (trigger != NULL)
     {
-      if (tr_object_map_added)
+      if (object != NULL)
 	{
-	  (void) mht_rem (tr_object_map, trigger->object, NULL, NULL);
+	  if (tr_object_map_added)
+	    {
+	      (void) mht_rem (tr_object_map, trigger->object, NULL, NULL);
+	    }
+
+	  (void) trigger_table_drop (trigger->name);
 	}
       remove_trigger_list (&tr_Uncommitted_triggers, trigger);
       tr_drop_deferred_activities (trigger->object, NULL);
@@ -4446,21 +4455,18 @@ tr_drop_trigger_internal (TR_TRIGGER * trigger, int rollback, bool need_savepoin
 	       * if this isn't a rollback, delete the object, otherwise
 	       * it will already be marked as deleted as part of the normal transaction cleanup
 	       */
-	      error = db_drop (trigger->object);
-	      /* if the object has been deleted, just ignore the error */
-	      if (error == NO_ERROR || error == ER_HEAP_UNKNOWN_OBJECT)
+	      db_drop (trigger->object);
+
+	      /*
+	       * flush, decache object; no need to check if the object was indeed deleted;
+	       * it is supposed that the last version of the object was locked and deleted
+	       * because only the last version can be locked; previous versions are in the log
+	       */
+	      error = locator_flush_instance (trigger->object);
+	      if (error == NO_ERROR)
 		{
-		  /*
-		   * flush, decache object; no need to check if the object was indeed deleted;
-		   * it is supposed that the last version of the object was locked and deleted
-		   * because only the last version can be locked; previous versions are in the log
-		   */
-		  error = locator_flush_instance (trigger->object);
-		  if (error == NO_ERROR)
-		    {
-		      ws_decache (trigger->object);
-		      ws_clear_hints (trigger->object, false);
-		    }
+		  ws_decache (trigger->object);
+		  ws_clear_hints (trigger->object, false);
 		}
 	    }
 
@@ -4535,7 +4541,9 @@ tr_drop_trigger (DB_OBJECT * obj, bool call_from_api)
 
       if (error == NO_ERROR)
 	{
-	  error = tr_drop_trigger_internal (trigger, 0, true);
+	  bool need_savepoint = (TM_TRAN_ISOLATION () >= TRAN_REP_READ);
+
+	  error = tr_drop_trigger_internal (trigger, 0, need_savepoint);
 	}
     }
 
@@ -6838,6 +6846,7 @@ tr_rename_trigger (DB_OBJECT * trigger_object, const char *name, bool call_from_
   char *new_name = NULL;
   char *old_name = NULL;
   bool has_savepoint = false;
+  bool is_abort = false;
   int save = 0;
   int error = NO_ERROR;
 
@@ -6876,14 +6885,18 @@ tr_rename_trigger (DB_OBJECT * trigger_object, const char *name, bool call_from_
       goto end;
     }
 
-  error = tran_system_savepoint (UNIQUE_SAVEPOINT_RENAME_TRIGGER);
-  if (error != NO_ERROR)
+  if (TM_TRAN_ISOLATION () >= TRAN_REP_READ)
     {
-      ASSERT_ERROR ();
-      goto end;
-    }
+      /* protect against multiple flushes to server */
+      error = tran_system_savepoint (UNIQUE_SAVEPOINT_RENAME_TRIGGER);
+      if (error != NO_ERROR)
+	{
+	  ASSERT_ERROR ();
+	  goto end;
+	}
 
-  has_savepoint = true;
+      has_savepoint = true;
+    }
 
   error = trigger_table_rename (trigger_object, new_name);
   if (error != NO_ERROR)
@@ -6898,6 +6911,7 @@ tr_rename_trigger (DB_OBJECT * trigger_object, const char *name, bool call_from_
   if (error != NO_ERROR)
     {
       ASSERT_ERROR ();
+      is_abort = true;
       goto end;
     }
   pr_clear_value (&value);
@@ -6907,6 +6921,7 @@ tr_rename_trigger (DB_OBJECT * trigger_object, const char *name, bool call_from_
   if (error != NO_ERROR)
     {
       ASSERT_ERROR ();
+      is_abort = true;
       goto end;
     }
   pr_clear_value (&value);
@@ -6917,6 +6932,7 @@ tr_rename_trigger (DB_OBJECT * trigger_object, const char *name, bool call_from_
       if (error != NO_ERROR)
 	{
 	  ASSERT_ERROR ();
+	  is_abort = true;
 	  goto end;
 	}
     }
@@ -6929,9 +6945,23 @@ tr_rename_trigger (DB_OBJECT * trigger_object, const char *name, bool call_from_
   trigger->name = new_name;
 
 end:
-  if (new_name != NULL && trigger->name != new_name)
+  if (is_abort && error != NO_ERROR)
     {
-      free_and_init (new_name);
+      /* 
+       * Archive old comments:
+       * 1. hmm, couldn't set the new name, put the old one back,
+       *    we might need to abort the transaction here ?
+       * 2. if we can't do this, the transaction better abort
+       */
+      if (trigger_table_rename (trigger_object, old_name) != NO_ERROR)
+	{
+	  assert (false);
+	}
+
+      if (new_name)
+	{
+	  free_and_init (new_name);
+	}
     }
 
   AU_ENABLE (save);


### PR DESCRIPTION
Reverts CUBRID/cubrid#7809