### PR TITLE
[CBRD-27348] SHARD proxy writes the attempted DB password to the proxy log in cleartext on authentication/ACL failure

### DIFF
--- a/src/broker/shard_proxy_io.c
+++ b/src/broker/shard_proxy_io.c
@@ -1749,8 +1749,8 @@ proxy_process_client_register (T_SOCKET_IO * sock_io_p)
 	  snprintf (err_msg, sizeof (err_msg), "Authorization error.(Address is rejected)");
 	  proxy_context_set_error_with_msg (ctx_p, DBMS_ERROR_INDICATOR, CAS_ER_NOT_AUTHORIZED_CLIENT, err_msg);
 
-	  PROXY_LOG (PROXY_LOG_MODE_ERROR, "Authorization error. (Address is rejected) " "(db_name:[%s], db_user:[%s]).",
-		     db_name, db_user);
+	  PROXY_LOG (PROXY_LOG_MODE_ERROR,
+		     "Authorization error. (Address is rejected) " "(db_name:[%s], db_user:[%s]).", db_name, db_user);
 
 	  if (shm_as_p->access_log == ON)
 	    {

--- a/src/broker/shard_proxy_io.c
+++ b/src/broker/shard_proxy_io.c
@@ -1749,8 +1749,8 @@ proxy_process_client_register (T_SOCKET_IO * sock_io_p)
 	  snprintf (err_msg, sizeof (err_msg), "Authorization error.(Address is rejected)");
 	  proxy_context_set_error_with_msg (ctx_p, DBMS_ERROR_INDICATOR, CAS_ER_NOT_AUTHORIZED_CLIENT, err_msg);
 
-	  PROXY_LOG (PROXY_LOG_MODE_ERROR, "Authentication failure. " "(db_name:[%s], db_user:[%s], db_passwd:[%s]).",
-		     db_name, db_user, db_passwd);
+	  PROXY_LOG (PROXY_LOG_MODE_ERROR, "Authorization error. (Address is rejected) " "(db_name:[%s], db_user:[%s]).",
+		     db_name, db_user);
 
 	  if (shm_as_p->access_log == ON)
 	    {
@@ -4828,8 +4828,7 @@ authorization_error:
   snprintf (err_msg, sizeof (err_msg), "Authorization error.");
   proxy_context_set_error_with_msg (ctx_p, DBMS_ERROR_INDICATOR, CAS_ER_NOT_AUTHORIZED_CLIENT, err_msg);
 
-  PROXY_LOG (PROXY_LOG_MODE_ERROR, "Authentication failure. " "(db_name:[%s], db_user:[%s], db_passwd:[%s]).", db_name,
-	     db_user, db_passwd);
+  PROXY_LOG (PROXY_LOG_MODE_ERROR, "Authentication failure. " "(db_name:[%s], db_user:[%s]).", db_name, db_user);
 
   return -1;
 }

--- a/src/broker/shard_proxy_log.c
+++ b/src/broker/shard_proxy_log.c
@@ -92,6 +92,10 @@ proxy_log_open (char *br_name, int proxy_index)
 	  make_proxy_log_filename (log_filepath, BROKER_PATH_MAX, br_name, proxy_id);
 	}
 
+#if !defined(WINDOWS)
+      mode_t old_mask = umask (0177);
+#endif /* !WINDOWS */
+
       /* note: in "a+" mode, output is always appended */
       log_fp = fopen (log_filepath, "r+");
       if (log_fp != NULL)
@@ -102,6 +106,16 @@ proxy_log_open (char *br_name, int proxy_index)
 	{
 	  log_fp = fopen (log_filepath, "w");
 	}
+
+#if !defined(WINDOWS)
+      umask (old_mask);
+
+      if (log_fp != NULL)
+	{
+	  /* make sure a pre-existing log file (created before this fix) is not left world-readable */
+	  fchmod (fileno (log_fp), 0600);
+	}
+#endif /* !WINDOWS */
     }
   else
     {

--- a/src/broker/shard_proxy_log.c
+++ b/src/broker/shard_proxy_log.c
@@ -61,6 +61,15 @@ static const char *proxy_log_level_str[] = {
   "DBG"
 };
 
+#if !defined(WINDOWS)
+static void
+proxy_log_secure_file_permission (const char *filepath)
+{
+  /* best-effort: a missing file (ENOENT) simply means there is nothing to fix yet */
+  (void) chmod (filepath, 0600);
+}
+#endif /* !WINDOWS */
+
 static char *
 make_proxy_log_filename (char *filepath_buf, size_t buf_size, const char *br_name, int proxy_index)
 {
@@ -112,8 +121,16 @@ proxy_log_open (char *br_name, int proxy_index)
 
       if (log_fp != NULL)
 	{
+	  char backup_filepath[BROKER_PATH_MAX];
+
 	  /* make sure a pre-existing log file (created before this fix) is not left world-readable */
 	  fchmod (fileno (log_fp), 0600);
+
+	  /* also fix up an already rotated backup that may still carry pre-fix, world-readable permissions */
+	  if (snprintf (backup_filepath, BROKER_PATH_MAX - 1, "%s.bak", log_filepath) > 0)
+	    {
+	      proxy_log_secure_file_permission (backup_filepath);
+	    }
 	}
 #endif /* !WINDOWS */
     }
@@ -163,6 +180,11 @@ proxy_log_backup (void)
 
   unlink (backup_filepath);
   rename (log_filepath, backup_filepath);
+
+#if !defined(WINDOWS)
+  /* rename() preserves the source file's mode; re-assert 0600 in case it was ever created insecurely */
+  proxy_log_secure_file_permission (backup_filepath);
+#endif /* !WINDOWS */
 }
 
 void

--- a/src/broker/shard_proxy_log.c
+++ b/src/broker/shard_proxy_log.c
@@ -61,15 +61,6 @@ static const char *proxy_log_level_str[] = {
   "DBG"
 };
 
-#if !defined(WINDOWS)
-static void
-proxy_log_secure_file_permission (const char *filepath)
-{
-  /* best-effort: a missing file (ENOENT) simply means there is nothing to fix yet */
-  (void) chmod (filepath, 0600);
-}
-#endif /* !WINDOWS */
-
 static char *
 make_proxy_log_filename (char *filepath_buf, size_t buf_size, const char *br_name, int proxy_index)
 {
@@ -121,16 +112,8 @@ proxy_log_open (char *br_name, int proxy_index)
 
       if (log_fp != NULL)
 	{
-	  char backup_filepath[BROKER_PATH_MAX];
-
 	  /* make sure a pre-existing log file (created before this fix) is not left world-readable */
 	  fchmod (fileno (log_fp), 0600);
-
-	  /* also fix up an already rotated backup that may still carry pre-fix, world-readable permissions */
-	  if (snprintf (backup_filepath, BROKER_PATH_MAX - 1, "%s.bak", log_filepath) > 0)
-	    {
-	      proxy_log_secure_file_permission (backup_filepath);
-	    }
 	}
 #endif /* !WINDOWS */
     }
@@ -180,11 +163,6 @@ proxy_log_backup (void)
 
   unlink (backup_filepath);
   rename (log_filepath, backup_filepath);
-
-#if !defined(WINDOWS)
-  /* rename() preserves the source file's mode; re-assert 0600 in case it was ever created insecurely */
-  proxy_log_secure_file_permission (backup_filepath);
-#endif /* !WINDOWS */
 }
 
 void

--- a/src/broker/shard_proxy_log.c
+++ b/src/broker/shard_proxy_log.c
@@ -314,7 +314,8 @@ proxy_access_log (struct timeval *start_time, int client_ip_addr, const char *db
   char *script = NULL;
   char *clt_ip;
   char *clt_appl = NULL;
-  struct tm ct1, ct2;
+  struct tm ct1 = { };
+  struct tm ct2 = { };
   time_t t1, t2;
   char *p;
   char err_str[4];

--- a/src/broker/shard_proxy_log.h
+++ b/src/broker/shard_proxy_log.h
@@ -38,6 +38,8 @@
 #else
 #include <unistd.h>
 #include <sys/time.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 #endif
 
 #include "broker_shm.h"


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27348>

### Purpose

SHARD 브로커 프록시(cub_proxy)가 클라이언트 커넥트 패킷의 {{db_passwd}}를 평문으로 읽고, 인증 실패 및 ACL 거부 시 그 값을 마스킹 없이 프록시 로그에 기록한다.
기본 로그 레벨(SHARD_PROXY_LOG=ERROR)에서 항상 기록되며, 로그 파일($CUBRID/log/broker/cubrid_broker.log) 권한은 0644(world-readable)이므로 호스트의 모든 로컬 계정이 읽을 수 있는 취약점을 수정한다.

로그출력시 암호 출력 제거 : PROXY_LOG() 수정 
로그파일 권한을 0644에서 0600으로 변경
ACL 오류 발생시 "Authentication failure" 오류 메세지가 출력되는데, 인증 실패가 아닌 접근 통제 거부로 오류 메세지를 분리 수정 ("Authorization error. (Address is rejected)")

### Implementation

shard_proxy_io.c: access_control_check_right() 오류 -> PROXY_LOG()
shard_proxy_io.c: proxy_check_authorization() 오류 -> PROXY_LOG()
shard_proxy_log.c의 proxy_log_open()에서 umask() 추가 필요

### Remarks

11.4 이하 버전에 백포트 필요
