### PR TITLE
[CBRD-27347] Resolved loaddb failure when processing collection element types exclusively in CS mode

### DIFF
--- a/src/loaddb/load_db_value_converter.cpp
+++ b/src/loaddb/load_db_value_converter.cpp
@@ -74,6 +74,8 @@ namespace cubload
   int to_db_monetary (const char *str, const size_t str_size, const attribute *attr, db_value *val);
   int to_db_varbit_from_bin_str (const char *str, const size_t str_size, const attribute *attr, db_value *val);
   int to_db_varbit_from_hex_str (const char *str, const size_t str_size, const attribute *attr, db_value *val);
+  int to_db_varbit_from_bin_str_set (const char *str, const size_t str_size, const attribute *attr, db_value *val);
+  int to_db_varbit_from_hex_str_set (const char *str, const size_t str_size, const attribute *attr, db_value *val);
   int to_db_elo_ext (const char *str, const size_t str_size, const attribute *attr, db_value *val);
   int to_db_elo_int (const char *str, const size_t str_size, const attribute *attr, db_value *val);
   int to_int_generic (const char *str, const size_t str_size, const attribute *attr, db_value *val);
@@ -118,8 +120,8 @@ namespace cubload
 	setters_[set_type][LDR_DATETIME] = &to_db_datetime;
 	setters_[set_type][LDR_DATETIMELTZ] = &to_db_datetimeltz;
 	setters_[set_type][LDR_DATETIMETZ] = &to_db_datetimetz;
-	setters_[set_type][LDR_BSTR] = &to_db_varbit_from_bin_str;
-	setters_[set_type][LDR_XSTR] = &to_db_varbit_from_hex_str;
+	setters_[set_type][LDR_BSTR] = &to_db_varbit_from_bin_str_set;
+	setters_[set_type][LDR_XSTR] = &to_db_varbit_from_hex_str_set;
 	setters_[set_type][LDR_MONETARY] = &to_db_monetary;
 	setters_[set_type][LDR_ELO_EXT] = &to_db_elo_ext;
 	setters_[set_type][LDR_ELO_INT] = &to_db_elo_int;
@@ -628,16 +630,20 @@ namespace cubload
       }
   }
 
-  int
-  to_db_varbit_from_bin_str (const char *str, const size_t str_size, const attribute *attr, db_value *val)
+  /*
+   * Build a bit string value of floating precision out of a B'..' or X'..' token.
+   * The value owns its buffer, so the caller has to release it with db_value_clear ().
+   */
+  static int
+  make_varbit_value (const char *str, const size_t str_size, bool from_hex, const attribute *attr, db_value *val)
   {
     int error_code = NO_ERROR;
-    char *bstring;
-    db_value temp;
-    std::size_t dest_size;
-    tp_domain temp_domain, *domain_ptr = NULL;
+    char *bstring = NULL;
+    std::size_t dest_size = from_hex ? (str_size + 1) / 2 : (str_size + 7) / 8;
+    int bit_length;
+    int converted;
 
-    dest_size = (str_size + 7) / 8;
+    db_make_null (val);
 
     bstring = (char *) db_private_alloc (NULL, dest_size + 1);
     if (bstring == NULL)
@@ -648,7 +654,18 @@ namespace cubload
 	return error_code;
       }
 
-    if (qstr_bit_to_bin (bstring, (int) dest_size, const_cast<char *> (str), (int) str_size) != (int) str_size)
+    if (from_hex)
+      {
+	bit_length = ((int) str_size) << 2;
+	converted = qstr_hex_to_bin (bstring, (int) dest_size, const_cast<char *> (str), (int) str_size);
+      }
+    else
+      {
+	bit_length = (int) str_size;
+	converted = qstr_bit_to_bin (bstring, (int) dest_size, const_cast<char *> (str), (int) str_size);
+      }
+
+    if (converted != (int) str_size)
       {
 	db_private_free_and_init (NULL, bstring);
 
@@ -659,14 +676,30 @@ namespace cubload
 	return error_code;
       }
 
-    error_code = db_make_varbit (&temp, TP_FLOATING_PRECISION_VALUE, bstring, (int) str_size);
+    error_code = db_make_varbit (val, TP_FLOATING_PRECISION_VALUE, bstring, bit_length);
     if (error_code != NO_ERROR)
       {
 	db_private_free_and_init (NULL, bstring);
 	return error_code;
       }
 
-    temp.need_clear = true;
+    val->need_clear = true;
+
+    return NO_ERROR;
+  }
+
+  /* Convert a bit string token into the domain of the attribute it is assigned to.  */
+  static int
+  to_db_varbit (const char *str, const size_t str_size, bool from_hex, const attribute *attr, db_value *val)
+  {
+    db_value temp;
+    tp_domain temp_domain, *domain_ptr = NULL;
+
+    int error_code = make_varbit_value (str, str_size, from_hex, attr, &temp);
+    if (error_code != NO_ERROR)
+      {
+	return error_code;
+      }
 
     const tp_domain &domain = attr->get_domain ();
     error_code = db_value_domain_init (val, domain.type->id, domain.precision, domain.scale);
@@ -682,6 +715,7 @@ namespace cubload
     if (tp_value_cast (&temp, val, domain_ptr, false) != DOMAIN_COMPATIBLE)
       {
 	db_value_clear (val);
+	db_value_clear (&temp);
 
 	error_code = ER_OBJ_DOMAIN_CONFLICT;
 	er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_code, 1, attr->get_name ());
@@ -689,76 +723,40 @@ namespace cubload
 	// TODO CBRD-22271 log LOADDB_MSG_PARSE_ERROR
 	return error_code;
       }
+
     db_value_clear (&temp);
 
-    return error_code;
+    return NO_ERROR;
+  }
+
+  int
+  to_db_varbit_from_bin_str (const char *str, const size_t str_size, const attribute *attr, db_value *val)
+  {
+    return to_db_varbit (str, str_size, false, attr, val);
   }
 
   int
   to_db_varbit_from_hex_str (const char *str, const size_t str_size, const attribute *attr, db_value *val)
   {
-    int error_code = NO_ERROR;
-    char *bstring = NULL;
-    db_value temp;
-    std::size_t dest_size;
-    tp_domain *domain_ptr, temp_domain;
+    return to_db_varbit (str, str_size, true, attr, val);
+  }
 
-    db_make_null (&temp);
+  /*
+   * Used within a collection. The attribute domain is the domain of the collection, not of the
+   * element, so it must not be used to coerce an element. The value is built with its natural type
+   * and set_add_element () coerces it into the element domain of the collection, the same way
+   * ldr_bstr_elem () / ldr_xstr_elem () of the SA loader do.
+   */
+  int
+  to_db_varbit_from_bin_str_set (const char *str, const size_t str_size, const attribute *attr, db_value *val)
+  {
+    return make_varbit_value (str, str_size, false, attr, val);
+  }
 
-    dest_size = (str_size + 1) / 2;
-
-    bstring = (char *) db_private_alloc (NULL, dest_size + 1);
-    if (bstring == NULL)
-      {
-	error_code = er_errid ();
-	assert (error_code != NO_ERROR);
-
-	return error_code;
-      }
-
-    if (qstr_hex_to_bin (bstring, (int) dest_size, const_cast<char *> (str), (int) str_size) != (int) str_size)
-      {
-	db_private_free_and_init (NULL, bstring);
-
-	error_code = ER_OBJ_DOMAIN_CONFLICT;
-	er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_code, 1, attr->get_name ());
-
-	// TODO CBRD-22271 log LOADDB_MSG_PARSE_ERROR
-	return error_code;
-      }
-
-    error_code = db_make_varbit (&temp, TP_FLOATING_PRECISION_VALUE, bstring, ((int) str_size) * 4);
-    if (error_code != NO_ERROR)
-      {
-	db_private_free_and_init (NULL, bstring);
-	return error_code;
-      }
-
-    temp.need_clear = true;
-
-    const tp_domain &domain = attr->get_domain ();
-    error_code = db_value_domain_init (val, domain.type->id, domain.precision, domain.scale);
-    if (error_code != NO_ERROR)
-      {
-	// TODO CBRD-22271 log LOADDB_MSG_PARSE_ERROR
-	db_value_clear (&temp);
-	return error_code;
-      }
-
-    domain_ptr = tp_domain_resolve_value (val, &temp_domain);
-    if (tp_value_cast (&temp, val, domain_ptr, false))
-      {
-	db_value_clear (val);
-
-	error_code = ER_OBJ_DOMAIN_CONFLICT;
-	er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_code, 1, attr->get_name ());
-
-	// TODO CBRD-22271 log LOADDB_MSG_PARSE_ERROR
-	return error_code;
-      }
-    db_value_clear (&temp);
-
-    return error_code;
+  int
+  to_db_varbit_from_hex_str_set (const char *str, const size_t str_size, const attribute *attr, db_value *val)
+  {
+    return make_varbit_value (str, str_size, true, attr, val);
   }
 
   int

--- a/src/loaddb/load_server_loader.cpp
+++ b/src/loaddb/load_server_loader.cpp
@@ -948,18 +948,12 @@ namespace cubload
     conv_func &func = get_conv_func (cons->type, attr.get_domain ().type->get_id ());
 
     error_code = func (full_mon_str_p, full_mon_str_len, &attr, &db_val);
-    if (error_code != NO_ERROR)
+    if (error_code == ER_OBJ_ATTRIBUTE_CANT_BE_NULL)
       {
+	char class_attr[DB_MAX_IDENTIFIER_LENGTH * 2];
 
-	if (error_code == ER_OBJ_ATTRIBUTE_CANT_BE_NULL)
-	  {
-	    char class_attr[DB_MAX_IDENTIFIER_LENGTH * 2];
-
-	    snprintf (class_attr, DB_MAX_IDENTIFIER_LENGTH * 2, "%s.%s", m_class_entry->get_class_name (), attr.get_name ());
-	    er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_code, 1, class_attr);
-	  }
-
-	return error_code;
+	snprintf (class_attr, DB_MAX_IDENTIFIER_LENGTH * 2, "%s.%s", m_class_entry->get_class_name (), attr.get_name ());
+	er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_code, 1, class_attr);
       }
 
     if (full_mon_str_p != full_mon_str)
@@ -1006,6 +1000,14 @@ namespace cubload
 	    er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_code, 0);
 	    break;
 
+	  case LDR_NULL:
+	    /* An element being NULL does not make the attribute NULL, so the NOT NULL constraint of the
+	     * attribute must not be checked here.
+	     * Do not use to_db_null() for elements because it checks the NOT NULL constraint.
+	     * Refer to ldr_null_elem() of the SA loader. */
+	    error_code = db_make_null (&db_val);
+	    break;
+
 	  case LDR_MONETARY:
 	    error_code = process_monetary_constant (c, attr);
 	    break;
@@ -1024,12 +1026,18 @@ namespace cubload
 
 	if (error_code != NO_ERROR)
 	  {
+	    db_value_clear (&db_val);
 	    set_free (set);
 	    return error_code;
 	  }
 
 	// add element to the set (db_val will be cloned, so it is safe to reuse same variable)
 	error_code = set_add_element (set, &db_val);
+
+	/* The element was cloned into the collection, so release whatever the conversion allocated before
+	 * the next element overwrites the slot. */
+	db_value_clear (&db_val);
+
 	if (error_code != NO_ERROR)
 	  {
 	    set_free (set);


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27347>

### Purpose

* Resolved loaddb failure when processing collection element types (e.g., SET) exclusively in CS mode

### Implementation

- 기존의 `to_db_varbit_from_bin_str()`, `to_db_varbit_from_hex_str()`는 비 컬렉션 타입의 경우에만 사용하도록 변경
- 컬렉션 타입의 내부 원소에 대한 처리는 새로운 함수를 도입해서 처리
  `to_db_varbit_from_bin_str_set ()`, `to_db_varbit_from_hex_str_set ()`
- 신규 함수와 기존 함수의 중첩을 피하기 위해 내부 함수를 이용해서 기존 코드 재배치


### Remarks
- 데이터 준비
```
csql -S -udba testdb -c "CREATE TABLE tc_bit_set      (id INT PRIMARY KEY, c SET(BIT VARYING(64)));"
csql -S -udba testdb -c "CREATE TABLE tc_null_nn (id INT PRIMARY KEY, c SET(INT) NOT NULL);"
csql -S -udba testdb -c "INSERT INTO tc_bit_set VALUES (1, {X'0a1b', X'ff'});"
csql -S -udba testdb -c "INSERT INTO tc_bit_set VALUES (2, {B'1010'});"
csql -S -udba testdb -c "INSERT INTO tc_null_nn      VALUES (1, {NULL, 1});"

cubrid unloaddb -S  -udba --datafile-per-class testdb
```

- SA 모드
```
csql -S -udba testdb -c "delete from tc_null_nn; delete from tc_bit_set;";
cubrid loaddb -S -udba -d testdb_dba.tc_null_nn_objects testdb
cubrid loaddb -S -udba -d testdb_dba.tc_bit_set_objects testdb
```

- CS 모드
```
cubrid server start testdb
csql -C -udba testdb -c "delete from tc_null_nn; delete from tc_bit_set;";
cubrid loaddb -C -udba -d testdb_dba.tc_null_nn_objects testdb
cubrid loaddb -C -udba -d testdb_dba.tc_bit_set_objects testdb
```

CS모드에서는 아래와 같은 오류가 발생했었음.
Line 2:Attribute "dba.tc_null_nn.c" cannot be made NULL.
Line 2:A domain conflict exists on attribute "c".