### PR TITLE
[CBRD-26571] Serialize count(*) PK-count optimization state under parallel UNION

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -26893,12 +26893,34 @@ qexec_evaluate_aggregates_optimize (THREAD_ENTRY * thread_p, AGGREGATE_TYPE * ag
 	      continue;
 	    }
 
+#if defined (SERVER_MODE)
+	  /* Parallel UNION branches executing this query share tdes (and therefore
+	   * log_upd_stats.classes_cos_hash / unique_stats_hash) across worker threads that adopt the
+	   * main thread's tran_index. All accesses to those per-tran hash tables below must be
+	   * serialized with the same lock logtb_get_mvcc_snapshot() uses, or concurrent mht_get()/
+	   * mht_put() calls on the shared hash can corrupt it (observed as an infinite spin) or let one
+	   * worker see COS_LOADED before another worker's statistics write becomes visible (observed as
+	   * count(*) wrongly returning -1). */
+	  THREAD_ENTRY *main_thread_p = NULL;
+	  if (thread_p->m_px_orig_thread_entry != NULL)
+	    {
+	      main_thread_p = thread_get_main_thread (thread_p);
+	      pthread_mutex_lock (&main_thread_p->m_px_lock_mutex);
+	    }
+#endif /* SERVER_MODE */
+
 	  LOG_TRAN_CLASS_COS *class_cos = logtb_tran_find_class_cos (thread_p, &ACCESS_SPEC_CLS_OID (spec),
 								     true);
 	  if (class_cos == NULL)
 	    {
 	      agg_ptr->flag.agg_optimized = false;
 	      *is_scan_needed = true;
+#if defined (SERVER_MODE)
+	      if (main_thread_p != NULL)
+		{
+		  pthread_mutex_unlock (&main_thread_p->m_px_lock_mutex);
+		}
+#endif /* SERVER_MODE */
 	      continue;
 	    }
 
@@ -26911,16 +26933,36 @@ qexec_evaluate_aggregates_optimize (THREAD_ENTRY * thread_p, AGGREGATE_TYPE * ag
 		{
 		  agg_ptr->flag.agg_optimized = false;
 		  *is_scan_needed = true;
+#if defined (SERVER_MODE)
+		  if (main_thread_p != NULL)
+		    {
+		      pthread_mutex_unlock (&main_thread_p->m_px_lock_mutex);
+		    }
+#endif /* SERVER_MODE */
 		  continue;
 		}
 
 	      if (!tdes->mvccinfo.snapshot.valid)
 		{
+#if defined (SERVER_MODE)
+		  /* logtb_get_mvcc_snapshot() takes main_thread_p->m_px_lock_mutex itself; release it
+		   * here first to avoid a self-deadlock, then reacquire before touching class_cos again. */
+		  if (main_thread_p != NULL)
+		    {
+		      pthread_mutex_unlock (&main_thread_p->m_px_lock_mutex);
+		    }
+#endif /* SERVER_MODE */
 		  if (logtb_get_mvcc_snapshot (thread_p) == NULL)
 		    {
 		      error = er_errid ();
 		      return (error == NO_ERROR ? ER_FAILED : error);
 		    }
+#if defined (SERVER_MODE)
+		  if (main_thread_p != NULL)
+		    {
+		      pthread_mutex_lock (&main_thread_p->m_px_lock_mutex);
+		    }
+#endif /* SERVER_MODE */
 		}
 
 	      /* 
@@ -26933,6 +26975,12 @@ qexec_evaluate_aggregates_optimize (THREAD_ENTRY * thread_p, AGGREGATE_TYPE * ag
 		  if (logtb_load_global_statistics_to_tran (thread_p) != NO_ERROR)
 		    {
 		      error = er_errid ();
+#if defined (SERVER_MODE)
+		      if (main_thread_p != NULL)
+			{
+			  pthread_mutex_unlock (&main_thread_p->m_px_lock_mutex);
+			}
+#endif /* SERVER_MODE */
 		      return (error == NO_ERROR ? ER_FAILED : error);
 		    }
 		}
@@ -26941,9 +26989,22 @@ qexec_evaluate_aggregates_optimize (THREAD_ENTRY * thread_p, AGGREGATE_TYPE * ag
 		{
 		  agg_ptr->flag.agg_optimized = false;
 		  *is_scan_needed = true;
+#if defined (SERVER_MODE)
+		  if (main_thread_p != NULL)
+		    {
+		      pthread_mutex_unlock (&main_thread_p->m_px_lock_mutex);
+		    }
+#endif /* SERVER_MODE */
 		  continue;
 		}
 	    }
+
+#if defined (SERVER_MODE)
+	  if (main_thread_p != NULL)
+	    {
+	      pthread_mutex_unlock (&main_thread_p->m_px_lock_mutex);
+	    }
+#endif /* SERVER_MODE */
 	}
 
       if (thread_is_on_trace (thread_p))

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -26851,6 +26851,37 @@ cleanup:
   return error;
 }
 
+/* qexec_evaluate_aggregates_optimize () serializes access to the count-optimization state
+ * (tdes->log_upd_stats.classes_cos_hash / unique_stats_hash) that parallel UNION branch
+ * worker threads share via main_thread_p->m_px_lock_mutex; QEXEC_COUNT_OPT_PX_LOCK/UNLOCK
+ * collapse the repeated "#if defined (SERVER_MODE) ... #endif" guard at each lock/unlock
+ * site down to one line. main_thread_p is only ever declared under SERVER_MODE, but that is
+ * safe here: outside SERVER_MODE these macros expand to a no-op that never mentions their
+ * argument, so it need not exist. */
+#if defined (SERVER_MODE)
+#define QEXEC_COUNT_OPT_PX_LOCK(main_thread_p) \
+  do \
+    { \
+      if ((main_thread_p) != NULL) \
+	{ \
+	  pthread_mutex_lock (&(main_thread_p)->m_px_lock_mutex); \
+	} \
+    } \
+  while (0)
+#define QEXEC_COUNT_OPT_PX_UNLOCK(main_thread_p) \
+  do \
+    { \
+      if ((main_thread_p) != NULL) \
+	{ \
+	  pthread_mutex_unlock (&(main_thread_p)->m_px_lock_mutex); \
+	} \
+    } \
+  while (0)
+#else
+#define QEXEC_COUNT_OPT_PX_LOCK(main_thread_p) ((void) 0)
+#define QEXEC_COUNT_OPT_PX_UNLOCK(main_thread_p) ((void) 0)
+#endif /* SERVER_MODE */
+
 /*
  * qexec_evaluate_aggregates_optimize () - optimize aggregate evaluation
  * return : error code or NO_ERROR
@@ -26905,9 +26936,9 @@ qexec_evaluate_aggregates_optimize (THREAD_ENTRY * thread_p, AGGREGATE_TYPE * ag
 	  if (thread_p->m_px_orig_thread_entry != NULL)
 	    {
 	      main_thread_p = thread_get_main_thread (thread_p);
-	      pthread_mutex_lock (&main_thread_p->m_px_lock_mutex);
 	    }
 #endif /* SERVER_MODE */
+	  QEXEC_COUNT_OPT_PX_LOCK (main_thread_p);
 
 	  LOG_TRAN_CLASS_COS *class_cos = logtb_tran_find_class_cos (thread_p, &ACCESS_SPEC_CLS_OID (spec),
 								     true);
@@ -26915,12 +26946,7 @@ qexec_evaluate_aggregates_optimize (THREAD_ENTRY * thread_p, AGGREGATE_TYPE * ag
 	    {
 	      agg_ptr->flag.agg_optimized = false;
 	      *is_scan_needed = true;
-#if defined (SERVER_MODE)
-	      if (main_thread_p != NULL)
-		{
-		  pthread_mutex_unlock (&main_thread_p->m_px_lock_mutex);
-		}
-#endif /* SERVER_MODE */
+	      QEXEC_COUNT_OPT_PX_UNLOCK (main_thread_p);
 	      continue;
 	    }
 
@@ -26933,36 +26959,21 @@ qexec_evaluate_aggregates_optimize (THREAD_ENTRY * thread_p, AGGREGATE_TYPE * ag
 		{
 		  agg_ptr->flag.agg_optimized = false;
 		  *is_scan_needed = true;
-#if defined (SERVER_MODE)
-		  if (main_thread_p != NULL)
-		    {
-		      pthread_mutex_unlock (&main_thread_p->m_px_lock_mutex);
-		    }
-#endif /* SERVER_MODE */
+		  QEXEC_COUNT_OPT_PX_UNLOCK (main_thread_p);
 		  continue;
 		}
 
 	      if (!tdes->mvccinfo.snapshot.valid)
 		{
-#if defined (SERVER_MODE)
 		  /* logtb_get_mvcc_snapshot() takes main_thread_p->m_px_lock_mutex itself; release it
 		   * here first to avoid a self-deadlock, then reacquire before touching class_cos again. */
-		  if (main_thread_p != NULL)
-		    {
-		      pthread_mutex_unlock (&main_thread_p->m_px_lock_mutex);
-		    }
-#endif /* SERVER_MODE */
+		  QEXEC_COUNT_OPT_PX_UNLOCK (main_thread_p);
 		  if (logtb_get_mvcc_snapshot (thread_p) == NULL)
 		    {
 		      error = er_errid ();
 		      return (error == NO_ERROR ? ER_FAILED : error);
 		    }
-#if defined (SERVER_MODE)
-		  if (main_thread_p != NULL)
-		    {
-		      pthread_mutex_lock (&main_thread_p->m_px_lock_mutex);
-		    }
-#endif /* SERVER_MODE */
+		  QEXEC_COUNT_OPT_PX_LOCK (main_thread_p);
 		}
 
 	      /* 
@@ -26975,12 +26986,7 @@ qexec_evaluate_aggregates_optimize (THREAD_ENTRY * thread_p, AGGREGATE_TYPE * ag
 		  if (logtb_load_global_statistics_to_tran (thread_p) != NO_ERROR)
 		    {
 		      error = er_errid ();
-#if defined (SERVER_MODE)
-		      if (main_thread_p != NULL)
-			{
-			  pthread_mutex_unlock (&main_thread_p->m_px_lock_mutex);
-			}
-#endif /* SERVER_MODE */
+		      QEXEC_COUNT_OPT_PX_UNLOCK (main_thread_p);
 		      return (error == NO_ERROR ? ER_FAILED : error);
 		    }
 		}
@@ -26989,22 +26995,12 @@ qexec_evaluate_aggregates_optimize (THREAD_ENTRY * thread_p, AGGREGATE_TYPE * ag
 		{
 		  agg_ptr->flag.agg_optimized = false;
 		  *is_scan_needed = true;
-#if defined (SERVER_MODE)
-		  if (main_thread_p != NULL)
-		    {
-		      pthread_mutex_unlock (&main_thread_p->m_px_lock_mutex);
-		    }
-#endif /* SERVER_MODE */
+		  QEXEC_COUNT_OPT_PX_UNLOCK (main_thread_p);
 		  continue;
 		}
 	    }
 
-#if defined (SERVER_MODE)
-	  if (main_thread_p != NULL)
-	    {
-	      pthread_mutex_unlock (&main_thread_p->m_px_lock_mutex);
-	    }
-#endif /* SERVER_MODE */
+	  QEXEC_COUNT_OPT_PX_UNLOCK (main_thread_p);
 	}
 
       if (thread_is_on_trace (thread_p))


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26571>

### Purpose

qexec_evaluate_aggregates_optimize() 함수는 tdes에서 log_upd_stats.classes_cos_hash 및 unique_stats_hash 값을 읽고 씁니다(logtb_tran_find_class_cos(), logtb_tran_find_btid_stats() 및 CBRD-26571 문제 해결을 위해 추가된 logtb_load_global_statistics_to_tran() 재시도 호출을 통해). 이 과정에서 락을 사용하지 않습니다.
병렬 UNION 분기 작업자 스레드는 동일한 tdes를 공유하므로(메인 스레드의 tran_index를 사용함) 두 분기가 이러한 보호되지 않은 경로를 동시에 호출할 수 있습니다.

logtb_get_mvcc_snapshot() 함수는 이미 main_thread_p->m_px_lock_mutex를 사용하여 자체 호출을 logtb_load_global_statistics_to_tran() 함수(build_mvcc_info()를 통해)로 직렬화하지만, CBRD-26571 재시도 경로는 스냅샷이 이미 유효한 경우(두 번째 이후 UNION 분기에서 흔히 발생하는 경우) 해당 잠금을 우회합니다.
이는 CTP 검증 중에 두 가지 간헐적인 증상을 유발하는 것으로 확인되었습니다. 하나는 무한 CPU 스핀(두 워커가 동일한 잠금 해제된 해시를 놓고 경쟁하는 현상으로, pstack을 통해 확인됨)이고, 다른 하나는 count(*) 함수가 간헐적으로 -1을 반환하는 현상(한 워커가 다른 워커의 통계 쓰기가 표시되기 전에 COS_LOADED를 관찰하는 경우)입니다.

### Implementation

qexec_evaluate_aggregates_optimize() 함수 내의 count_state 확인/재시도 블록 전체에 대해 main_thread_p->m_px_lock_mutex를 사용하고, logtb_get_mvcc_snapshot() 함수 호출 시에만 해당 뮤텍스를 해제하고 다시 획득하여 자체 교착 상태를 방지 (이 함수 자체도 동일한 비재귀적 뮤텍스를 사용)

### Remarks

11.4 이하 버전에 백포트 필요 없음 (11.4에는 병렬처리 없음)