### PR TITLE
[CBRD-27331] Keep HEAP_PAGE_VACUUM_ONCE for MVCC operations logged in the same vacuum block

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -1585,6 +1585,7 @@ vacuum_heap_page (THREAD_ENTRY * thread_p, VACUUM_HEAP_OBJECT * heap_objects, in
   HEAP_PAGE_VACUUM_STATUS page_vacuum_status;	/* Current page vacuum status. */
   int error_code = NO_ERROR;	/* Error code. */
   int obj_index = 0;		/* Index used to iterate the object array. */
+  int last_obj_index;		/* Index of the last distinct object; page status is finalized after it. */
 
   /* Assert expected arguments. */
   assert (heap_objects != NULL);
@@ -1639,8 +1640,8 @@ vacuum_heap_page (THREAD_ENTRY * thread_p, VACUUM_HEAP_OBJECT * heap_objects, in
       if (helper.home_page == NULL)
 	{
 	  /* deallocated */
-	  /* Safe guard: this was possible if there was only one object to be vacuumed. */
-	  assert (n_heap_objects == 1);
+	  /* Safe guard: the interrupted job had removed the page after processing all of its objects; a page in
+	   * HEAP_PAGE_VACUUM_ONCE may hold many objects of one job, so no assumption on their number is possible. */
 
 	  vacuum_er_log_warning (VACUUM_ER_LOG_HEAP, "Heap page %d|%d was deallocated during previous run",
 				 VPID_AS_ARGS (&helper.home_vpid));
@@ -1651,8 +1652,8 @@ vacuum_heap_page (THREAD_ENTRY * thread_p, VACUUM_HEAP_OBJECT * heap_objects, in
 	{
 	  /* page was deallocated and reused as file table. */
 	  assert (ptype == PAGE_FTAB);
-	  /* Safe guard: this was possible if there was only one object to be vacuumed. */
-	  assert (n_heap_objects == 1);
+	  /* Safe guard: the interrupted job had removed the page after processing all of its objects; a page in
+	   * HEAP_PAGE_VACUUM_ONCE may hold many objects of one job, so no assumption on their number is possible. */
 
 	  vacuum_er_log_warning (VACUUM_ER_LOG_HEAP,
 				 "Heap page %d|%d was deallocated during previous run and reused as file table page",
@@ -1701,6 +1702,14 @@ vacuum_heap_page (THREAD_ENTRY * thread_p, VACUUM_HEAP_OBJECT * heap_objects, in
     {
       helper.reusable = *reusable;
       helper.hfid = *hfid;
+    }
+
+  /* Objects are sorted by slot; the loop below skips repeated slots, so the last object it actually processes is the
+   * first of the trailing run of equal slots. The page status is finalized when that object is processed. */
+  last_obj_index = n_heap_objects - 1;
+  while (last_obj_index > 0 && heap_objects[last_obj_index].oid.slotid == heap_objects[last_obj_index - 1].oid.slotid)
+    {
+      last_obj_index--;
     }
 
   helper.crt_slotid = -1;
@@ -1811,11 +1820,13 @@ vacuum_heap_page (THREAD_ENTRY * thread_p, VACUUM_HEAP_OBJECT * heap_objects, in
        * Object can be removed.  8. Vacuum is executed for delete operation at #4.  It would be incorrect to change
        * page status from vacuum once to none, since it will be followed by another vacuum task. Since vacuum none
        * status means page might be deallocated, it is better to be paranoid about it. */
-      if ((page_vacuum_status == HEAP_PAGE_VACUUM_ONCE && !was_interrupted)
-	  || (page_vacuum_status == HEAP_PAGE_VACUUM_NONE && was_interrupted))
+      /* A page in HEAP_PAGE_VACUUM_ONCE may hold many objects of this job (all MVCC operations logged in the same
+       * block keep the status, see heap_page_update_chain_after_mvcc_log), so finalize the page status only after the
+       * last distinct object has been processed. */
+      if (obj_index == last_obj_index
+	  && ((page_vacuum_status == HEAP_PAGE_VACUUM_ONCE && !was_interrupted)
+	      || (page_vacuum_status == HEAP_PAGE_VACUUM_NONE && was_interrupted)))
 	{
-	  assert (n_heap_objects == 1);
-	  assert (helper.n_vacuumed <= 1);
 	  if (page_vacuum_status == HEAP_PAGE_VACUUM_ONCE)
 	    {
 	      heap_page_set_vacuum_status_none (thread_p, helper.home_page);

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -219,6 +219,7 @@ struct heap_hdr_stats
 /* Define heap page flags. */
 #define HEAP_PAGE_FLAG_BESTSPACE		  0x00000001
 #define HEAP_PAGE_FLAG_NOT_IN_HEAP		  0x00000002
+#define HEAP_PAGE_FLAG_LAST_MVCC_BLOCK_VALID	  0x00000004
 #define HEAP_PAGE_FLAG_VACUUM_STATUS_MASK	  0xC0000000
 #define HEAP_PAGE_FLAG_VACUUM_ONCE		  0x80000000
 #define HEAP_PAGE_FLAG_VACUUM_UNKNOWN		  0x40000000
@@ -274,7 +275,14 @@ struct heap_chain
   VPID next_vpid;		/* Next page */
   MVCCID max_mvccid;		/* Max MVCCID of any MVCC operations in page. */
   INT32 flags;			/* Flags for heap page. High 2 bits are used for vacuum state. */
+  INT32 last_mvcc_blockid;	/* Low 32 bits of the vacuum log block id of the last MVCC operation logged on this
+				 * page. Valid only when HEAP_PAGE_FLAG_LAST_MVCC_BLOCK_VALID is set. Occupies the
+				 * former tail padding, so the on-disk record size is unchanged. */
 };
+
+/* The chain record is stored on disk and compared by size against the header; the new field must not change it. */
+static_assert (sizeof (HEAP_CHAIN) == 40, "HEAP_CHAIN size must remain 40 bytes");
+static_assert (offsetof (HEAP_CHAIN, flags) == 32, "HEAP_CHAIN::flags offset must remain 32");
 
 #define HEAP_CHK_ADD_UNFOUND_RELOCOIDS 100
 
@@ -860,8 +868,11 @@ static int heap_get_class_info_from_record (THREAD_ENTRY * thread_p, const OID *
 					    char **classname_out);
 
 static void heap_page_update_chain_after_mvcc_op (THREAD_ENTRY * thread_p, PAGE_PTR heap_page, MVCCID mvccid);
+static void heap_page_update_chain_after_mvcc_log (THREAD_ENTRY * thread_p, PAGE_PTR heap_page,
+						   HEAP_PAGE_VACUUM_STATUS status_before_op,
+						   const LOG_LSA * page_lsa_before_log);
 static void heap_page_rv_chain_update (THREAD_ENTRY * thread_p, PAGE_PTR heap_page, MVCCID mvccid,
-				       bool vacuum_status_change);
+				       bool vacuum_status_change, const LOG_LSA * rcv_lsa);
 
 static int heap_scancache_add_partition_node (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cache,
 					      OID * partition_oid);
@@ -16179,11 +16190,13 @@ heap_mvcc_log_insert (THREAD_ENTRY * thread_p, RECDES * p_recdes, LOG_DATA_ADDR 
   LOG_CRUMB redo_crumbs[HEAP_LOG_MVCC_INSERT_MAX_REDO_CRUMBS];
   INT32 mvcc_flags;
   HEAP_PAGE_VACUUM_STATUS vacuum_status;
+  LOG_LSA lsa_before_log;
 
   assert (p_recdes != NULL);
   assert (p_addr != NULL);
 
   vacuum_status = heap_page_get_vacuum_status (thread_p, p_addr->pgptr);
+  LSA_COPY (&lsa_before_log, pgbuf_get_lsa (p_addr->pgptr));
 
   /* Update chain. */
   heap_page_update_chain_after_mvcc_op (thread_p, p_addr->pgptr, logtb_get_current_mvccid (thread_p));
@@ -16232,6 +16245,8 @@ heap_mvcc_log_insert (THREAD_ENTRY * thread_p, RECDES * p_recdes, LOG_DATA_ADDR 
     {
       log_append_undoredo_crumbs (thread_p, RVHF_MVCC_INSERT, p_addr, 0, n_redo_crumbs, NULL, redo_crumbs);
     }
+
+  heap_page_update_chain_after_mvcc_log (thread_p, p_addr->pgptr, vacuum_status, &lsa_before_log);
 }
 
 /*
@@ -16321,7 +16336,7 @@ heap_rv_mvcc_redo_insert (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
       return ER_FAILED;
     }
 
-  heap_page_rv_chain_update (thread_p, rcv->pgptr, rcv->mvcc_id, vacuum_status_change);
+  heap_page_rv_chain_update (thread_p, rcv->pgptr, rcv->mvcc_id, vacuum_status_change, &rcv->record_lsa);
   pgbuf_set_dirty (thread_p, rcv->pgptr, DONT_FREE);
 
   return NO_ERROR;
@@ -16410,7 +16425,8 @@ heap_mvcc_log_delete (THREAD_ENTRY * thread_p, LOG_DATA_ADDR * p_addr, LOG_RCVIN
   char *redo_data_p = PTR_ALIGN (redo_data_buffer, MAX_ALIGNMENT);
   char *ptr;
   int redo_data_size = 0;
-  HEAP_PAGE_VACUUM_STATUS vacuum_status;
+  HEAP_PAGE_VACUUM_STATUS vacuum_status = HEAP_PAGE_VACUUM_NONE;
+  LOG_LSA lsa_before_log = LSA_INITIALIZER;
 
   assert (p_addr != NULL);
   assert (rcvindex == RVHF_MVCC_DELETE_REC_HOME || rcvindex == RVHF_MVCC_DELETE_REC_NEWHOME
@@ -16419,6 +16435,7 @@ heap_mvcc_log_delete (THREAD_ENTRY * thread_p, LOG_DATA_ADDR * p_addr, LOG_RCVIN
   if (LOG_IS_MVCC_HEAP_OPERATION (rcvindex))
     {
       vacuum_status = heap_page_get_vacuum_status (thread_p, p_addr->pgptr);
+      LSA_COPY (&lsa_before_log, pgbuf_get_lsa (p_addr->pgptr));
 
       heap_page_update_chain_after_mvcc_op (thread_p, p_addr->pgptr, logtb_get_current_mvccid (thread_p));
       if (heap_page_get_vacuum_status (thread_p, p_addr->pgptr) != vacuum_status)
@@ -16448,6 +16465,11 @@ heap_mvcc_log_delete (THREAD_ENTRY * thread_p, LOG_DATA_ADDR * p_addr, LOG_RCVIN
   else
     {
       log_append_undoredo_data (thread_p, rcvindex, p_addr, 0, redo_data_size, NULL, redo_data_p);
+    }
+
+  if (LOG_IS_MVCC_HEAP_OPERATION (rcvindex))
+    {
+      heap_page_update_chain_after_mvcc_log (thread_p, p_addr->pgptr, vacuum_status, &lsa_before_log);
     }
 }
 
@@ -16631,7 +16653,7 @@ heap_rv_mvcc_redo_delete_home (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
       ASSERT_ERROR ();
       return error_code;
     }
-  heap_page_rv_chain_update (thread_p, rcv->pgptr, rcv->mvcc_id, vacuum_status_change);
+  heap_page_rv_chain_update (thread_p, rcv->pgptr, rcv->mvcc_id, vacuum_status_change, &rcv->record_lsa);
 
   pgbuf_set_dirty (thread_p, rcv->pgptr, DONT_FREE);
   return NO_ERROR;
@@ -19494,6 +19516,9 @@ heap_mvcc_log_home_change_on_delete (THREAD_ENTRY * thread_p, RECDES * old_recde
 				     LOG_DATA_ADDR * p_addr)
 {
   HEAP_PAGE_VACUUM_STATUS vacuum_status = heap_page_get_vacuum_status (thread_p, p_addr->pgptr);
+  LOG_LSA lsa_before_log;
+
+  LSA_COPY (&lsa_before_log, pgbuf_get_lsa (p_addr->pgptr));
 
   /* REC_RELOCATION type record was brought back to home page or REC_HOME has been converted to
    * REC_RELOCATION/REC_BIGONE. */
@@ -19514,6 +19539,8 @@ heap_mvcc_log_home_change_on_delete (THREAD_ENTRY * thread_p, RECDES * old_recde
     {
       log_append_undoredo_recdes (thread_p, RVHF_MVCC_DELETE_MODIFY_HOME, p_addr, old_recdes, new_recdes);
     }
+
+  heap_page_update_chain_after_mvcc_log (thread_p, p_addr->pgptr, vacuum_status, &lsa_before_log);
 }
 
 /*
@@ -19528,6 +19555,9 @@ static void
 heap_mvcc_log_home_no_change (THREAD_ENTRY * thread_p, LOG_DATA_ADDR * p_addr)
 {
   HEAP_PAGE_VACUUM_STATUS vacuum_status = heap_page_get_vacuum_status (thread_p, p_addr->pgptr);
+  LOG_LSA lsa_before_log;
+
+  LSA_COPY (&lsa_before_log, pgbuf_get_lsa (p_addr->pgptr));
 
   /* Update heap chain for vacuum. */
   heap_page_update_chain_after_mvcc_op (thread_p, p_addr->pgptr, logtb_get_current_mvccid (thread_p));
@@ -19538,6 +19568,8 @@ heap_mvcc_log_home_no_change (THREAD_ENTRY * thread_p, LOG_DATA_ADDR * p_addr)
     }
 
   log_append_undoredo_data (thread_p, RVHF_MVCC_NO_MODIFY_HOME, p_addr, 0, 0, NULL, NULL);
+
+  heap_page_update_chain_after_mvcc_log (thread_p, p_addr->pgptr, vacuum_status, &lsa_before_log);
 }
 
 /*
@@ -19570,7 +19602,7 @@ heap_rv_redo_update_and_update_chain (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
       return error_code;
     }
 
-  heap_page_rv_chain_update (thread_p, rcv->pgptr, rcv->mvcc_id, vacuum_status_change);
+  heap_page_rv_chain_update (thread_p, rcv->pgptr, rcv->mvcc_id, vacuum_status_change, &rcv->record_lsa);
   /* Page was already marked as dirty */
   return NO_ERROR;
 }
@@ -23157,9 +23189,13 @@ heap_log_update_physical (THREAD_ENTRY * thread_p, PAGE_PTR page_p, VFID * vfid_
   address.vfid = vfid_p;
 
   /* actual logging */
+  HEAP_PAGE_VACUUM_STATUS vacuum_status = HEAP_PAGE_VACUUM_NONE;
+  LOG_LSA lsa_before_log = LSA_INITIALIZER;
+
   if (LOG_IS_MVCC_HEAP_OPERATION (rcvindex))
     {
-      HEAP_PAGE_VACUUM_STATUS vacuum_status = heap_page_get_vacuum_status (thread_p, page_p);
+      vacuum_status = heap_page_get_vacuum_status (thread_p, page_p);
+      LSA_COPY (&lsa_before_log, pgbuf_get_lsa (page_p));
       heap_page_update_chain_after_mvcc_op (thread_p, page_p, logtb_get_current_mvccid (thread_p));
       if (heap_page_get_vacuum_status (thread_p, page_p) != vacuum_status)
 	{
@@ -23175,6 +23211,11 @@ heap_log_update_physical (THREAD_ENTRY * thread_p, PAGE_PTR page_p, VFID * vfid_
   else
     {
       log_append_undoredo_recdes (thread_p, rcvindex, &address, old_recdes_p, new_recdes_p);
+    }
+
+  if (LOG_IS_MVCC_HEAP_OPERATION (rcvindex))
+    {
+      heap_page_update_chain_after_mvcc_log (thread_p, page_p, vacuum_status, &lsa_before_log);
     }
 }
 
@@ -24676,11 +24717,10 @@ heap_page_update_chain_after_mvcc_op (THREAD_ENTRY * thread_p, PAGE_PTR heap_pag
       break;
 
     case HEAP_PAGE_VACUUM_ONCE:
-      /* Change status to unknown number of vacuums. */
-      HEAP_PAGE_SET_VACUUM_STATUS (chain, HEAP_PAGE_VACUUM_UNKNOWN);
-      vacuum_er_log (VACUUM_ER_LOG_HEAP,
-		     "Changed vacuum status for page %d|%d, lsa=%lld|%d from vacuum once to unknown.",
-		     PGBUF_PAGE_STATE_ARGS (heap_page));
+      /* Vacuum jobs are per log block and a job visits a page once for all of its operations in that block. Whether
+       * this operation adds a second visit depends on the log block of the record about to be appended, which is only
+       * known after logging. The decision is made in heap_page_update_chain_after_mvcc_log (). Until then the status
+       * stays HEAP_PAGE_VACUUM_ONCE. */
       break;
 
     case HEAP_PAGE_VACUUM_UNKNOWN:
@@ -24716,6 +24756,90 @@ heap_page_update_chain_after_mvcc_op (THREAD_ENTRY * thread_p, PAGE_PTR heap_pag
 }
 
 /*
+ * heap_page_update_chain_after_mvcc_log () - Finish the vacuum status update of an MVCC operation after its log
+ *					      record has been appended.
+ *
+ * return		     : Void.
+ * thread_p (in)	     : Thread entry.
+ * heap_page (in)	     : Heap page.
+ * status_before_op (in)     : Vacuum status of the page before heap_page_update_chain_after_mvcc_op ().
+ * page_lsa_before_log (in)  : Page LSA before the log record was appended.
+ *
+ * Note: Vacuum works per log block and a vacuum job visits a page once for all the MVCC operations of that block.
+ *	 HEAP_PAGE_VACUUM_ONCE therefore stays exact as long as every pending operation on the page belongs to the same
+ *	 block. The block of the new operation is the block of its log record, which is known only now: log append
+ *	 stamped the page LSA with the record LSA. The block of the previous MVCC operation is remembered in the chain
+ *	 (last_mvcc_blockid). Recovery repeats the same decision from the record LSA in heap_page_rv_chain_update ().
+ */
+static void
+heap_page_update_chain_after_mvcc_log (THREAD_ENTRY * thread_p, PAGE_PTR heap_page,
+				       HEAP_PAGE_VACUUM_STATUS status_before_op, const LOG_LSA * page_lsa_before_log)
+{
+  HEAP_CHAIN *chain;
+  RECDES chain_recdes;
+  const LOG_LSA *page_lsa;
+  VACUUM_LOG_BLOCKID blockid;
+
+  assert (heap_page != NULL);
+  assert (page_lsa_before_log != NULL);
+
+  page_lsa = pgbuf_get_lsa (heap_page);
+  if (page_lsa == NULL || LSA_ISNULL (page_lsa) || LSA_EQ (page_lsa, page_lsa_before_log))
+    {
+      /* Nothing was logged for this operation (e.g. logging is disabled); no vacuum job was added. */
+      return;
+    }
+
+  if (spage_get_record (thread_p, heap_page, HEAP_HEADER_AND_CHAIN_SLOTID, &chain_recdes, PEEK) != S_SUCCESS)
+    {
+      assert_release (false);
+      return;
+    }
+  if (chain_recdes.length != sizeof (HEAP_CHAIN))
+    {
+      /* Heap header page. Do nothing. */
+      assert (chain_recdes.length == sizeof (HEAP_HDR_STATS));
+      return;
+    }
+  chain = (HEAP_CHAIN *) chain_recdes.data;
+
+  blockid = vacuum_get_log_blockid (page_lsa->pageid);
+
+  if (status_before_op == HEAP_PAGE_VACUUM_ONCE && HEAP_PAGE_GET_VACUUM_STATUS (chain) == HEAP_PAGE_VACUUM_ONCE)
+    {
+      /* One vacuum job was already expected. It stays one only if this operation was logged in the same block as the
+       * previous MVCC operation. */
+      if (blockid == VACUUM_NULL_LOG_BLOCKID || (chain->flags & HEAP_PAGE_FLAG_LAST_MVCC_BLOCK_VALID) == 0
+	  || chain->last_mvcc_blockid != (INT32) blockid)
+	{
+	  HEAP_PAGE_SET_VACUUM_STATUS (chain, HEAP_PAGE_VACUUM_UNKNOWN);
+	  vacuum_er_log (VACUUM_ER_LOG_HEAP,
+			 "Changed vacuum status for page %d|%d, lsa=%lld|%d from vacuum once to unknown "
+			 "(previous block %d, new block %lld).", PGBUF_PAGE_STATE_ARGS (heap_page),
+			 (chain->flags & HEAP_PAGE_FLAG_LAST_MVCC_BLOCK_VALID) ? chain->last_mvcc_blockid : -1,
+			 (long long int) blockid);
+	}
+      else
+	{
+	  vacuum_er_log (VACUUM_ER_LOG_HEAP,
+			 "Vacuum status for page %d|%d, lsa=%lld|%d remains vacuum once (same log block %lld).",
+			 PGBUF_PAGE_STATE_ARGS (heap_page), (long long int) blockid);
+	}
+    }
+
+  /* Remember the block of this operation for the next one. */
+  if (blockid != VACUUM_NULL_LOG_BLOCKID)
+    {
+      chain->last_mvcc_blockid = (INT32) blockid;
+      chain->flags |= HEAP_PAGE_FLAG_LAST_MVCC_BLOCK_VALID;
+    }
+  else
+    {
+      chain->flags &= ~HEAP_PAGE_FLAG_LAST_MVCC_BLOCK_VALID;
+    }
+}
+
+/*
  * heap_page_rv_vacuum_status_change () - Applies vacuum status change for
  *					  recovery.
  *
@@ -24724,8 +24848,10 @@ heap_page_update_chain_after_mvcc_op (THREAD_ENTRY * thread_p, PAGE_PTR heap_pag
  * heap_page (in) : Heap page.
  */
 static void
-heap_page_rv_chain_update (THREAD_ENTRY * thread_p, PAGE_PTR heap_page, MVCCID mvccid, bool vacuum_status_change)
+heap_page_rv_chain_update (THREAD_ENTRY * thread_p, PAGE_PTR heap_page, MVCCID mvccid, bool vacuum_status_change,
+			   const LOG_LSA * rcv_lsa)
 {
+  VACUUM_LOG_BLOCKID blockid = VACUUM_NULL_LOG_BLOCKID;
   HEAP_CHAIN *chain;
   RECDES chain_recdes;
   HEAP_PAGE_VACUUM_STATUS vacuum_status;
@@ -24748,30 +24874,48 @@ heap_page_rv_chain_update (THREAD_ENTRY * thread_p, PAGE_PTR heap_page, MVCCID m
     }
   chain = (HEAP_CHAIN *) chain_recdes.data;
 
-  if (vacuum_status_change)
+  if (rcv_lsa != NULL && !LSA_ISNULL (rcv_lsa))
     {
-      /* Change status. */
-      vacuum_status = HEAP_PAGE_GET_VACUUM_STATUS (chain);
-      switch (vacuum_status)
-	{
-	case HEAP_PAGE_VACUUM_NONE:
-	case HEAP_PAGE_VACUUM_UNKNOWN:
-	  HEAP_PAGE_SET_VACUUM_STATUS (chain, HEAP_PAGE_VACUUM_ONCE);
+      blockid = vacuum_get_log_blockid (rcv_lsa->pageid);
+    }
 
-	  vacuum_er_log (VACUUM_ER_LOG_HEAP | VACUUM_ER_LOG_RECOVERY,
-			 "Change heap page %d|%d, lsa=%lld|%d, status from %s to once.",
-			 PGBUF_PAGE_STATE_ARGS (heap_page),
-			 vacuum_status == HEAP_PAGE_VACUUM_NONE ? "none" : "unknown");
-	  break;
-	case HEAP_PAGE_VACUUM_ONCE:
+  vacuum_status = HEAP_PAGE_GET_VACUUM_STATUS (chain);
+  if (vacuum_status_change && vacuum_status != HEAP_PAGE_VACUUM_ONCE)
+    {
+      /* NONE/UNKNOWN => ONCE. The runtime decided it before logging and marked the record. */
+      HEAP_PAGE_SET_VACUUM_STATUS (chain, HEAP_PAGE_VACUUM_ONCE);
+
+      vacuum_er_log (VACUUM_ER_LOG_HEAP | VACUUM_ER_LOG_RECOVERY,
+		     "Change heap page %d|%d, lsa=%lld|%d, status from %s to once.",
+		     PGBUF_PAGE_STATE_ARGS (heap_page), vacuum_status == HEAP_PAGE_VACUUM_NONE ? "none" : "unknown");
+    }
+  else if (vacuum_status == HEAP_PAGE_VACUUM_ONCE)
+    {
+      /* ONCE => ONCE or UNKNOWN. The runtime decides this after logging (heap_page_update_chain_after_mvcc_log) and
+       * does not mark the record; repeat the same decision from the record LSA. A marked record here can only come
+       * from a log written before this decision existed, when ONCE + operation always meant UNKNOWN. */
+      if (vacuum_status_change || blockid == VACUUM_NULL_LOG_BLOCKID
+	  || (chain->flags & HEAP_PAGE_FLAG_LAST_MVCC_BLOCK_VALID) == 0 || chain->last_mvcc_blockid != (INT32) blockid)
+	{
 	  HEAP_PAGE_SET_VACUUM_STATUS (chain, HEAP_PAGE_VACUUM_UNKNOWN);
 
 	  vacuum_er_log (VACUUM_ER_LOG_HEAP | VACUUM_ER_LOG_RECOVERY,
 			 "Change heap page %d|%d, lsa=%lld|%d, status from once to unknown.",
 			 PGBUF_PAGE_STATE_ARGS (heap_page));
-	  break;
 	}
     }
+
+  /* Remember the block of this operation, exactly as the runtime did. */
+  if (blockid != VACUUM_NULL_LOG_BLOCKID)
+    {
+      chain->last_mvcc_blockid = (INT32) blockid;
+      chain->flags |= HEAP_PAGE_FLAG_LAST_MVCC_BLOCK_VALID;
+    }
+  else
+    {
+      chain->flags &= ~HEAP_PAGE_FLAG_LAST_MVCC_BLOCK_VALID;
+    }
+
   if (MVCC_ID_PRECEDES (chain->max_mvccid, mvccid))
     {
       chain->max_mvccid = mvccid;
@@ -24921,7 +25065,7 @@ heap_rv_update_chain_after_mvcc_op (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
   assert (MVCCID_IS_NORMAL (rcv->mvcc_id));
 
   vacuum_status_change = (rcv->offset & HEAP_RV_FLAG_VACUUM_STATUS_CHANGE) != 0;
-  heap_page_rv_chain_update (thread_p, rcv->pgptr, rcv->mvcc_id, vacuum_status_change);
+  heap_page_rv_chain_update (thread_p, rcv->pgptr, rcv->mvcc_id, vacuum_status_change, &rcv->record_lsa);
   pgbuf_set_dirty (thread_p, rcv->pgptr, DONT_FREE);
   return NO_ERROR;
 }
@@ -25006,11 +25150,13 @@ heap_mvcc_log_redistribute (THREAD_ENTRY * thread_p, RECDES * p_recdes, LOG_DATA
   MVCCID delid;
   MVCC_REC_HEADER mvcc_rec_header;
   HEAP_PAGE_VACUUM_STATUS vacuum_status;
+  LOG_LSA lsa_before_log;
 
   assert (p_recdes != NULL);
   assert (p_addr != NULL);
 
   vacuum_status = heap_page_get_vacuum_status (thread_p, p_addr->pgptr);
+  LSA_COPY (&lsa_before_log, pgbuf_get_lsa (p_addr->pgptr));
 
   /* Update chain. */
   heap_page_update_chain_after_mvcc_op (thread_p, p_addr->pgptr, logtb_get_current_mvccid (thread_p));
@@ -25051,6 +25197,8 @@ heap_mvcc_log_redistribute (THREAD_ENTRY * thread_p, RECDES * p_recdes, LOG_DATA
   /* Append redo crumbs; undo crumbs not necessary as the spage_delete physical operation uses the offset field of the
    * address */
   log_append_undoredo_crumbs (thread_p, RVHF_MVCC_REDISTRIBUTE, p_addr, 0, n_redo_crumbs, NULL, redo_crumbs);
+
+  heap_page_update_chain_after_mvcc_log (thread_p, p_addr->pgptr, vacuum_status, &lsa_before_log);
 }
 
 /*
@@ -25137,7 +25285,7 @@ heap_rv_mvcc_redo_redistribute (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
       return ER_FAILED;
     }
 
-  heap_page_rv_chain_update (thread_p, rcv->pgptr, rcv->mvcc_id, vacuum_status_change);
+  heap_page_rv_chain_update (thread_p, rcv->pgptr, rcv->mvcc_id, vacuum_status_change, &rcv->record_lsa);
   pgbuf_set_dirty (thread_p, rcv->pgptr, DONT_FREE);
 
   return NO_ERROR;

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -454,6 +454,7 @@ log_rv_redo_record (THREAD_ENTRY * thread_p, log_reader & log_pgptr_reader,
 
   if (redofun != NULL)
     {
+      LSA_COPY (&rcv->record_lsa, rcv_lsa_ptr);
       error_code = (*redofun) (thread_p, rcv);
       if (error_code != NO_ERROR)
 	{

--- a/src/transaction/log_recovery_redo.hpp
+++ b/src/transaction/log_recovery_redo.hpp
@@ -643,6 +643,7 @@ void log_rv_redo_record_sync (THREAD_ENTRY *thread_p, log_rv_redo_context &redo_
        */
       perfmon_counter_timer_raii_tracker perfmon { PSTAT_LOG_REDO_FUNC_EXEC };
 
+      rcv.record_lsa = record_info.m_start_lsa;
       const int err_func = redofunc (thread_p, &rcv);
       if (err_func != NO_ERROR)
 	{

--- a/src/transaction/recovery.h
+++ b/src/transaction/recovery.h
@@ -210,6 +210,7 @@ struct log_rcv
   int length = 0;		/* Length of data */
   const char *data = nullptr;	/* Replacement data. Pointer becomes invalid once the recovery of the data is finished */
   LOG_LSA reference_lsa = NULL_LSA;	/* Next LSA used by compensate/postpone. */
+  LOG_LSA record_lsa = NULL_LSA;	/* LSA of the log record being redone; NULL_LSA when the caller does not know it. */
 
   // *INDENT-OFF*
   log_rcv () = default;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27331

## Purpose

vacuum 이 비워진 heap 페이지를 파일에 반납(`heap_remove_page_on_vacuum`)하는 것은 페이지 vacuum 상태가 `HEAP_PAGE_VACUUM_ONCE`("이 페이지를 방문할 vacuum job 이 정확히 하나 남음")일 때만 허용됩니다. 그런데 `heap_page_update_chain_after_mvcc_op ()` 는 vacuum 전에 두 번째 MVCC op 가 오면 무조건 `HEAP_PAGE_VACUUM_UNKNOWN` 으로 내렸습니다. vacuum job 은 로그 블록 단위이고 같은 블록의 op 는 한 job 이 페이지를 한 번 방문해 모두 처리하므로 이 판정은 필요 이상으로 보수적입니다. 결과적으로 bulk INSERT 된 페이지는 2번째 행에서 UNKNOWN 이 되고, bulk DELETE 로 완전히 비어도 영구히 반납되지 않았습니다(UNKNOWN 은 새 op 가 와야만 벗어날 수 있는데 빈 페이지에는 op 가 오지 않음). 회수 수단은 `compactdb` 만이었습니다.

실측(11.5 develop, `er_log_vacuum=144`, 300K 행 INSERT..SELECT → DELETE): "remains unknown" 1,699,258건, 비워진 약 6,000 페이지 중 반납 1건.

관련: 비워진 페이지가 다음 INSERT 에 재사용되지 않는 bestspace 회귀는 별도 이슈 CBRD-27325 입니다. 본 PR 은 재사용과 무관하게 "비워진 페이지를 실제로 파일에 돌려주는" 개선입니다.

## Implementation

**"같은 vacuum job" 을 정확히 추적** — 페이지가 직전 MVCC op 의 로그 블록을 기억하고, 새 op 는 자기 로그 레코드가 같은 블록에 기록됐을 때만 ONCE 를 유지합니다.

* `HEAP_CHAIN` 에 `INT32 last_mvcc_blockid`(블록 id 하위 32비트)와 플래그 `HEAP_PAGE_FLAG_LAST_MVCC_BLOCK_VALID` 추가. 기존 꼬리 패딩 자리를 쓰므로 `sizeof (HEAP_CHAIN)` 은 40, `flags` 오프셋은 32 그대로이며(`static_assert`), 디스크상 체인 레코드 형식이 바뀌지 않습니다. 이전 빌드가 쓴 페이지는 플래그가 없어 보수적으로(UNKNOWN, 기존 동작) 처리됩니다.
* `heap_page_update_chain_after_mvcc_op ()` 는 ONCE 케이스를 더 이상 로깅 전에 결정하지 않습니다(레코드의 블록을 아직 모름). 새 함수 `heap_page_update_chain_after_mvcc_log ()` 를 6개 MVCC heap 로깅 지점의 `log_append_*` 직후에 호출해, log append 가 페이지에 찍은 레코드 LSA 로 블록을 구하고 저장된 블록과 비교해 ONCE 유지 또는 UNKNOWN 을 결정한 뒤 새 블록을 저장합니다. 아무것도 로깅되지 않았으면(페이지 LSA 불변) vacuum job 이 추가되지 않았으므로 건드리지 않습니다.
* 복구는 같은 입력으로 같은 결정을 재현합니다: `LOG_RCV` 에 `record_lsa` 를 추가하고 시리얼 redo(`log_rv_redo_record ()`)와 템플릿 redo(`log_recovery_redo.hpp`) 양쪽에서 세팅, `heap_page_rv_chain_update ()` 가 저장된 블록과 비교합니다. `HEAP_RV_FLAG_VACUUM_STATUS_CHANGE` 는 로깅 전에 결정되는 `NONE/UNKNOWN → ONCE` 전이를 계속 표시하며, ONCE 페이지에 이 플래그가 찍힌 레코드는 이전 빌드가 쓴 로그에서만 나올 수 있으므로 기존대로 `ONCE → UNKNOWN` 으로 처리합니다.

**vacuum 은 마지막 객체 뒤에 페이지를 마무리** — `vacuum_heap_page ()` 는 ONCE=객체 1개 전제로 첫 객체 직후 상태를 NONE 으로 바꾸고 반납을 시도한 뒤 루프를 빠져나갔는데, 이제 ONCE 페이지에 한 job 의 객체가 여럿 있으므로 나머지 객체가 처리되지 않는 문제가 생깁니다(실측: 300K 삭제 후 272,625 레코드 잔존). 마지막 distinct 객체(루프가 중복 슬롯을 건너뛰므로 뒤쪽 동일 슬롯 구간의 첫 인덱스) 처리 후에 마무리하도록 바꾸고, interrupted job 경로의 "객체 1개" assert 두 개를 제거했습니다. 페이지 fix 로직과 반납 조건 자체는 바꾸지 않았습니다.

**안전성**: ONCE 의 의미("pending job 이 정확히 하나")는 그대로입니다. 두 op 가 같은 블록에 기록됐다는 것은 같은 job 이 둘을 처리한다는 뜻이므로, 반납을 보호하던 불변식("다른 job 이 이 페이지를 더 방문하지 않음")이 유지됩니다. 판정 입력이 추정값(페이지 LSA 대리, `prior_lsa` 비동기 읽기)이 아니라 페이지에 저장된 값과 레코드 LSA 이므로 런타임과 복구가 어긋나지 않습니다.

## Remarks

단일 노드(REUSE_OID 테이블, 300K 행 INSERT..SELECT → DELETE 5라운드, vacuum 후 `SHOW HEAP CAPACITY`):

| 라운드 | 수정 전 (insert 후 / delete 후) | 수정 후 (insert 후 / delete 후) |
|---|---|---|
| 1 | 2,973 / 2,973 | 2,973 / 256 |
| 2 | 5,793 / 5,793 | 3,080 / 475 |
| 3 | 8,629 / 8,629 | 3,318 / 718 |
| 4 | 11,461 / 11,461 | 3,537 / 926 |
| 5 | 14,336 / 14,336 | 3,752 / 972 |

트레이스: "remains vacuum once (same log block)" 746,654회, `ONCE → UNKNOWN` 614회(블록 경계에 걸친 op, 예상된 잔여), 반납 5,405 페이지, 서버 오류 0.

* 크래시/복구: bulk DELETE 진행 중 `kill -9` → 재기동(redo 가 레코드 LSA 로 상태 재계산: once 4,447 / unknown 922) → `checkdb -C` 정상 → 이후 라운드도 정상 반납(152/390/579). 릴리스·디버그 빌드 모두, 디버그 빌드 assert 실패 0.
* 수정 전 빌드로 같은 크래시 테스트: `checkdb` 정상, 반납 0(2,973 → 5,932 → 8,756).
* HA 페어(마스터/standby 슬레이브, bulk insert/delete + OLTP 8세션 10분): 마스터 bt heap 수정 전 +45.5K → 수정 후 +2.6K 페이지. 슬레이브는 단일 applier 로 vacuum 이 뒤처져 insert 가 vacuum 되기 전에 delete 가 도착하는 페이지(정당하게 두 job 대기 → UNKNOWN)가 많아 개선 폭이 작습니다(+51.2K → +16K).
* 잔여: 블록 경계에 걸친 op 를 가진 페이지는 기존처럼 UNKNOWN 이 되어 반납되지 않습니다. 이는 페이지 포맷 변경 없는 블록 단위 추적의 한계이며, 빈 UNKNOWN 페이지의 지연 반납은 후속 과제로 남깁니다.
* CI 코드 스타일(indent 2.2.11 / astyle) 적용 결과 변경 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
