### PR TITLE
[CBRD-27286] heap_hfid_cache_get에서 클래스 레코드의 NULL HFID를 캐시하지 않도록 수정

### DIFF
--- a/src/communication/network_interface_cl.c
+++ b/src/communication/network_interface_cl.c
@@ -5980,8 +5980,15 @@ histogram_build_multi_by_reservoir_request (OID * class_oid, int attr_cnt, const
     }
 
   thread_p = enter_server ();
-  if (heap_get_class_info (thread_p, class_oid, &hfid, NULL, NULL) != NO_ERROR)
+  bool hfid_found = false;
+
+  if (heap_get_class_info (thread_p, class_oid, &hfid, NULL, &hfid_found) != NO_ERROR || !hfid_found)
     {
+      if (!hfid_found)
+	{
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_HEAP_UNKNOWN_OBJECT, 3, class_oid->volid, class_oid->pageid,
+		  class_oid->slotid);
+	}
       exit_server (*thread_p);
       free (priv_blobs);
       return ER_FAILED;

--- a/src/communication/network_interface_sr.cpp
+++ b/src/communication/network_interface_sr.cpp
@@ -2178,8 +2178,15 @@ sqst_histogram_build_by_reservoir (THREAD_ENTRY *thread_p, unsigned int rid, cha
       null_freqs[i] = 0.0;
     }
 
-  if (heap_get_class_info (thread_p, &class_oid, &hfid, NULL, NULL) != NO_ERROR)
+  bool hfid_found;		/* always written by heap_get_class_info () */
+
+  if (heap_get_class_info (thread_p, &class_oid, &hfid, NULL, &hfid_found) != NO_ERROR || !hfid_found)
     {
+      if (!hfid_found)
+	{
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_HEAP_UNKNOWN_OBJECT, 3, class_oid.volid, class_oid.pageid,
+		  class_oid.slotid);
+	}
       status = ER_FAILED;
       (void) return_error_to_client (thread_p, rid);
       goto cleanup;

--- a/src/connection/connection_support.cpp
+++ b/src/connection/connection_support.cpp
@@ -2370,6 +2370,7 @@ css_make_access_status_exist_user (THREAD_ENTRY *thread_p, OID *class_oid, LAST_
   char *rec_attr_name_p = NULL, *string = NULL;
   const char *user_name = NULL;
   HFID hfid;
+  bool hfid_found = false;
   OID inst_oid;
   HEAP_CACHE_ATTRINFO attr_info;
   HEAP_SCANCACHE scan_cache;
@@ -2440,13 +2441,13 @@ clean_string:
   heap_scancache_end (thread_p, &scan_cache);
   scan_cache_inited = false;
 
-  error = heap_get_class_info (thread_p, class_oid, &hfid, NULL, NULL);
+  error = heap_get_class_info (thread_p, class_oid, &hfid, NULL, &hfid_found);
   if (error != NO_ERROR)
     {
       goto end;
     }
 
-  if (HFID_IS_NULL (&hfid))
+  if (!hfid_found)
     {
       error = ER_FAILED;
       goto end;

--- a/src/loaddb/load_server_loader.cpp
+++ b/src/loaddb/load_server_loader.cpp
@@ -209,10 +209,12 @@ namespace cubload
 	return LC_CLASSNAME_ERROR;
       }
 
-    error = heap_get_class_info (&thread_ref, oid_User_class_oid, &hfid, NULL, NULL);
-    if (error != NO_ERROR)
+    bool hfid_found = false;
+
+    error = heap_get_class_info (&thread_ref, oid_User_class_oid, &hfid, NULL, &hfid_found);
+    if (error != NO_ERROR || !hfid_found)
       {
-	ASSERT_ERROR ();
+	assert (hfid_found);
 	heap_attrinfo_end (&thread_ref, &attr_info);
 	return LC_CLASSNAME_ERROR;
       }
@@ -1084,10 +1086,12 @@ namespace cubload
   server_object_loader::start_scancache (const OID &class_oid)
   {
     hfid hfid;
+    bool found = false;
 
-    int error_code = heap_get_class_info (m_thread_ref, &class_oid, &hfid, NULL, NULL);
-    if (error_code != NO_ERROR)
+    int error_code = heap_get_class_info (m_thread_ref, &class_oid, &hfid, NULL, &found);
+    if (error_code != NO_ERROR || !found)
       {
+	assert (found);
 	m_error_handler.on_failure_with_line (LOADDB_MSG_LOAD_FAIL);
 	return;
       }

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -15971,6 +15971,7 @@ sm_truncate_using_destroy_heap (MOP class_mop)
 {
   HFID *insts_hfid = NULL;
   HFID prev_hfid;
+  HFID new_hfid;
   SM_CLASS *class_ = NULL;
   OID *oid = NULL;
   DB_OBJLIST *subs;
@@ -16015,28 +16016,18 @@ sm_truncate_using_destroy_heap (MOP class_mop)
 
   prev_hfid = *insts_hfid;
 
-  /* Destroy the heap */
-  error = heap_destroy_newly_created (insts_hfid, oid, true);
+  /* Create the new heap first and flush the class straight from the old HFID to the new one, so the class record
+   * never exposes a NULL HFID on disk; a concurrent lock-free reader caching that transient state aborted the
+   * server (CBRD-27286). The old heap is destroyed last - its destruction is postponed to commit time anyway, so
+   * the ordering does not change when the pages are actually freed. */
+  HFID_SET_NULL (&new_hfid);
+  error = heap_create (&new_hfid, oid, reuse_oid);
   if (error != NO_ERROR)
     {
       goto end;
     }
 
-  HFID_SET_NULL (insts_hfid);
-  ws_dirty (class_mop);
-
-  error = locator_flush_class (class_mop);
-  if (error != NO_ERROR)
-    {
-      goto end;
-    }
-
-  /* Create a new heap */
-  error = heap_create (insts_hfid, oid, reuse_oid);
-  if (error != NO_ERROR)
-    {
-      goto end;
-    }
+  *insts_hfid = new_hfid;
 
   /* Destroy and Create the lob dir if need */
   error = locator_lob_process_dir (class_, &prev_hfid, insts_hfid);
@@ -16047,6 +16038,13 @@ sm_truncate_using_destroy_heap (MOP class_mop)
 
   ws_dirty (class_mop);
   error = locator_flush_class (class_mop);
+  if (error != NO_ERROR)
+    {
+      goto end;
+    }
+
+  /* Destroy the old heap */
+  error = heap_destroy_newly_created (&prev_hfid, oid, true);
 
 end:
   return error;

--- a/src/optimizer/histogram/histogram_sampler_sr.cpp
+++ b/src/optimizer/histogram/histogram_sampler_sr.cpp
@@ -2159,14 +2159,15 @@ histogram_scan_targets (THREAD_ENTRY *thread_p, const OID *class_oid, const HFID
       for (int i = 0; i < cnt; i++)
 	{
 	  HFID part_hfid;
+	  bool part_hfid_found = false;
 	  HFID_SET_NULL (&part_hfid);
-	  error = heap_get_class_info (thread_p, &parts[i], &part_hfid, NULL, NULL);
+	  error = heap_get_class_info (thread_p, &parts[i], &part_hfid, NULL, &part_hfid_found);
 	  if (error != NO_ERROR)
 	    {
 	      ASSERT_ERROR ();
 	      break;
 	    }
-	  if (HFID_IS_NULL (&part_hfid))
+	  if (!part_hfid_found)
 	    {
 	      continue;		/* partition without a heap: nothing to sample */
 	    }

--- a/src/storage/catalog_class.c
+++ b/src/storage/catalog_class.c
@@ -4987,8 +4987,10 @@ catcls_get_server_compat_info (THREAD_ENTRY * thread_p, INTL_CODESET * charset_i
   scan_cache_inited = false;
 
   /* read values of the single record in heap */
-  error = heap_get_class_info (thread_p, &class_oid, &hfid, NULL, NULL);
-  if (error != NO_ERROR || HFID_IS_NULL (&hfid))
+  bool found;			/* always written by heap_get_class_info () */
+
+  error = heap_get_class_info (thread_p, &class_oid, &hfid, NULL, &found);
+  if (error != NO_ERROR || !found)
     {
       error = ER_FAILED;
       goto exit;
@@ -5429,8 +5431,10 @@ catcls_get_db_collation (THREAD_ENTRY * thread_p, LANG_COLL_COMPAT ** db_collati
   scan_cache_inited = false;
 
   /* read values of all records in heap */
-  error = heap_get_class_info (thread_p, &class_oid, &hfid, NULL, NULL);
-  if (error != NO_ERROR || HFID_IS_NULL (&hfid))
+  bool found;			/* always written by heap_get_class_info () */
+
+  error = heap_get_class_info (thread_p, &class_oid, &hfid, NULL, &found);
+  if (error != NO_ERROR || !found)
     {
       error = ER_FAILED;
       goto exit;
@@ -5650,8 +5654,10 @@ catcls_get_apply_info_log_record_time (THREAD_ENTRY * thread_p, time_t * log_rec
   heap_scancache_end (thread_p, &scan_cache);
   scan_cache_inited = false;
 
-  error = heap_get_class_info (thread_p, &class_oid, &hfid, NULL, NULL);
-  if (error != NO_ERROR || HFID_IS_NULL (&hfid))
+  bool found;			/* always written by heap_get_class_info () */
+
+  error = heap_get_class_info (thread_p, &class_oid, &hfid, NULL, &found);
+  if (error != NO_ERROR || !found)
     {
       error = ER_FAILED;
       goto exit;

--- a/src/storage/compactdb_sr.c
+++ b/src/storage/compactdb_sr.c
@@ -573,7 +573,9 @@ boot_compact_db (THREAD_ENTRY * thread_p, OID * class_oids, int n_classes, int s
 	  continue;
 	}
 
-      if (heap_get_class_info (thread_p, class_oids + i, &hfid, NULL, NULL) != NO_ERROR)
+      bool found = false;
+
+      if (heap_get_class_info (thread_p, class_oids + i, &hfid, NULL, &found) != NO_ERROR || !found)
 	{
 	  lock_unlock_object (thread_p, class_oids + i, oid_Root_class_oid, IX_LOCK, true);
 	  OID_SET_NULL (last_processed_oid);

--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -12452,9 +12452,16 @@ xfile_apply_tde_to_class_files (THREAD_ENTRY * thread_p, const OID * class_oid)
   assert (tde_algo != TDE_ALGORITHM_NONE);
 
   /* apply to heap file and heap overflow file */
-  error_code = heap_get_class_info (thread_p, class_oid, &hfid, NULL, NULL);
+  bool hfid_found;		/* always written by heap_get_class_info () */
+
+  error_code = heap_get_class_info (thread_p, class_oid, &hfid, NULL, &hfid_found);
   if (error_code != NO_ERROR)
     {
+      goto exit;
+    }
+  if (!hfid_found)
+    {
+      /* no heap - nothing to apply the TDE algorithm to. */
       goto exit;
     }
 

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -24518,6 +24518,28 @@ heap_hfid_cache_get (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * hfid
 	  heap_hfid_table_log (thread_p, class_oid, "heap_hfid_cache_get failed error = %d", error_code);
 	  return error_code;
 	}
+
+      if (HFID_IS_NULL (&hfid_local))
+	{
+	  /* The class record has no heap file assigned at this moment: TRUNCATE flushes the class with a NULL HFID
+	   * before re-creating the heap (sm_truncate_using_destroy_heap), and views never have one. Do not cache
+	   * the transient state; report the class as unknown so the caller treats the access as a miss. */
+	  if (classname_local != NULL)
+	    {
+	      free_and_init (classname_local);
+	    }
+	  lf_tran_end_with_mb (t_entry);
+
+	  // remove entry
+	  lf_hash_delete (t_entry, &heap_Hfid_table->hfid_hash, (void *) class_oid, NULL);
+
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_HEAP_UNKNOWN_OBJECT, 3, class_oid->volid, class_oid->pageid,
+		  class_oid->slotid);
+	  heap_hfid_table_log (thread_p, class_oid, "heap_hfid_cache_get: class record has NULL HFID, error = %d",
+			       ER_HEAP_UNKNOWN_OBJECT);
+	  return ER_HEAP_UNKNOWN_OBJECT;
+	}
+
       entry->hfid = hfid_local;
 
       char *dummy_null = NULL;

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -855,7 +855,7 @@ static int heap_hfid_table_entry_key_copy (void *src, void *dest);
 static unsigned int heap_hfid_table_entry_key_hash (void *key, int hash_table_size);
 static int heap_hfid_table_entry_key_compare (void *k1, void *k2);
 static int heap_hfid_cache_get (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * hfid, FILE_TYPE * ftype_out,
-				char **classname_out);
+				bool * found);
 static int heap_get_class_info_from_record (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * hfid,
 					    char **classname_out);
 
@@ -6397,11 +6397,21 @@ heap_scancache_start_internal (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_ca
 	    }
 	}
 
-      ret = heap_get_class_info (thread_p, class_oid, &scan_cache->node.hfid, &scan_cache->file_type, NULL);
+      bool found = false;
+
+      ret = heap_get_class_info (thread_p, class_oid, &scan_cache->node.hfid, &scan_cache->file_type, &found);
       if (ret != NO_ERROR)
 	{
 	  ASSERT_ERROR ();
 	  return ret;
+	}
+      if (!found)
+	{
+	  /* instances of the class are being scanned, so its heap must exist. */
+	  assert (false);
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_HEAP_UNKNOWN_OBJECT, 3, class_oid->volid, class_oid->pageid,
+		  class_oid->slotid);
+	  return ER_HEAP_UNKNOWN_OBJECT;
 	}
       assert (hfid == NULL || HFID_EQ (hfid, &scan_cache->node.hfid));
       assert (scan_cache->file_type == FILE_HEAP || scan_cache->file_type == FILE_HEAP_REUSE_SLOTS);
@@ -6646,11 +6656,20 @@ heap_scancache_reset_modify (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cach
     {
       if (!OID_EQ (class_oid, &scan_cache->node.class_oid))
 	{
-	  ret = heap_get_class_info (thread_p, class_oid, &scan_cache->node.hfid, &scan_cache->file_type, NULL);
+	  bool found = false;
+
+	  ret = heap_get_class_info (thread_p, class_oid, &scan_cache->node.hfid, &scan_cache->file_type, &found);
 	  if (ret != NO_ERROR)
 	    {
 	      ASSERT_ERROR ();
 	      return ret;
+	    }
+	  if (!found)
+	    {
+	      assert (false);
+	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_HEAP_UNKNOWN_OBJECT, 3, class_oid->volid,
+		      class_oid->pageid, class_oid->slotid);
+	      return ER_HEAP_UNKNOWN_OBJECT;
 	    }
 	  assert (HFID_EQ (&scan_cache->node.hfid, hfid));
 	  scan_cache->node.class_oid = *class_oid;
@@ -9522,7 +9541,7 @@ heap_get_class_oid (THREAD_ENTRY * thread_p, const OID * oid, OID * class_oid)
   if (err != NO_ERROR)
     {
       /* for non existent object, return S_DOESNT_EXIST and let the caller handle the case; */
-      return err == ER_HEAP_UNKNOWN_OBJECT ? S_DOESNT_EXIST : S_ERROR;
+      return (err == ER_HEAP_UNKNOWN_OBJECT || err == ER_PB_ORDERED_NO_HEAP) ? S_DOESNT_EXIST : S_ERROR;
     }
 
   /* Get class OID from HEAP_CHAIN. */
@@ -12184,7 +12203,16 @@ heap_attrinfo_transform_variable_to_disk (THREAD_ENTRY * thread_p, HEAP_CACHE_AT
 	      return S_ERROR;
 	    }
 
-	  heap_hfid_cache_get (thread_p, &attr_info->class_oid, &hfid, NULL, NULL);
+	  bool found = false;
+
+	  if (heap_hfid_cache_get (thread_p, &attr_info->class_oid, &hfid, NULL, &found) != NO_ERROR || !found)
+	    {
+	      /* an instance of the class is being transformed, so its heap must exist. */
+	      assert (false);
+	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_HEAP_UNKNOWN_OBJECT, 3, attr_info->class_oid.volid,
+		      attr_info->class_oid.pageid, attr_info->class_oid.slotid);
+	      return S_ERROR;
+	    }
 
 	  snprintf (lob_path_prefix, PATH_MAX, "%d%d%d%d", HFID_AS_ARGS (&hfid), attrid);
 
@@ -14894,6 +14922,7 @@ heap_dump_heap_file (THREAD_ENTRY * thread_p, FILE * fp, bool dump_records, cons
   OID class_oid;
   LC_FIND_CLASSNAME status;
   HFID hfid;
+  bool found = false;
   OR_PARTITION *parts = NULL;
   int parts_count = 0;
 
@@ -14906,10 +14935,16 @@ heap_dump_heap_file (THREAD_ENTRY * thread_p, FILE * fp, bool dump_records, cons
 
   fprintf (fp, "\n*** DUMP HEAP OF %s ***\n", class_name);
 
-  error_code = heap_hfid_cache_get (thread_p, &class_oid, &hfid, NULL, NULL);
+  error_code = heap_hfid_cache_get (thread_p, &class_oid, &hfid, NULL, &found);
   if (error_code != NO_ERROR)
     {
       assert (false);
+      goto exit;
+    }
+  if (!found)
+    {
+      /* a view, or a class whose heap is not assigned - nothing to dump. */
+      fprintf (fp, "*** class %s has no heap (a view?) ***\n", class_name);
       goto exit;
     }
 
@@ -16356,8 +16391,11 @@ heap_rv_undo_insert (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
 	  goto end;
 	}
 
-      if (heap_get_class_info (thread_p, &class_oid, &hfid, NULL, NULL) != NO_ERROR)
+      bool found = false;
+
+      if (heap_get_class_info (thread_p, &class_oid, &hfid, NULL, &found) != NO_ERROR || !found)
 	{
+	  assert (found);
 	  goto end;
 	}
       assert (!HFID_IS_NULL (&hfid));
@@ -17384,20 +17422,23 @@ heap_attrinfo_set_uninitialized_global (THREAD_ENTRY * thread_p, OID * inst_oid,
 /*
  * heap_get_class_info () - get HFID and file type for class.
  *
- * return             : error code
- * thread_p (in)      : thread entry
- * class_oid (in)     : class OID
- * hfid_out (out)     : output heap file identifier
- * ftype_out (out)    : output heap file type
- * classname_out (out): output classname
+ * return          : error code (real failures only, e.g. record or file I/O; "the class has no heap" is NOT an
+ *                   error - it is reported through found)
+ * thread_p (in)   : thread entry
+ * class_oid (in)  : class OID
+ * hfid_out (out)  : output heap file identifier; HFID_SET_NULL initialized, valid only when *found is true
+ * ftype_out (out) : output heap file type; valid only when *found is true
+ * found (out)     : false when the class currently has no heap (a view, or a transient DDL state). The returned
+ *                   mapping is a point-in-time snapshot; liveness at use time is the caller's concern (locks or
+ *                   page-level validation).
  */
 int
 heap_get_class_info (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * hfid_out,
-		     FILE_TYPE * ftype_out, char **classname_out)
+		     FILE_TYPE * ftype_out, bool * found)
 {
   int error_code = NO_ERROR;
 
-  error_code = heap_hfid_cache_get (thread_p, class_oid, hfid_out, ftype_out, classname_out);
+  error_code = heap_hfid_cache_get (thread_p, class_oid, hfid_out, ftype_out, found);
   if (error_code != NO_ERROR)
     {
       ASSERT_ERROR_AND_SET (error_code);
@@ -17433,8 +17474,10 @@ heap_compact_pages (THREAD_ENTRY * thread_p, OID * class_oid)
       return ER_FAILED;
     }
 
-  ret = heap_get_class_info (thread_p, class_oid, &hfid, NULL, NULL);
-  if (ret != NO_ERROR || HFID_IS_NULL (&hfid))
+  bool found = false;
+
+  ret = heap_get_class_info (thread_p, class_oid, &hfid, NULL, &found);
+  if (ret != NO_ERROR || !found)
     {
       lock_unlock_object (thread_p, class_oid, oid_Root_class_oid, IS_LOCK, true);
       return ret;
@@ -18434,9 +18477,18 @@ heap_header_capacity_start_scan (THREAD_ENTRY * thread_p, int show_type, DB_VALU
 	  goto cleanup;
 	}
 
-      error = heap_get_class_info (thread_p, &class_oid, &ctx->hfids[0], NULL, NULL);
+      bool found = false;
+
+      error = heap_get_class_info (thread_p, &class_oid, &ctx->hfids[0], NULL, &found);
       if (error != NO_ERROR)
 	{
+	  goto cleanup;
+	}
+      if (!found)
+	{
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_HEAP_UNKNOWN_OBJECT, 3, class_oid.volid, class_oid.pageid,
+		  class_oid.slotid);
+	  error = ER_HEAP_UNKNOWN_OBJECT;
 	  goto cleanup;
 	}
 
@@ -19913,8 +19965,9 @@ int
 heap_scancache_quick_start_with_class_oid (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cache, OID * class_oid)
 {
   HFID class_hfid;
+  bool found = false;
 
-  heap_get_class_info (thread_p, class_oid, &class_hfid, NULL, NULL);
+  heap_get_class_info (thread_p, class_oid, &class_hfid, NULL, &found);
   (void) heap_scancache_quick_start_with_class_hfid (thread_p, scan_cache, &class_hfid);
   scan_cache->page_latch = PGBUF_LATCH_READ;
 
@@ -19962,8 +20015,9 @@ int
 heap_scancache_quick_start_modify_with_class_oid (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cache, OID * class_oid)
 {
   HFID class_hfid;
+  bool found = false;
 
-  heap_get_class_info (thread_p, class_oid, &class_hfid, NULL, NULL);
+  heap_get_class_info (thread_p, class_oid, &class_hfid, NULL, &found);
   (void) heap_scancache_quick_start_internal (scan_cache, &class_hfid);
   scan_cache->page_latch = PGBUF_LATCH_WRITE;
 
@@ -20155,9 +20209,11 @@ heap_get_file_type (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context)
     }
   else
     {
-      if (heap_get_class_info (thread_p, &context->class_oid, NULL, &file_type, NULL) != NO_ERROR)
+      bool found = false;
+
+      if (heap_get_class_info (thread_p, &context->class_oid, NULL, &file_type, &found) != NO_ERROR || !found)
 	{
-	  ASSERT_ERROR ();
+	  assert (found);
 	  return FILE_UNKNOWN_TYPE;
 	}
       assert (file_type == FILE_HEAP || file_type == FILE_HEAP_REUSE_SLOTS);
@@ -24009,8 +24065,6 @@ heap_hfid_table_entry_alloc (void)
       return NULL;
     }
 
-  new_entry->classname = NULL;
-
   return (void *) new_entry;
 }
 
@@ -24024,15 +24078,6 @@ heap_hfid_table_entry_free (void *entry)
 {
   if (entry != NULL)
     {
-      HEAP_HFID_TABLE_ENTRY *entry_p = (HEAP_HFID_TABLE_ENTRY *) entry;
-
-      // Clear the classname.
-      if (entry_p->classname != NULL)
-	{
-	  free (entry_p->classname);
-	  entry_p->classname = NULL;
-	}
-
       free (entry);
       return NO_ERROR;
     }
@@ -24063,7 +24108,6 @@ heap_hfid_table_entry_init (void *entry)
   entry_p->hfid.vfid.volid = NULL_VOLID;
   entry_p->hfid.hpgid = NULL_PAGEID;
   entry_p->ftype = FILE_UNKNOWN_TYPE;
-  entry_p->classname = NULL;
 
   return NO_ERROR;
 }
@@ -24071,13 +24115,8 @@ heap_hfid_table_entry_init (void *entry)
 static int
 heap_hfid_table_entry_uninit (void *entry)
 {
-  HEAP_HFID_TABLE_ENTRY *entry_p = (HEAP_HFID_TABLE_ENTRY *) entry;
-  if (entry_p->classname != NULL)
-    {
-      free (entry_p->classname);
-      entry_p->classname = NULL;
-    }
-  return NO_ERROR;
+  /* nothing to release: the entry has no owned payload since the classname cache was removed. */
+  return entry != NULL ? NO_ERROR : ER_FAILED;
 }
 
 /*
@@ -24203,6 +24242,9 @@ heap_initialize_hfid_table (void)
     }
 
   heap_Hfid_table_area.logging = prm_get_bool_value (PRM_ID_HEAP_INFO_CACHE_LOGGING);
+// *INDENT-OFF*
+  heap_Hfid_table_area.generation.store (0);
+// *INDENT-ON*
 
   heap_Hfid_table = &heap_Hfid_table_area;
 
@@ -24240,6 +24282,11 @@ heap_delete_hfid_from_cache (THREAD_ENTRY * thread_p, OID * class_oid)
   LF_TRAN_ENTRY *t_entry = thread_get_tran_entry (thread_p, THREAD_TS_HFID_TABLE);
   int error = NO_ERROR;
   int success = 0;
+
+  /* Bump the invalidation clock BEFORE the delete and regardless of whether an entry exists: a filler that read
+   * the class record before this invalidation may not have published yet (nothing to delete), and the clock is
+   * what makes it withdraw its stale publish afterwards (see heap_hfid_cache_get). */
+  heap_Hfid_table->generation.fetch_add (1);
 
   error = lf_hash_delete (t_entry, &heap_Hfid_table->hfid_hash, class_oid, &success);
   heap_hfid_table_log (thread_p, class_oid, "heap_delete_hfid_from_cache success=%d", success);
@@ -24373,14 +24420,11 @@ exit:
  * ftype (in)     : FILE_HEAP or FILE_HEAP_REUSE_SLOTS.
  */
 int
-heap_cache_class_info (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * hfid, FILE_TYPE ftype,
-		       const char *classname_in)
+heap_cache_class_info (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * hfid, FILE_TYPE ftype)
 {
   int error_code = NO_ERROR;
   LF_TRAN_ENTRY *t_entry = thread_get_tran_entry (thread_p, THREAD_TS_HFID_TABLE);
   HEAP_HFID_TABLE_ENTRY *entry = NULL;
-  HFID hfid_local = HFID_INITIALIZER;
-  char *classname_local = NULL;
   int inserted = 0;
 
   assert (hfid != NULL && !HFID_IS_NULL (hfid));
@@ -24392,62 +24436,31 @@ heap_cache_class_info (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * hf
       return NO_ERROR;
     }
 
+  /* fill-then-publish, same as heap_hfid_cache_get (): the entry is completed before it is linked. */
+  entry = (HEAP_HFID_TABLE_ENTRY *) lf_freelist_claim (t_entry, &heap_Hfid_table->hfid_hash_freelist);
+  if (entry == NULL)
+    {
+      assert (false);
+      return ER_FAILED;
+    }
+  COPY_OID (&entry->class_oid, class_oid);	/* LF_LIST_BF_INSERT_GIVEN does not copy the key */
+  HFID_COPY (&entry->hfid, hfid);
+  entry->ftype = ftype;
+
   error_code =
-    lf_hash_find_or_insert (t_entry, &heap_Hfid_table->hfid_hash, (void *) class_oid, (void **) &entry, &inserted);
+    lf_hash_insert_given (t_entry, &heap_Hfid_table->hfid_hash, (void *) class_oid, (void **) &entry, &inserted);
   if (error_code != NO_ERROR)
     {
       assert (false);
       return error_code;
     }
-  // NOTE: no collisions are expected when heap_cache_class_info is called
-
-  assert (entry != NULL);
-  assert (entry->hfid.hpgid == NULL_PAGEID);
-
-  HFID_COPY (&entry->hfid, hfid);
-  if (classname_in != NULL)
-    {
-      classname_local = strdup (classname_in);
-    }
-  else
-    {
-      error_code = heap_get_class_info_from_record (thread_p, class_oid, &hfid_local, &classname_local);
-      if (error_code != NO_ERROR)
-	{
-	  ASSERT_ERROR ();
-	  lf_tran_end_with_mb (t_entry);
-
-	  // remove from hash
-	  int success = 0;
-	  if (lf_hash_delete (t_entry, &heap_Hfid_table->hfid_hash, (void *) class_oid, &success) != NO_ERROR)
-	    {
-	      assert (false);
-	    }
-	  assert (success);
-
-	  heap_hfid_table_log (thread_p, class_oid, "heap_cache_class_info failed error=%d", error_code);
-
-	  if (classname_local != NULL)
-	    {
-	      free (classname_local);
-	    }
-
-	  return error_code;
-	}
-    }
-
-  entry->ftype = ftype;
-
-  char *dummy_null = NULL;
-  if (!entry->classname.compare_exchange_strong (dummy_null, classname_local))
-    {
-      free (classname_local);
-    }
+  // NOTE: no collisions are expected when heap_cache_class_info is called (boot-time root class only)
+  assert (inserted == 1);
 
   lf_tran_end_with_mb (t_entry);
 
-  heap_hfid_table_log (thread_p, class_oid, "heap_cache_class_info hfid=%d|%d|%d, ftype=%s, classname = %s",
-		       HFID_AS_ARGS (hfid), file_type_to_string (ftype), classname_local);
+  heap_hfid_table_log (thread_p, class_oid, "heap_cache_class_info hfid=%d|%d|%d, ftype=%s",
+		       HFID_AS_ARGS (hfid), file_type_to_string (ftype));
 
   /* Successfully cached. */
   return NO_ERROR;
@@ -24466,131 +24479,139 @@ heap_cache_class_info (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * hf
  */
 static int
 heap_hfid_cache_get (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * hfid_out, FILE_TYPE * ftype_out,
-		     char **classname_out)
+		     bool * found)
 {
   int error_code = NO_ERROR;
   LF_TRAN_ENTRY *t_entry = thread_get_tran_entry (thread_p, THREAD_TS_HFID_TABLE);
   HEAP_HFID_TABLE_ENTRY *entry = NULL;
-  char *classname_local = NULL;
+  HFID hfid_local = HFID_INITIALIZER;
+  FILE_TYPE ftype_local = FILE_UNKNOWN_TYPE;
+  uint64_t generation_snapshot;
   int inserted = 0;
 
   assert (class_oid != NULL && !OID_ISNULL (class_oid));
+  assert (found != NULL);
 
-  error_code =
-    lf_hash_find_or_insert (t_entry, &heap_Hfid_table->hfid_hash, (void *) class_oid, (void **) &entry, &inserted);
+  *found = false;
+  if (hfid_out != NULL)
+    {
+      HFID_SET_NULL (hfid_out);
+    }
+
+  /* lookup: the hash only holds complete entries (fill-then-publish), so a found entry needs no state checks. */
+  error_code = lf_hash_find (t_entry, &heap_Hfid_table->hfid_hash, (void *) class_oid, (void **) &entry);
   if (error_code != NO_ERROR)
     {
       ASSERT_ERROR ();
       return error_code;
     }
-  assert (entry != NULL);
-
-  /*  Here we check only the classname because this is the last field to be populated by other possible concurrent
-   *  inserters. This means that if this field is already set by someone else, then the entry data is already
-   *  mature so we don't need to add data again.
-   */
-  if (entry->classname == NULL)
+  if (entry != NULL)
     {
-      HFID hfid_local = HFID_INITIALIZER;
+      assert (entry->hfid.hpgid != NULL_PAGEID && entry->hfid.vfid.fileid != NULL_FILEID
+	      && entry->hfid.vfid.volid != NULL_VOLID);
+      assert (entry->ftype == FILE_HEAP || entry->ftype == FILE_HEAP_REUSE_SLOTS);
 
-      /* root HFID should already be added. */
-      if (OID_IS_ROOTOID (class_oid))
+      if (hfid_out != NULL)
 	{
-	  assert_release (false);
-	  boot_find_root_heap (&entry->hfid);
-	  entry->ftype = FILE_HEAP;
-	  lf_tran_end_with_mb (t_entry);
-	  return NO_ERROR;
+	  *hfid_out = entry->hfid;
 	}
+      if (ftype_out != NULL)
+	{
+	  *ftype_out = entry->ftype;
+	}
+      *found = true;
+      lf_tran_end_with_mb (t_entry);
+      return NO_ERROR;
+    }
 
-      /* this is either a newly inserted entry or one with incomplete information that is currently being filled by
-       * another transaction. We need to retrieve the HFID from the class record. We do not care that we are
-       * overwriting the information, since it must be always the same (the HFID never changes for the same class OID). */
-      error_code = heap_get_class_info_from_record (thread_p, class_oid, &hfid_local, &classname_local);
+  /* miss. Snapshot the invalidation clock before reading the class record, so we can tell whether an invalidation
+   * overlapped the fill (see the publish step below). */
+  generation_snapshot = heap_Hfid_table->generation.load ();
+
+  /* fill outside the hash: nothing is exposed until the completed entry is linked. */
+  if (OID_IS_ROOTOID (class_oid))
+    {
+      /* root HFID should already be cached at boot. */
+      assert_release (false);
+      boot_find_root_heap (&hfid_local);
+      ftype_local = FILE_HEAP;
+    }
+  else
+    {
+      error_code = heap_get_class_info_from_record (thread_p, class_oid, &hfid_local, NULL);
       if (error_code != NO_ERROR)
 	{
 	  ASSERT_ERROR ();
-	  lf_tran_end_with_mb (t_entry);
-
-	  // remove entry
-	  lf_hash_delete (t_entry, &heap_Hfid_table->hfid_hash, (void *) class_oid, NULL);
-
 	  heap_hfid_table_log (thread_p, class_oid, "heap_hfid_cache_get failed error = %d", error_code);
 	  return error_code;
 	}
 
       if (HFID_IS_NULL (&hfid_local))
 	{
-	  /* The class record has no heap file assigned at this moment: TRUNCATE flushes the class with a NULL HFID
-	   * before re-creating the heap (sm_truncate_using_destroy_heap), and views never have one. Do not cache
-	   * the transient state; report the class as unknown so the caller treats the access as a miss. */
-	  if (classname_local != NULL)
-	    {
-	      free_and_init (classname_local);
-	    }
-	  lf_tran_end_with_mb (t_entry);
-
-	  // remove entry
-	  lf_hash_delete (t_entry, &heap_Hfid_table->hfid_hash, (void *) class_oid, NULL);
-
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_HEAP_UNKNOWN_OBJECT, 3, class_oid->volid, class_oid->pageid,
-		  class_oid->slotid);
-	  heap_hfid_table_log (thread_p, class_oid, "heap_hfid_cache_get: class record has NULL HFID, error = %d",
-			       ER_HEAP_UNKNOWN_OBJECT);
-	  return ER_HEAP_UNKNOWN_OBJECT;
+	  /* The class record has no heap file assigned at this moment: views never have one, and DDL may expose a
+	   * transient state. This is a state, not an error - report a miss and cache nothing. */
+	  heap_hfid_table_log (thread_p, class_oid, "heap_hfid_cache_get: class record has NULL HFID (no heap)%s", "");
+	  return NO_ERROR;	/* *found remains false */
 	}
 
-      entry->hfid = hfid_local;
-
-      char *dummy_null = NULL;
-
-      if (!entry->classname.compare_exchange_strong (dummy_null, classname_local))
-	{
-	  // somebody else has set it
-	  free (classname_local);
-	}
-    }
-
-  assert (entry->hfid.hpgid != NULL_PAGEID && entry->hfid.vfid.fileid != NULL_FILEID
-	  && entry->hfid.vfid.volid != NULL_VOLID && entry->classname != NULL);
-
-  if (entry->ftype == FILE_UNKNOWN_TYPE)
-    {
-      FILE_TYPE ftype_local;
-      error_code = file_get_type (thread_p, &entry->hfid.vfid, &ftype_local);
+      error_code = file_get_type (thread_p, &hfid_local.vfid, &ftype_local);
       if (error_code != NO_ERROR)
 	{
 	  ASSERT_ERROR ();
-	  lf_tran_end_with_mb (t_entry);
-
-	  // remove entry
-	  lf_hash_delete (t_entry, &heap_Hfid_table->hfid_hash, (void *) class_oid, NULL);
-
 	  heap_hfid_table_log (thread_p, class_oid, "heap_hfid_cache_get failed error = %d", error_code);
 	  return error_code;
 	}
-      entry->ftype = ftype_local;
     }
-  assert (entry->ftype == FILE_HEAP || entry->ftype == FILE_HEAP_REUSE_SLOTS);
+  assert (ftype_local == FILE_HEAP || ftype_local == FILE_HEAP_REUSE_SLOTS);
 
+  /* publish: link the completed entry with one CAS. If the key already exists, our entry is retired and the
+   * winner's (equally complete) entry is returned instead - observationally the same as a cache hit. */
+  entry = (HEAP_HFID_TABLE_ENTRY *) lf_freelist_claim (t_entry, &heap_Hfid_table->hfid_hash_freelist);
+  if (entry == NULL)
+    {
+      assert (false);
+      return ER_FAILED;
+    }
+  COPY_OID (&entry->class_oid, class_oid);	/* LF_LIST_BF_INSERT_GIVEN does not copy the key */
+  entry->hfid = hfid_local;
+  entry->ftype = ftype_local;
+
+  error_code =
+    lf_hash_insert_given (t_entry, &heap_Hfid_table->hfid_hash, (void *) class_oid, (void **) &entry, &inserted);
+  if (error_code != NO_ERROR)
+    {
+      ASSERT_ERROR ();
+      return error_code;
+    }
+  assert (entry != NULL);
+  lf_tran_end_with_mb (t_entry);
+
+  /* re-check the invalidation clock after publishing. A change means some invalidation overlapped the fill and our
+   * record snapshot may already be stale, so withdraw the entry: either the invalidator's delete or this delete
+   * removes it, and the worst case is over-invalidating a valid entry (one extra record read later). Checking only
+   * before the insert would leave a window between the check and the link-in. */
+  if (inserted == 1 && generation_snapshot != heap_Hfid_table->generation.load ())
+    {
+      (void) lf_hash_delete (t_entry, &heap_Hfid_table->hfid_hash, (void *) class_oid, NULL);
+      heap_hfid_table_log (thread_p, class_oid, "heap_hfid_cache_get: publish withdrawn, generation moved to %llu",
+			   (unsigned long long) heap_Hfid_table->generation.load ());
+    }
+
+  /* the values handed out are a point-in-time snapshot of the class record; liveness at use time is guaranteed by
+   * the caller's locks or by page-level validation, exactly as for a cache hit. */
   if (hfid_out != NULL)
     {
-      *hfid_out = entry->hfid;
+      *hfid_out = hfid_local;
     }
   if (ftype_out != NULL)
     {
-      *ftype_out = entry->ftype;
+      *ftype_out = ftype_local;
     }
-  if (classname_out != NULL)
-    {
-      *classname_out = entry->classname;
-    }
+  *found = true;
 
-  lf_tran_end_with_mb (t_entry);
-
-  heap_hfid_table_log (thread_p, class_oid, "heap_hfid_cache_get hfid=%d|%d|%d, ftype = %s, classname = %s",
-		       HFID_AS_ARGS (&entry->hfid), file_type_to_string (entry->ftype), entry->classname.load ());
-  return error_code;
+  heap_hfid_table_log (thread_p, class_oid, "heap_hfid_cache_get hfid=%d|%d|%d, ftype = %s, inserted = %d",
+		       HFID_AS_ARGS (&hfid_local), file_type_to_string (ftype_local), inserted);
+  return NO_ERROR;
 }
 
 /*
@@ -24601,13 +24622,11 @@ heap_hfid_cache_get (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * hfid
  *   class_oid (in)     : the class OID for which the entry will be returned
  *   hfid_out (out)     : output heap file identifier
  *   ftype_out (out)    : output heap file type
- *   classname_out (out): output classname. The string is owned by the cache entry and is freed when the entry is
- *                        deleted and reclaimed; callers must not retain it beyond the entry's lifetime.
  *   success  (out)     : true if found from cache
  */
 int
 heap_get_hfid_if_cached (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * hfid_out, FILE_TYPE * ftype_out,
-			 char **classname_out, bool * success)
+			 bool * success)
 {
   int error_code = NO_ERROR;
   LF_TRAN_ENTRY *t_entry = thread_get_tran_entry (thread_p, THREAD_TS_HFID_TABLE);
@@ -24617,6 +24636,10 @@ heap_get_hfid_if_cached (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * 
   assert (success != NULL);
 
   *success = false;
+  if (hfid_out != NULL)
+    {
+      HFID_SET_NULL (hfid_out);
+    }
 
   error_code = lf_hash_find (t_entry, &heap_Hfid_table->hfid_hash, (void *) class_oid, (void **) &entry);
   if (error_code != NO_ERROR)
@@ -24627,24 +24650,10 @@ heap_get_hfid_if_cached (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * 
 
   if (entry)
     {
-      /* The cache is publish-then-fill: heap_hfid_cache_get () exposes the entry in the hash through
-       * lf_hash_find_or_insert () first and fills it afterwards, publishing classname last (CAS). If classname is
-       * not set yet, the entry is still being filled by a concurrent thread; treat it as a cache miss. Reading
-       * classname before hfid mirrors the writer's order (hfid store, then classname CAS), so a non-NULL
-       * classname guarantees a valid hfid. ftype, however, is resolved only after classname is published, so it
-       * may still be unknown; report a miss rather than an unknown type when the caller asked for it. */
-      char *classname_local = entry->classname;
-
-      if (classname_local == NULL || HFID_IS_NULL (&entry->hfid)
-	  || (ftype_out != NULL && entry->ftype == FILE_UNKNOWN_TYPE))
-	{
-	  /* *success remains false */
-	  lf_tran_end_with_mb (t_entry);
-	  return NO_ERROR;
-	}
-
+      /* the hash only holds complete entries (fill-then-publish), so a found entry is always fully valid. */
       assert (entry->hfid.hpgid != NULL_PAGEID && entry->hfid.vfid.fileid != NULL_FILEID
 	      && entry->hfid.vfid.volid != NULL_VOLID);
+      assert (entry->ftype == FILE_HEAP || entry->ftype == FILE_HEAP_REUSE_SLOTS);
 
       if (hfid_out != NULL)
 	{
@@ -24653,10 +24662,6 @@ heap_get_hfid_if_cached (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * 
       if (ftype_out != NULL)
 	{
 	  *ftype_out = entry->ftype;
-	}
-      if (classname_out != NULL)
-	{
-	  *classname_out = classname_local;
 	}
 
       *success = true;
@@ -25002,8 +25007,11 @@ heap_scancache_add_partition_node (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * sca
 
   assert (scan_cache != NULL);
 
-  if (heap_get_class_info (thread_p, partition_oid, &hfid, NULL, NULL) != NO_ERROR)
+  bool found = false;
+
+  if (heap_get_class_info (thread_p, partition_oid, &hfid, NULL, &found) != NO_ERROR || !found)
     {
+      assert (found);
       return ER_FAILED;
     }
 

--- a/src/storage/heap_file.h
+++ b/src/storage/heap_file.h
@@ -194,11 +194,19 @@ struct heap_hfid_table
   LF_ENTRY_DESCRIPTOR hfid_hash_descriptor;	/* used by hfid_hash */
   LF_FREELIST hfid_hash_freelist;	/* used by hfid_hash */
   bool logging;
+// *INDENT-OFF*
+  std::atomic<uint64_t> generation;	/* invalidation clock: bumped by every heap_delete_hfid_from_cache () call.
+					 * A filler snapshots it before reading the class record and re-checks it
+					 * after publishing; a mismatch means an invalidation overlapped the fill,
+					 * so the filler withdraws its own entry instead of leaving a stale one. */
+// *INDENT-ON*
 };
 
 #define HEAP_HFID_HASH_SIZE 1000
 
-/* entry for class OID->HFID lock free hashtable */
+/* entry for class OID->HFID lock free hashtable.
+ * The hash only ever holds complete entries: hfid and ftype are fully resolved and valid before the entry is
+ * linked (fill-then-publish), so a found entry never carries partial or NULL information. */
 typedef struct heap_hfid_table_entry HEAP_HFID_TABLE_ENTRY;
 struct heap_hfid_table_entry
 {
@@ -207,11 +215,8 @@ struct heap_hfid_table_entry
   HEAP_HFID_TABLE_ENTRY *next;	/* used in hash table */
   UINT64 del_id;		/* delete transaction ID (for lock free) */
 
-  HFID hfid;			/* value - HFID */
-  FILE_TYPE ftype;		/* value - FILE_HEAP or FILE_HEAP_REUSE_SLOTS */
-// *INDENT-OFF*
-  std::atomic<char*> classname;	/* Also cache the classname. */
-// *INDENT-ON*
+  HFID hfid;			/* value - HFID; never NULL in a linked entry */
+  FILE_TYPE ftype;		/* value - FILE_HEAP or FILE_HEAP_REUSE_SLOTS; resolved before publish */
 };
 
 // forward declaration
@@ -605,11 +610,10 @@ extern int heap_rv_mark_deleted_on_undo (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
 extern int heap_rv_mark_deleted_on_postpone (THREAD_ENTRY * thread_p, LOG_RCV * rcv);
 
 extern int heap_get_class_info (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * hfid_out,
-				FILE_TYPE * ftype_out, char **classname_out);
-extern int heap_cache_class_info (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * hfid,
-				  FILE_TYPE ftype, const char *classname_in);
+				FILE_TYPE * ftype_out, bool * found);
+extern int heap_cache_class_info (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * hfid, FILE_TYPE ftype);
 extern int heap_get_hfid_if_cached (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * hfid_out,
-				    FILE_TYPE * ftype_out, char **classname_out, bool * success);
+				    FILE_TYPE * ftype_out, bool * success);
 extern int heap_compact_pages (THREAD_ENTRY * thread_p, OID * class_oid);
 
 extern void heap_classrepr_dump_all (THREAD_ENTRY * thread_p, FILE * fp, OID * class_oid);

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -13322,7 +13322,11 @@ pgbuf_get_groupid_and_unfix (THREAD_ENTRY * thread_p, const VPID * req_vpid, PAG
     }
   else
     {
-      er_status = heap_get_class_info (thread_p, &cls_oid, &hfid, NULL, NULL);
+      bool found = false;
+
+      /* on a miss (e.g. the class currently has no heap) hfid stays NULL and is reported as
+       * ER_PB_ORDERED_NO_HEAP below. */
+      er_status = heap_get_class_info (thread_p, &cls_oid, &hfid, NULL, &found);
     }
 
   if (er_status == NO_ERROR)

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2334,9 +2334,7 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
     }
 
   /* we need to manually add root class HFID to cache */
-  error_code =
-    heap_cache_class_info (thread_p, &boot_Db_parm->rootclass_oid, &boot_Db_parm->rootclass_hfid, FILE_HEAP,
-			   boot_Db_parm->rootclass_name);
+  error_code = heap_cache_class_info (thread_p, &boot_Db_parm->rootclass_oid, &boot_Db_parm->rootclass_hfid, FILE_HEAP);
   if (error_code != NO_ERROR)
     {
       assert_release (false);
@@ -3633,7 +3631,9 @@ xboot_checkdb_table (THREAD_ENTRY * thread_p, int check_flag, OID * oid, BTID * 
 	}
     }
 
-  if (heap_get_class_info (thread_p, oid, &hfid, NULL, NULL) != NO_ERROR || HFID_IS_NULL (&hfid))
+  bool found = false;
+
+  if (heap_get_class_info (thread_p, oid, &hfid, NULL, &found) != NO_ERROR || !found)
     {
       return DISK_ERROR;
     }
@@ -5024,9 +5024,7 @@ boot_create_all_volumes (THREAD_ENTRY * thread_p, const BOOT_CLIENT_CREDENTIAL *
 
   oid_set_root (&boot_Db_parm->rootclass_oid);
   /* we need to manually add root class HFID to cache */
-  error_code =
-    heap_cache_class_info (thread_p, &boot_Db_parm->rootclass_oid, &boot_Db_parm->rootclass_hfid, FILE_HEAP,
-			   boot_Db_parm->rootclass_name);
+  error_code = heap_cache_class_info (thread_p, &boot_Db_parm->rootclass_oid, &boot_Db_parm->rootclass_hfid, FILE_HEAP);
   if (error_code != NO_ERROR)
     {
       assert_release (false);

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -4302,9 +4302,20 @@ locator_check_primary_key_delete (THREAD_ENTRY * thread_p, OR_INDEX * index, DB_
 	  /* We might check for foreign key and schema consistency problems here but we rely on the schema manager to
 	   * prevent inconsistency; see do_check_fk_constraints() for details */
 
-	  error_code = heap_get_class_info (thread_p, &fkref->self_oid, &hfid, NULL, NULL);
+	  bool hfid_found = false;
+
+	  error_code = heap_get_class_info (thread_p, &fkref->self_oid, &hfid, NULL, &hfid_found);
 	  if (error_code != NO_ERROR)
 	    {
+	      goto error3;
+	    }
+	  if (!hfid_found)
+	    {
+	      /* the referencing class must have a heap. */
+	      assert (false);
+	      error_code = ER_HEAP_UNKNOWN_OBJECT;
+	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_code, 3, fkref->self_oid.volid, fkref->self_oid.pageid,
+		      fkref->self_oid.slotid);
 	      goto error3;
 	    }
 
@@ -4680,9 +4691,20 @@ locator_check_primary_key_update (THREAD_ENTRY * thread_p, OR_INDEX * index, DB_
 	  /* We might check for foreign key and schema consistency problems here but we rely on the schema manager to
 	   * prevent inconsistency; see do_check_fk_constraints() for details */
 
-	  error_code = heap_get_class_info (thread_p, &fkref->self_oid, &hfid, NULL, NULL);
+	  bool hfid_found = false;
+
+	  error_code = heap_get_class_info (thread_p, &fkref->self_oid, &hfid, NULL, &hfid_found);
 	  if (error_code != NO_ERROR)
 	    {
+	      goto error3;
+	    }
+	  if (!hfid_found)
+	    {
+	      /* the referencing class must have a heap. */
+	      assert (false);
+	      error_code = ER_HEAP_UNKNOWN_OBJECT;
+	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_code, 3, fkref->self_oid.volid, fkref->self_oid.pageid,
+		      fkref->self_oid.slotid);
 	      goto error3;
 	    }
 
@@ -5574,12 +5596,14 @@ locator_update_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
 		{
 		  HFID cached_hfid = HFID_INITIALIZER;
 		  bool was_cached = false;
-		  error_code = heap_get_hfid_if_cached (thread_p, oid, &cached_hfid, NULL, NULL, &was_cached);
+		  error_code = heap_get_hfid_if_cached (thread_p, oid, &cached_hfid, NULL, &was_cached);
 		  if (error_code != NO_ERROR)
 		    {
 		      goto error;
 		    }
-		  if (was_cached && !HFID_EQ (&cached_hfid, &new_hfid))
+		  /* Invalidate on a cache miss too: a filler may be mid-fill with the pre-update record, and the
+		   * delete's generation bump is what makes it withdraw its publish (see heap_hfid_cache_get). */
+		  if (!was_cached || !HFID_EQ (&cached_hfid, &new_hfid))
 		    {
 		      error_code = heap_delete_hfid_from_cache (thread_p, oid);
 		      if (error_code != NO_ERROR)
@@ -5927,8 +5951,11 @@ locator_update_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
 	      goto error;
 	    }
 
-	  if (heap_get_class_info (thread_p, class_oid, hfid, NULL, NULL) != NO_ERROR)
+	  bool hfid_found = false;
+
+	  if (heap_get_class_info (thread_p, class_oid, hfid, NULL, &hfid_found) != NO_ERROR || !hfid_found)
 	    {
+	      assert (hfid_found);
 	      goto error;
 	    }
 
@@ -6971,9 +6998,19 @@ xlocator_repl_force (THREAD_ENTRY * thread_p, LC_COPYAREA * force_area, LC_COPYA
 
       LC_REPL_RECDES_FOR_ONEOBJ (force_area, obj, packed_key_value_len, &recdes);
 
-      error_code = heap_get_class_info (thread_p, &obj->class_oid, &obj->hfid, NULL, NULL);
+      bool hfid_found = false;
+
+      error_code = heap_get_class_info (thread_p, &obj->class_oid, &obj->hfid, NULL, &hfid_found);
       if (error_code != NO_ERROR)
 	{
+	  goto exit_on_error;
+	}
+      if (!hfid_found)
+	{
+	  assert (false);
+	  error_code = ER_HEAP_UNKNOWN_OBJECT;
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_code, 3, obj->class_oid.volid, obj->class_oid.pageid,
+		  obj->class_oid.slotid);
 	  goto exit_on_error;
 	}
 
@@ -12157,9 +12194,18 @@ xlocator_upgrade_instances_domain (THREAD_ENTRY * thread_p, OID * class_oid, int
   nobjects = 0;
   nfetched = -1;
 
-  error = heap_get_class_info (thread_p, class_oid, &hfid, NULL, NULL);
+  bool hfid_found;		/* always written by heap_get_class_info () */
+
+  error = heap_get_class_info (thread_p, class_oid, &hfid, NULL, &hfid_found);
   if (error != NO_ERROR)
     {
+      goto error_exit;
+    }
+  if (!hfid_found)
+    {
+      assert (false);
+      error = ER_HEAP_UNKNOWN_OBJECT;
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error, 3, class_oid->volid, class_oid->pageid, class_oid->slotid);
       goto error_exit;
     }
 
@@ -12716,8 +12762,10 @@ redistribute_partition_data (THREAD_ENTRY * thread_p, OID * class_oid, int no_oi
 
   PGBUF_INIT_WATCHER (&old_page_watcher, PGBUF_ORDERED_RANK_UNDEFINED, PGBUF_ORDERED_NULL_HFID);
 
-  error = heap_get_class_info (thread_p, class_oid, &class_hfid, NULL, NULL);
-  if (error != NO_ERROR || HFID_IS_NULL (&class_hfid))
+  bool class_hfid_found = false;
+
+  error = heap_get_class_info (thread_p, class_oid, &class_hfid, NULL, &class_hfid_found);
+  if (error != NO_ERROR || !class_hfid_found)
     {
       error = ER_FAILED;
       goto exit;
@@ -12752,8 +12800,10 @@ redistribute_partition_data (THREAD_ENTRY * thread_p, OID * class_oid, int no_oi
 	  goto exit;
 	}
 
-      error = heap_get_class_info (thread_p, &oid_list[i], &hfid, NULL, NULL);
-      if (error != NO_ERROR || HFID_IS_NULL (&hfid))
+      bool hfid_found = false;
+
+      error = heap_get_class_info (thread_p, &oid_list[i], &hfid, NULL, &hfid_found);
+      if (error != NO_ERROR || !hfid_found)
 	{
 	  error = ER_FAILED;
 	  goto exit;


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27286>

### Purpose

QA의 debug 빌드 테스트 중 cub_server가 `heap_hfid_cache_get()`의 assert 실패로 abort 했습니다. 두 세션의 작업이 겹치면서 발생합니다.

**어느 상황에서 발생했나**

한 세션이 `TRUNCATE TABLE dml_0001`을 수행하는 동안, 다른 세션이 이미 삭제된 객체를 가리키는 참조(stale OID)의 존재 확인 요청을 보냈습니다. 이 존재 확인은 객체의 클래스를 모르는 상태로 들어오기 때문에, 서버가 클래스 락을 잡기 전에 페이지 헤더에서 클래스를 알아내고 그 클래스의 HFID를 캐시(`heap_Hfid_table`)에서 조회하는 단계를 먼저 거칩니다. 즉 이 조회는 TRUNCATE가 쥔 SCH_M 락으로 직렬화되지 않습니다.

**왜 NULL HFID가 노출되나**

TRUNCATE의 빠른 경로인 `sm_truncate_using_destroy_heap()`은 heap을 다음 순서로 교체합니다.

1. 구 heap 파괴 예약 — 실제 파괴는 커밋 시점으로 postpone 되므로, 구 heap의 페이지들은 아직 살아 있고 페이지 헤더의 class_oid도 그대로입니다.
2. 클래스 객체의 HFID를 NULL로 만들어 flush — **이 순간부터 디스크의 클래스 레코드가 "이 클래스는 heap이 없다"고 말하게 됩니다.**
3. 새 heap 생성.
4. 새 HFID로 두 번째 flush — 여기서야 레코드가 다시 유효해집니다.

2와 4 사이가 취약 구간입니다. 이 구간에 위의 존재 확인 스레드가 들어오면, 살아 있는 구 heap 페이지에서 class_oid를 얻고, 캐시 미스가 나서 클래스 레코드를 읽는데, 그 레코드가 NULL HFID를 담고 있습니다.

**그 결과**

`heap_hfid_cache_get()`은 레코드에서 읽은 HFID를 검증 없이 캐시 엔트리에 저장하기 때문에, 바로 다음의 완성성 assert(hfid가 유효해야 한다)가 깨져 debug 빌드가 abort 합니다. release 빌드에서는 assert가 없는 대신 NULL HFID 엔트리가 캐시에 남아, 이후 접근이 `file_get_type()`에서 부정확한 에러를 받는 형태로 나타납니다. heap이 원래 없는 view가 이 함수에 들어와도 같은 assert가 깨집니다.

### Implementation

`heap_hfid_cache_get()`에서 클래스 레코드를 읽은 직후 HFID가 NULL이면 **캐시에 넣지 않고 조기 반환**하도록 했습니다.

- 만들던 엔트리를 정리하고(classname 해제, lock-free 트랜잭션 종료, 스텁 삭제) `ER_HEAP_UNKNOWN_OBJECT`를 반환합니다. "heap이 없다"는 일시 상태를 캐시에 영속화하지 않으므로, TRUNCATE가 끝난 뒤 첫 접근이 새 HFID를 정상적으로 캐시합니다.
- 반환 에러는 기존 상위 처리와 그대로 맞물립니다. `heap_get_class_oid()`가 이 에러를 `S_DOESNT_EXIST`로 변환하고 `xlocator_does_exist`가 `LC_DOESNOT_EXIST`를 돌려주므로, 크래시를 유발했던 stale OID 존재 확인은 서버를 죽이는 대신 "그 객체는 존재하지 않는다"는 올바른 답을 받습니다.
- 완성성 assert는 그대로 유지했습니다. 이제 assert에는 유효한 HFID만 도달하므로, 실제 캐시 오염을 잡아내는 본래 역할이 보존됩니

TRUNCATE가 NULL HFID를 디스크에 노출하는 구간 자체를 없애는 수정(flush 순서 재배열)은 별도 후속 건으로 분리합니다.

### Remarks

N/A
