### PR TITLE
[CBRD-27335] Add PGO build option for GCC (PoC)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -383,6 +383,39 @@ if(CMAKE_BUILD_TYPE MATCHES "Profile")
   mark_as_advanced(CMAKE_CXX_FLAGS_PROFILE CMAKE_C_FLAGS_PROFILE)
 endif(CMAKE_BUILD_TYPE MATCHES "Profile")
 
+# Profile-guided optimization (CBRD-27335).
+# Two-phase build: configure with -DPGO=generate, run a representative training
+# workload against that build (processes must exit cleanly so the .gcda counter
+# files get written), then reconfigure the SAME binary directory with -DPGO=use.
+# GCC locates .gcda files by a name mangled from each object file's absolute
+# path, so the generate and use phases must share one binary directory.
+set(PGO "OFF" CACHE STRING "Profile-guided optimization phase (OFF, generate, use)")
+set_property(CACHE PGO PROPERTY STRINGS OFF generate use)
+set(PGO_PROFILE_DIR "${CMAKE_BINARY_DIR}/pgo-profile-data"
+  CACHE PATH "Directory where PGO profile data (.gcda) is written and read")
+if(PGO STREQUAL "generate" OR PGO STREQUAL "use")
+  if(NOT CMAKE_COMPILER_IS_GNUCC)
+    message(FATAL_ERROR "PGO=${PGO} is currently supported only with GCC")
+  endif()
+  if(PGO STREQUAL "generate")
+    # -fprofile-update=atomic: cub_server is heavily multi-threaded and racy
+    # counter updates corrupt the profile without it.
+    set(PGO_FLAGS "-fprofile-generate=${PGO_PROFILE_DIR} -fprofile-update=atomic")
+  else()
+    # -fprofile-correction repairs residual counter inconsistencies.
+    # -Wno-missing-profile: objects never executed during training are expected.
+    # -Wno-error=coverage-mismatch tolerates a slightly stale profile.
+    # -Wno-error=stringop-overflow=: profile-driven inlining currently trips this
+    # warning in src/broker/cas_cgw_odbc.c; demoted until that code is fixed.
+    set(PGO_FLAGS "-fprofile-use=${PGO_PROFILE_DIR} -fprofile-correction -Wno-missing-profile -Wno-error=coverage-mismatch -Wno-error=stringop-overflow=")
+  endif()
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${PGO_FLAGS}")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${PGO_FLAGS}")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${PGO_FLAGS}")
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${PGO_FLAGS}")
+  set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} ${PGO_FLAGS}")
+  message(STATUS "PGO phase: ${PGO} (profile dir: ${PGO_PROFILE_DIR})")
+endif()
 
 # source directories
 set(API_DIR                  ${CMAKE_SOURCE_DIR}/src/api)


### PR DESCRIPTION
https://jira.cubrid.org/browse/CBRD-27335

## Purpose

PGO(Profile-Guided Optimization, 프로그램을 실제로 실행해 얻은 통계(profile)로 컴파일러 최적화를 유도하는 2-pass 빌드 기법)를 CUBRID 빌드에서 켤 수 있게 하는 PoC입니다.

- AS-IS: 빌드 시스템에 PGO를 켤 방법이 없어 실험마다 컴파일러 flag를 수동으로 주입해야 합니다.
- TO-BE: `cmake -DPGO=generate`로 훈련용 빌드를 만들고, workload 실행 후 같은 빌드 디렉터리를 `-DPGO=use`로 재구성하면 profile 기반 최적화 빌드가 나옵니다.

동기: CBRD-26382에서 코드 배치(layout) 변화가 질의(query, 데이터베이스에 보내는 조회 명령) 성능을 움직이는 인과가 확인됐습니다. 이 커밋과 별개로 진행한 GCC 11 PoC 실측에서는 훈련 workload와 같은 질의 기준 질의 시간 median(중앙값) -8.94%를 확인했습니다 (조건과 한계는 JIRA 이슈 참고).

## Implementation

- `CMakeLists.txt`에 빌드 설정 값(CMake cache 변수) `PGO`(OFF/generate/use)와 profile 저장 위치 `PGO_PROFILE_DIR`를 추가했습니다. 소스 코드 변경은 없습니다.
- generate 단계는 실행 통계를 남기는 flag를, use 단계는 그 통계를 읽어 최적화하는 flag를 컴파일·링크에 추가합니다.
- 구체적으로 generate는 `-fprofile-generate`와 `-fprofile-update=atomic`(multi-thread 카운터 보호), use는 `-fprofile-use`, `-fprofile-correction`, 그리고 profile이 없거나 낡았을 때 또는 최적화 과정에서 새 경고가 생겼을 때 빌드가 중단되지 않게 하는 경고 관련 flag 3종입니다.
- 기본값이 `OFF`라 기존 빌드에는 아무 영향이 없고, PGO를 켰을 때만 동작합니다. GCC 전용이라 다른 컴파일러에서 켜면 설정 단계에서 오류로 막습니다.

## Remarks

- 검증: GCC 11.5 / Rocky 9.6에서 generate full build와, 같은 디렉터리를 use로 바꾼 full build가 모두 성공했습니다.
- 다만 이 use 빌드는 profile 파일이 없는 상태에서 돌린 것이라, flag가 제대로 붙고 빌드가 깨지지 않는지까지만 확인한 결과입니다. profile을 실제로 소비한 빌드와 성능 실측은 같은 flag 조합의 별도 PoC 빌드로 수행했습니다.
- draft PoC입니다. 훈련 workload 표준화, `cas_cgw_odbc.c`의 `stringop-overflow` 경고 근본 수정, 전용 호스트 재검증, release 파이프라인 통합 방안은 CBRD-27335에서 후속 진행합니다.
- 자세한 설명: https://github.com/vimkim/my-cubrid-docs/blob/main/cbrd-27335/CBRD-27335-pgo-build-option-poc_2adb33a_claude.md
