### PR TITLE
[CBRD-27354] Do not free the scan cache's buffer on the error path of catcls_update_class_stats

### DIFF
--- a/src/storage/catalog_class.c
+++ b/src/storage/catalog_class.c
@@ -4463,7 +4463,10 @@ catcls_update_class_stats (THREAD_ENTRY * thread_p, const char *class_name, unsi
   bool is_scan_inited = false;
   int old_chn;
   OR_VALUE *value_p = NULL;
-  RECDES record = RECDES_INITIALIZER;
+  /* Read into old_record and write from record, as catcls_update_instance () does: old_record.data belongs to the
+   * scan cache, record.data is this function's malloc. Reusing one RECDES for both let the error label free a
+   * scan-cache-owned buffer when the read succeeded but the parse below did not. */
+  RECDES record = RECDES_INITIALIZER, old_record = RECDES_INITIALIZER;
   HEAP_OPERATION_CONTEXT update_context;
 
   error = catcls_find_oid_by_class_name (thread_p, class_name, &oid);
@@ -4487,14 +4490,14 @@ catcls_update_class_stats (THREAD_ENTRY * thread_p, const char *class_name, unsi
 
   is_scan_inited = true;
 
-  if (heap_get_visible_version (thread_p, &oid, catalog_class_oid_p, &record, &scan, COPY, NULL_CHN) != S_SUCCESS)
+  if (heap_get_visible_version (thread_p, &oid, catalog_class_oid_p, &old_record, &scan, COPY, NULL_CHN) != S_SUCCESS)
     {
       ASSERT_ERROR_AND_SET (error);
       goto error;
     }
 
-  old_chn = or_chn (&record);
-  value_p = catcls_get_or_value_from_record (thread_p, &record, catalog_class_oid_p);
+  old_chn = or_chn (&old_record);
+  value_p = catcls_get_or_value_from_record (thread_p, &old_record, catalog_class_oid_p);
   if (value_p == NULL)
     {
       ASSERT_ERROR_AND_SET (error);


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27354>

### Purpose

`catcls_update_class_stats()`가 에러 경로에서 **자기가 malloc 하지 않은 버퍼를 free** 해 서버가 glibc `munmap_chunk(): invalid pointer` 로 abort 하는 것을 고칩니다.

### Implementation

이 함수는 카탈로그 행을 읽는 일과 교체할 행을 만드는 일에 RECDES 하나를 돌려 썼습니다. `heap_get_visible_version (..., COPY)` 는 `record.data` 를 **스캔캐시 소유 버퍼**로 채우고, 그 아래 `malloc()` 에 도달해야 비로소 그 버퍼가 이 함수 소유가 됩니다. 그 사이에서 실패하면 — 관측된 것은 `catcls_get_or_value_from_record()` 가 `ER_INTERRUPTED` 로 NULL 을 반환한 경우 — error 레이블이 스캔캐시 버퍼를 `free_and_init()` 합니다.

같은 파일의 `catcls_update_instance()` 는 읽기용 `old_record` 와 쓰기용 `record` 를 따로 두어 이 문제가 없습니다. 동일한 형태로 맞췄습니다 — 읽기는 `old_record` 로, 쓰기는 `record` 로. error 레이블은 그대로 두었고, 이제 `record.data` 는 이 함수의 `malloc` 산물뿐입니다.

### Remarks

- 관측: PR #7658 CI test_shell (11.5.0.2532-0e85118 optdebug), `bug_bts_14565` 실행 중. 코어의 gdb 로컬 변수가 진단을 확정해 줍니다.

  ```
  #9 catcls_update_class_stats (...) at catalog_class.c:4541
       error = -4 (ER_INTERRUPTED), value_p = 0x0
       record = {area_size = 32688, length = 560, data = 0x563664f8c3a8}
  #8~#5 munmap_chunk () -> malloc_printerr () -> abort ()
  ```

  `area_size 32688` 과 `length 560` 이 다릅니다. 이 함수가 잡은 버퍼라면 둘이 같아야 합니다(`record.area_size = record.length` 로 함께 설정하므로) — 그 시점 버퍼가 이 함수 것이 아니었다는 증거입니다.
- 트리거는 인터럽트 타이밍 레이스입니다: 한 세션이 `UPDATE STATISTICS ON ALL CLASSES` 를 도는 동안 다른 세션의 DDL 이 그 트랜잭션을 인터럽트합니다. 발화는 드물지만 조건이 맞으면 결정적으로 abort 합니다.
- 결과·동작 변화는 없습니다. 정상 경로는 손대지 않았고 에러 경로의 소유권만 바로잡았습니다.
- 로컬 검증: 코드 스타일 검사 통과, `catalog_class.c` 단일 파일 컴파일 통과. 서버 기동 검증은 CI 에 맡깁니다.
