### PR TITLE
[CBRD-27332] Judge hash-aggregate abandon on a sample-size-scaled unique-ratio cutoff

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -4632,7 +4632,7 @@ qexec_hash_gby_agg_tuple_public (THREAD_ENTRY * thread_p, xasl_node * xasl, XASL
 /*
  * qexec_hash_gby_abandon_cutoff () - cumulative unique-ratio above which hash aggregation
  *                                    should be abandoned, given the tuples hashed so far
- *   return: cutoff ratio in [FLOOR_RATIO .. START_RATIO]
+ *   return: cutoff ratio in [FLOOR_RATIO .. START_RATIO]; START_RATIO up to TUPLE_THRESHOLD tuples
  *   tuple_count(in): number of tuples hashed so far
  *
  * Note: the observed ratio (group_count / tuple_count) is an online estimate of how much the
@@ -4648,6 +4648,14 @@ qexec_hash_gby_agg_tuple_public (THREAD_ENTRY * thread_p, xasl_node * xasl, XASL
 static float
 qexec_hash_gby_abandon_cutoff (int tuple_count)
 {
+  if (tuple_count <= HASH_AGGREGATE_VH_SELECTIVITY_TUPLE_THRESHOLD)
+    {
+      /* the budget-exceeded check can fire before TUPLE_THRESHOLD tuples (wide keys or a small
+       * max_agg_hash_size); extrapolating the log curve there would push the cutoff above 1.0
+       * and make abandoning impossible, so hold it at the strict start value instead */
+      return HASH_AGGREGATE_VH_SELECTIVITY_START_RATIO;
+    }
+
   if (tuple_count >= HASH_AGGREGATE_VH_SELECTIVITY_FLOOR_TUPLES)
     {
       return HASH_AGGREGATE_VH_SELECTIVITY_FLOOR_RATIO;

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -130,8 +130,13 @@
    selectivity is very high */
 #define HASH_AGGREGATE_VH_SELECTIVITY_TUPLE_THRESHOLD   2000
 
-/* maximum selectivity allowed for hash aggregate evaluation */
-#define HASH_AGGREGATE_VH_SELECTIVITY_THRESHOLD         0.5f
+/* cumulative unique-ratio cutoff above which hash aggregation is abandoned: starts at
+ * START_RATIO when TUPLE_THRESHOLD tuples have been hashed and decays on a log scale down to
+ * FLOOR_RATIO at FLOOR_TUPLES, staying there for larger inputs.
+ * See qexec_hash_gby_abandon_cutoff () for the rationale behind the anchors. */
+#define HASH_AGGREGATE_VH_SELECTIVITY_START_RATIO       0.95f
+#define HASH_AGGREGATE_VH_SELECTIVITY_FLOOR_RATIO       0.5f
+#define HASH_AGGREGATE_VH_SELECTIVITY_FLOOR_TUPLES      300000
 
 #define QEXEC_CLEAR_AGG_LIST_VALUE(agg_list) \
   do \
@@ -4625,6 +4630,37 @@ qexec_hash_gby_agg_tuple_public (THREAD_ENTRY * thread_p, xasl_node * xasl, XASL
 }
 
 /*
+ * qexec_hash_gby_abandon_cutoff () - cumulative unique-ratio above which hash aggregation
+ *                                    should be abandoned, given the tuples hashed so far
+ *   return: cutoff ratio in [FLOOR_RATIO .. START_RATIO]
+ *   tuple_count(in): number of tuples hashed so far
+ *
+ * Note: the observed ratio (group_count / tuple_count) is an online estimate of how much the
+ *       hash table compresses its input, so each anchor translates to a physical bound.  At
+ *       2,000 tuples a ratio above 0.95 implies the group count exceeds ~20,000, which does
+ *       not fit the default hash budget (max_agg_hash_size, 2MB) anyway; at 300,000 tuples a
+ *       ratio above 0.5 means the sort input shrinks less than 2x, so hashing no longer pays
+ *       for the per-tuple probes.  The interpolation is logarithmic because the expected
+ *       ratio of a finite group count itself decays on a log scale in the tuple count, which
+ *       keeps the margin between the cutoff and a legitimately hashable key roughly constant
+ *       across the whole range.
+ */
+static float
+qexec_hash_gby_abandon_cutoff (int tuple_count)
+{
+  if (tuple_count >= HASH_AGGREGATE_VH_SELECTIVITY_FLOOR_TUPLES)
+    {
+      return HASH_AGGREGATE_VH_SELECTIVITY_FLOOR_RATIO;
+    }
+
+  return HASH_AGGREGATE_VH_SELECTIVITY_START_RATIO
+    - (HASH_AGGREGATE_VH_SELECTIVITY_START_RATIO - HASH_AGGREGATE_VH_SELECTIVITY_FLOOR_RATIO)
+    * (float) (log ((double) tuple_count / HASH_AGGREGATE_VH_SELECTIVITY_TUPLE_THRESHOLD)
+	       / log ((double) HASH_AGGREGATE_VH_SELECTIVITY_FLOOR_TUPLES
+		      / HASH_AGGREGATE_VH_SELECTIVITY_TUPLE_THRESHOLD));
+}
+
+/*
  * qexec_hash_gby_agg_tuple () - aggregate tuple using hash table
  *   return: error code or NO_ERROR
  *   thread_p(in): thread
@@ -4798,8 +4834,30 @@ qexec_hash_gby_agg_tuple (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE 
 	}
     }
 
+  /* The hash table exceeded its memory budget.  If the key still looks high-cardinality at
+   * this point, abandon hashing instead of thrashing the LRU: a working set larger than the
+   * budget gets no re-hits, so evicting entry by entry only adds overhead on every tuple.
+   * A low ratio means repeats dominate (skewed key, or a group count near the budget), and
+   * LRU eviction keeps the hot groups resident, so spilling entry by entry stays profitable. */
+  if (context->hash_size > (int) mem_limit
+      && (float) context->group_count / context->tuple_count > qexec_hash_gby_abandon_cutoff (context->tuple_count))
+    {
+      context->state = HS_REJECT_ALL;
+
+      rc = qdata_save_agg_htable_to_list (thread_p, context->hash_table, groupby_list, context->part_list_id,
+					  context->temp_dbval_array);
+      if (rc != NO_ERROR)
+	{
+	  return rc;
+	}
+
+#if !defined(NDEBUG)
+      er_log_debug (ARG_FILE_LINE, "hash aggregation abandoned: budget exceeded while still high-cardinality");
+#endif
+    }
+
   /* keep hash table within memory limit */
-  while (context->hash_size > (int) mem_limit)
+  while (context->state != HS_REJECT_ALL && context->hash_size > (int) mem_limit)
     {
       /* get least recently used entry */
       hentry = context->hash_table->lru_head;
@@ -4839,18 +4897,32 @@ qexec_hash_gby_agg_tuple (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE 
       mht_rem (context->hash_table, key, qdata_free_agg_hentry, NULL);
     }
 
-  /* check very high selectivity case */
-  if (context->tuple_count > HASH_AGGREGATE_VH_SELECTIVITY_TUPLE_THRESHOLD)
+  /* Very-high-selectivity check, evaluated every TUPLE_THRESHOLD tuples on the cumulative
+   * unique ratio (groups / tuples) against a cutoff that decays with the number of tuples
+   * seen (see qexec_hash_gby_abandon_cutoff).  A single fixed cutoff cannot serve both ends
+   * of the stream: early on even a low-NDV key looks unique because repeats have not
+   * accumulated yet (a birthday-problem artifact), while late in the stream even a modest
+   * ratio means hashing is not compressing the sort input.  The decaying cutoff starts
+   * strict (0.95) so only a truly unhashable key is cut early, and relaxes toward the
+   * compression break-even (0.5) as the evidence accumulates. */
+  if (context->state == HS_ACCEPT_ALL
+      && context->tuple_count >= HASH_AGGREGATE_VH_SELECTIVITY_TUPLE_THRESHOLD
+      && context->tuple_count % HASH_AGGREGATE_VH_SELECTIVITY_TUPLE_THRESHOLD == 0)
     {
-      float selectivity = (float) context->group_count / context->tuple_count;
-      if (selectivity > HASH_AGGREGATE_VH_SELECTIVITY_THRESHOLD)
+      float unique_ratio = (float) context->group_count / context->tuple_count;
+
+      if (unique_ratio > qexec_hash_gby_abandon_cutoff (context->tuple_count))
 	{
 	  /* very high selectivity, abort hash aggregation */
 	  context->state = HS_REJECT_ALL;
 
 	  /* dump hash table to list file, no need to keep it in memory */
-	  qdata_save_agg_htable_to_list (thread_p, context->hash_table, groupby_list, context->part_list_id,
-					 context->temp_dbval_array);
+	  rc = qdata_save_agg_htable_to_list (thread_p, context->hash_table, groupby_list, context->part_list_id,
+					      context->temp_dbval_array);
+	  if (rc != NO_ERROR)
+	    {
+	      return rc;
+	    }
 
 #if !defined(NDEBUG)
 	  er_log_debug (ARG_FILE_LINE, "hash aggregation abandoned: very high selectivity");


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27332

## Purpose

병렬 heap scan 위의 hash GROUP BY가, 실제로는 해시가 이득인 데이터인데도 **집계를 조기 포기하고 전량 정렬로 넘어가** 느려집니다. TPC-H Q15가 대표 사례입니다(SF=1, 현행 0.99s).

원인은 `qexec_hash_gby_agg_tuple()`의 selectivity 조기 포기 판정입니다:
```c
if (tuple_count > 2000 && (float)group_count/tuple_count > 0.5)
    state = HS_REJECT_ALL;   // 이후 해시 안 함 → 정렬 pass-through
```

이 판정의 목적은 타당합니다 — "거의 유니크한 입력(그룹당 2행 미만)은 해시가 뭉칠 게 없어 정렬이 낫다"는 손절. 문제는 **고정 임계값 0.5를 2000행 표본에 적용하는 것**입니다.

무작위로 분포한 저-NDV 키는 **생일 문제**로 표본 초반에 유니크처럼 보입니다. Q15의 `group by l_suppkey`(1만 그룹 / 필터 후 22.6만 행)는 2000행 표본에서 밀도 ~0.9지만 최종 밀도는 0.04입니다. 판정은 이 순간값 하나로 **영구 확정**되고, 병렬 스캔에서는 각 워커가 자기 몫의 부분집계를 포기해 22.6만 행이 코디네이터로 전량 흘러가 정렬됩니다.

## Implementation

고정 임계값 대신 **표본 크기에 따라 감쇠하는 컷오프 곡선**에 누적 고유비율(ρ = group_count / tuple_count)을 대조합니다. 2000행마다 1회 판정:

```
ρ > τ(n)  →  포기,   τ(n): 0.95 (n=2,000) → 0.5 (n=300,000, log 보간, 이후 고정)
```

각 앵커는 (미지의) 그룹 수 D에 대한 물리적 컷으로 번역됩니다:

- **n=2,000에서 τ=0.95**: ρ>0.95 ⟺ D > ~2만 — 기본 해시 예산(`max_agg_hash_size` 2MB ≈ 1만 그룹)에 어차피 담을 수 없는 크기만 조기 손절. Q15 워커의 ρ(2000)=0.906은 컷과 **6σ 마진**(기존 0.5는 이 지점을 한참 밑돌아 전 워커를 잘랐음)
- **n=300,000에서 τ=0.5**: 30만 행을 보고도 절반이 신규 그룹이면 정렬 입력 축소가 2배 미만 — 해시가 행당 프로브 비용을 회수하지 못하는 손익분기 컷
- **log 보간**: 유한한 그룹 수의 기대 ρ 자체가 log 스케일로 감쇠하므로, 같은 스케일로 내려야 전 구간에서 컷과 정상 키 사이 마진이 일정하게 유지됨

추가로 **해시가 `max_agg_hash_size`를 초과하는 순간에도 같은 판정**을 적용합니다: ρ가 컷 위면 working set이 예산보다 커서 LRU 축출이 재적중 없이 스래시만 하므로 즉시 포기, ρ가 낮으면(스큐 키) 인기 그룹이 상주하는 기존 축출 경로를 유지합니다.

판정은 컨텍스트가 이미 유지하는 카운터만 사용하므로, 이전 리비전의 구간 추적 필드 3개(`last_check_*`, `prev_seg_density`)는 제거했습니다.

## Remarks

TPC-H SF=1 (data_buffer 4G, 조용한 장비, 3회 median):

| | 현행 | 본 PR |
|---|---|---|
| Q15 | 0.993s | **0.885s** |
| 정합성 | — | 22/22 PostgreSQL 16과 일치 |

동작을 debug 빌드 `er_log_debug`로 직접 검증했습니다:

| 케이스 | 기대 | 로그 확인 |
|---|---|---|
| Q15 (1만 그룹) | 전 워커 해시 유지 | 포기·축출 로그 0건, 완주 |
| 전행 유니크 (22.6만 행) | 첫 체크 조기 포기 | `abandoned: very high selectivity` |
| 예산 초과 스래시 (128K 한도 강제) | 축출 폭풍 대신 포기 | `abandoned: budget exceeded`, per-entry dump 폭풍 소멸, 결과 정확 |

- 기존 추세(DECAY) 방식은 연속 구간의 자연 감쇠비가 `e^(-2000/D)`라서 **D > 2000/ln(1/0.9) ≈ 1.9만이면 정당한 키도 구조적으로 오판**하고, Q15(D=1만)도 경계와의 마진이 구간 표본 요동과 같은 크기였습니다. 곡선 방식은 이 두 문제를 함께 제거합니다.
- 진짜 유니크/고밀도 입력의 조기 손절 능력은 그대로이며(위 표), 예산 초과 스래시 케이스는 오히려 새로 보호됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
