### PR TITLE
[CBRD-27280] Reject setting VISIBILITY on MODIFY/CHANGE CLASS ATTRIBUTE

### DIFF
--- a/msg/ko_KR.utf8/cubrid.msg
+++ b/msg/ko_KR.utf8/cubrid.msg
@@ -1990,7 +1990,7 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 333 Stored Procedure를 호출하는 CALL 문은 INTO 절을 가질 수 없습니다.
 
 334 가상 클래스 속성은 visibility를 정의할 수 없습니다.
-335 '%1$s'은 CLASS 또는 SHARED 속성 컬럼입니다. 일반적인 컬럼에서 visibility를 정의할 수 있습니다.
+335 '%1$s'은 CLASS 또는 SHARED 속성 컬럼입니다. 일반적인 컬럼에서만 visibility를 정의할 수 있습니다.
 336 NUMERIC의 스케일 범위(-84부터 127)를 초과했습니다.
 337 파티션 이름이 너무 깁니다.
 

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -12035,6 +12035,10 @@ build_attr_change_map (PARSER_CONTEXT * parser, DB_CTMPL * ctemplate, PT_NODE * 
     {
       attr_chg_properties->new_name_space = ID_SHARED_ATTRIBUTE;
     }
+  else if (attr_def->info.attr_def.attr_type == PT_META_ATTR)
+    {
+      attr_chg_properties->new_name_space = ID_CLASS_ATTRIBUTE;
+    }
 
   if (attr_def->info.attr_def.data_default != NULL)
     {
@@ -14968,6 +14972,18 @@ check_change_attribute (PARSER_CONTEXT * parser, DB_CTMPL * ctemplate, PT_NODE *
 	{
 	  attr_name = old_name;
 	}
+    }
+
+  /* visibility can be set only on normal attributes; CREATE and ADD reject it at parse time, but for MODIFY/CHANGE
+   * the attribute's actual namespace is known only after build_attr_change_map(). This must precede the
+   * is_att_change_needed() early return: an explicit VISIBLE on an already visible attribute counts as "no change"
+   * and would silently succeed otherwise. */
+  if (attribute->info.attr_def.attr_invisible != PT_ATTR_INVISIBLE_UNSET && attr_chg_prop->name_space != ID_ATTRIBUTE)
+    {
+      PT_ERRORmf (parser, attribute, MSGCAT_SET_PARSER_SEMANTIC,
+		  MSGCAT_SEMANTIC_CLASS_ATT_OR_SHARED_CANT_SET_VISIBILITY, attr_name);
+      error = ER_PT_SEMANTIC;
+      goto exit;
     }
 
   if (!is_att_change_needed (attr_chg_prop))


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27280>

### Purpose

CLASS ATTRIBUTE는 visibility 설정이 불가능하며 CREATE 구문이나 ALTER ADD CLASS ATTRIBUTE 구문에서도 오류를 발생시킨다.
하지만 MODIFY, CHANGE 구문으로 이미 존재하는 CLASS ATTRIBUTE에 visibility 를 명시하는 경우 오류를 발생시키지 않는다. (visibility는 반영되지 않는다)
MODIFY, CHANGE 에서 사용자에게 visibility 설정이  불가능함을 알리도록 수정한다.

### Implementation

- MODIFY, CHANGE 구문에 사용되는 함수 `build_attr_change_map`, `check_change_attribute` 수정
- CLASS ATTRIBUTE 의 경우에도 namespace에 `ID_CLASS_ATTRIBUTE` 를 선언
    - 기존의 경우 `ID_NULL`
- namespace가 일반 attribute (`ID_ATTRIBUTE`) 가 아닌 경우 visibility 변경 시 semantic error

### Remarks

N/A
