### PR TITLE
[CBRD-27183] [CBRD-27355] Thread-scoped no-wait latch probes, and an error for zero-wait latch timeouts

### DIFF
--- a/src/storage/bestspace.cpp
+++ b/src/storage/bestspace.cpp
@@ -677,9 +677,12 @@ namespace cubstorage
     int error_code;
 
     thread_p = thread_get_thread_entry_info ();
-    wait_msecs = xlogtb_reset_wait_msecs (thread_p, LK_FORCE_ZERO_WAIT);
+    /* thread-scoped no-wait override: never mutate the transaction-global tdes->wait_msecs here; it is shared with
+     * sibling threads of the same transaction (parallel query workers), whose unconditional page fixes would be
+     * silently converted to conditional ones during the probe window. */
+    wait_msecs = logtb_set_thread_wait_msecs_override (thread_p, LK_FORCE_ZERO_WAIT);
     error_code = pgbuf_ordered_fix (thread_p, &vpid, OLD_PAGE_MAYBE_DEALLOCATED, PGBUF_LATCH_WRITE, &page_watcher);
-    (void) xlogtb_reset_wait_msecs (thread_p, wait_msecs);
+    (void) logtb_set_thread_wait_msecs_override (thread_p, wait_msecs);
     if (error_code != NO_ERROR)
       {
 	if (error_code == ER_LK_PAGE_TIMEOUT)

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -21726,13 +21726,15 @@ btree_set_error (THREAD_ENTRY * thread_p, const DB_VALUE * key, const OID * obj_
       /* We don't provide classname for VACUUM operations, since it may prevent other vacuums from fixing a page. */
       if (!VACUUM_IS_THREAD_VACUUM (thread_p))
 	{
-	  save_old_wait = xlogtb_reset_wait_msecs (thread_p, LK_FORCE_ZERO_WAIT);
+	  /* thread-scoped override: the transaction-global tdes->wait_msecs is shared with sibling threads of the
+	   * same transaction (parallel query workers) and must not be toggled from here. */
+	  save_old_wait = logtb_set_thread_wait_msecs_override (thread_p, LK_FORCE_ZERO_WAIT);
 	  if (heap_get_class_name (thread_p, class_oid, &class_name) != NO_ERROR)
 	    {
 	      /* ignore */
 	      er_clear ();
 	    }
-	  (void) xlogtb_reset_wait_msecs (thread_p, save_old_wait);
+	  (void) logtb_set_thread_wait_msecs_override (thread_p, save_old_wait);
 	}
     }
 

--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -7443,7 +7443,7 @@ xbtree_load_online_index (THREAD_ENTRY * thread_p, BTID * btid, const char *bt_n
   // We are going to do best to avoid lock promotion errors such as timeout and deadlocked.
 
   // never give up
-  old_wait_msec = xlogtb_reset_wait_msecs (thread_p, LK_INFINITE_WAIT);
+  old_wait_msec = logtb_set_thread_wait_msecs_override (thread_p, LK_INFINITE_WAIT);
   old_check_intr = logtb_set_check_interrupt (thread_p, false);
 
   /* The retry loop below consumes and clears its own errors (interrupted waits,
@@ -7492,7 +7492,7 @@ xbtree_load_online_index (THREAD_ENTRY * thread_p, BTID * btid, const char *bt_n
   er_stack_pop ();
 
   // reset back
-  (void) xlogtb_reset_wait_msecs (thread_p, old_wait_msec);
+  (void) logtb_set_thread_wait_msecs_override (thread_p, old_wait_msec);
   (void) logtb_set_check_interrupt (thread_p, old_check_intr);
 
   if (ret != NO_ERROR)

--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -4191,7 +4191,12 @@ disk_is_page_sector_reserved_with_debug_crash (THREAD_ENTRY * thread_p, VOLID vo
   int old_wait_msecs;
 
   old_check_interrupt = logtb_set_check_interrupt (thread_p, false);
-  old_wait_msecs = xlogtb_reset_wait_msecs (thread_p, LK_INFINITE_WAIT);
+  /* Thread-scoped, not tdes->wait_msecs: this runs nested inside the no-wait latch probes (bestspace L1_fix,
+   * btree_set_error) through pgbuf_fix's page validation, and those probes hold a thread-scoped LK_FORCE_ZERO_WAIT
+   * override that takes precedence over the TDES value. Writing LK_INFINITE_WAIT into the TDES would be shadowed, the
+   * volume-header fix below would be demoted to a conditional latch, and its failure asserts. Use the same override so
+   * the innermost (this) scope wins. */
+  old_wait_msecs = logtb_set_thread_wait_msecs_override (thread_p, LK_INFINITE_WAIT);
 
   if (fileio_get_volume_descriptor (volid) == NULL_VOLDES || pageid < 0)
     {
@@ -4231,7 +4236,7 @@ disk_is_page_sector_reserved_with_debug_crash (THREAD_ENTRY * thread_p, VOLID vo
   isvalid = disk_is_sector_reserved (thread_p, volheader, sectid, debug_crash);
 
 exit:
-  xlogtb_reset_wait_msecs (thread_p, old_wait_msecs);
+  (void) logtb_set_thread_wait_msecs_override (thread_p, old_wait_msecs);
   (void) logtb_set_check_interrupt (thread_p, old_check_interrupt);
 
   if (page_volheader)

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -8744,7 +8744,7 @@ heap_does_exist (THREAD_ENTRY * thread_p, OID * class_oid, const OID * oid)
   PGBUF_INIT_WATCHER (&pg_watcher, PGBUF_ORDERED_HEAP_NORMAL, PGBUF_ORDERED_NULL_HFID);
 
   old_check_interrupt = logtb_set_check_interrupt (thread_p, false);
-  old_wait_msec = xlogtb_reset_wait_msecs (thread_p, LK_INFINITE_WAIT);
+  old_wait_msec = logtb_set_thread_wait_msecs_override (thread_p, LK_INFINITE_WAIT);
 
   if (HEAP_ISVALID_OID (thread_p, oid) != DISK_VALID)
     {
@@ -8851,7 +8851,7 @@ exit_on_end:
     }
 
   (void) logtb_set_check_interrupt (thread_p, old_check_interrupt);
-  (void) xlogtb_reset_wait_msecs (thread_p, old_wait_msec);
+  (void) logtb_set_thread_wait_msecs_override (thread_p, old_wait_msec);
 
   return doesexist;
 }

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -6462,7 +6462,7 @@ pgbuf_latch_bcb_upon_fix (THREAD_ENTRY * thread_p, PGBUF_BCB * bufptr, PGBUF_LAT
       int wait_msec;
 
       tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
-      wait_msec = logtb_find_wait_msecs (tran_index);
+      wait_msec = logtb_find_current_wait_msecs (thread_p);
 
       if (wait_msec == LK_ZERO_WAIT)
 	{
@@ -16837,30 +16837,18 @@ pgbuf_lru_sanity_check (const PGBUF_LRU_LIST * lru)
 #endif /* !NDEBUG */
 }
 
-// TODO: find a better place for this, but not log_impl.h
 /*
  * pgbuf_find_current_wait_msecs - find waiting times for current transaction
  *
  * return : wait_msecs...
  *
- * Note: Find the waiting time for the current transaction.
+ * Note: Find the waiting time for the current thread; honors the thread-scoped override used by
+ *       no-wait latch probes (see logtb_set_thread_wait_msecs_override).
  */
 STATIC_INLINE int
 pgbuf_find_current_wait_msecs (THREAD_ENTRY * thread_p)
 {
-  LOG_TDES *tdes;		/* Transaction descriptor */
-  int tran_index;
-
-  tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
-  tdes = LOG_FIND_TDES (tran_index);
-  if (tdes != NULL)
-    {
-      return tdes->wait_msecs;
-    }
-  else
-    {
-      return 0;
-    }
+  return logtb_find_current_wait_msecs (thread_p);
 }
 
 /*

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -7338,7 +7338,27 @@ er_set_return:
     }
   else
     {
+      /* Zero wait: LK_ZERO_WAIT or LK_FORCE_ZERO_WAIT -- from the transaction, or from the thread-scoped override
+       * the no-wait latch probes use after the previous commit -- and the 0 that
+       * logtb_find_current_wait_msecs () returns when the thread has no transaction descriptor. The timeout is the
+       * expected outcome in all three cases, but an error still has to be
+       * set: this ER_FAILED travels up through pgbuf_block_bcb () and pgbuf_latch_bcb_upon_fix (), neither of which
+       * sets one, and comes out of pgbuf_fix () as a plain NULL. Callers then run ASSERT_ERROR_AND_SET () and assert
+       * on er_errid () != NO_ERROR -- which is how a page latch timeout aborted the server inside
+       * btree_split_node_and_advance (). Same reasoning as the interrupt path in pgbuf_block_bcb ().
+       *
+       * ER_LK_PAGE_TIMEOUT, the same error the zero-wait rejection in pgbuf_latch_bcb_upon_fix () sets and the one
+       * er_errid () ends up with in the wait_msecs > 0 branch above: callers that treat latch contention as benign
+       * test for exactly this code (bestspace.cpp's contended path clears it and retries), so a different code would
+       * turn a retryable contention into a hard failure. */
       PGBUF_BCB_UNLOCK (bufptr);
+
+      (void) logtb_find_client_name_host_pid (thread_p->tran_index, &client_prog_name, &client_user_name,
+					      &client_host_name, &client_pid);
+
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_LK_PAGE_TIMEOUT, 8, thread_p->tran_index, client_user_name,
+	      client_host_name, client_pid, (save_request_latch_mode == PGBUF_LATCH_READ ? "READ" : "WRITE"),
+	      bufptr->vpid.volid, bufptr->vpid.pageid, NULL);
     }
 
   return ER_FAILED;

--- a/src/thread/thread_entry.cpp
+++ b/src/thread/thread_entry.cpp
@@ -87,6 +87,7 @@ namespace cubthread
     , emulate_tid ()
     , client_id (-1)
     , tran_index (NULL_TRAN_INDEX)
+    , wait_msecs_override (THREAD_WAIT_MSECS_NO_OVERRIDE)
     , private_lru_index (-1)
     , tran_index_lock ()
     , rid (0)

--- a/src/thread/thread_entry.hpp
+++ b/src/thread/thread_entry.hpp
@@ -36,6 +36,10 @@
 #include <thread>
 
 #include <cassert>
+#include <climits>
+
+/* sentinel for cubthread::entry::wait_msecs_override meaning "no override is active" */
+#define THREAD_WAIT_MSECS_NO_OVERRIDE INT_MIN
 
 // forward definitions
 
@@ -226,6 +230,11 @@ namespace cubthread
 				   * thread */
       int client_id;		/* client id whom this thread is responding */
       int tran_index;		/* tran index to which this thread belongs */
+      int wait_msecs_override;	/* thread-scoped override of the transaction's lock/latch wait interval
+				 * (tdes->wait_msecs). Used by short no-wait latch probes so they never mutate the
+				 * transaction-global value, which is shared with sibling threads executing on behalf
+				 * of the same transaction (parallel query workers). THREAD_WAIT_MSECS_NO_OVERRIDE
+				 * when no override is active. */
       int private_lru_index;	/* private lru index when transaction quota is used */
       pthread_mutex_t tran_index_lock;
       unsigned int rid;		/* request id which this thread is processing */

--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -6337,7 +6337,7 @@ lock_object (THREAD_ENTRY * thread_p, const OID * oid, const OID * class_oid, LO
     }
   else
     {
-      wait_msecs = logtb_find_wait_msecs (tran_index);
+      wait_msecs = logtb_find_current_wait_msecs (thread_p);
     }
 
   /* check if the given oid is root class oid */
@@ -6496,7 +6496,7 @@ lock_transaction_mvccid (THREAD_ENTRY * thread_p, MVCCID mvccid, LOCK lock, int 
     }
   else
     {
-      wait_msecs = logtb_find_wait_msecs (tran_index);
+      wait_msecs = logtb_find_current_wait_msecs (thread_p);
     }
 
   /* A TRANSACTION-typed key (keyed by the inserter's MVCCID) never aliases a real class/instance. */
@@ -6718,7 +6718,7 @@ lock_subclass (THREAD_ENTRY * thread_p, const OID * subclass_oid, const OID * su
     }
   else
     {
-      wait_msecs = logtb_find_wait_msecs (tran_index);
+      wait_msecs = logtb_find_current_wait_msecs (thread_p);
     }
 
   /* get the intentional lock mode to be acquired on class oid */
@@ -6858,7 +6858,7 @@ lock_scan (THREAD_ENTRY * thread_p, const OID * class_oid, int cond_flag, LOCK c
   else
     {
       assert (cond_flag == LK_UNCOND_LOCK);
-      wait_msecs = logtb_find_wait_msecs (tran_index);
+      wait_msecs = logtb_find_current_wait_msecs (thread_p);
     }
 
   /* acquire the lock on the class */
@@ -6952,7 +6952,7 @@ lock_classes_lock_hint (THREAD_ENTRY * thread_p, LC_LOCKHINT * lockhint)
 #endif
 
   tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
-  wait_msecs = logtb_find_wait_msecs (tran_index);
+  wait_msecs = logtb_find_current_wait_msecs (thread_p);
 
   /* We do not want to rollback the transaction in the event of a deadlock. For now, let's just wait a long time. If
    * deadlock, the transaction is going to be notified of lock timeout instead of aborted. */
@@ -9025,8 +9025,9 @@ xlock_dump (THREAD_ENTRY * thread_p, FILE * outfp, int is_contention)
   fprintf (outfp, msgcat_message (MSGCAT_CATALOG_CUBRID, MSGCAT_SET_LOCK, MSGCAT_LK_DUMP_LOCK_TABLE),
 	   prm_get_integer_value (PRM_ID_LK_ESCALATION_AT), prm_get_float_value (PRM_ID_LK_RUN_DEADLOCK_INTERVAL));
 
-  /* Don't get block from anything when dumping object lock table. */
-  old_wait_msecs = xlogtb_reset_wait_msecs (thread_p, LK_FORCE_ZERO_WAIT);
+  /* Don't get block from anything when dumping object lock table. Use the thread-scoped override so the
+   * transaction-global tdes->wait_msecs, shared with sibling threads of the same transaction, is untouched. */
+  old_wait_msecs = logtb_set_thread_wait_msecs_override (thread_p, LK_FORCE_ZERO_WAIT);
 
   /* Dump some information about all transactions */
   fprintf (outfp, "%s", msgcat_message (MSGCAT_CATALOG_CUBRID, MSGCAT_SET_LOCK, MSGCAT_LK_NEWLINE));
@@ -9108,7 +9109,7 @@ xlock_dump (THREAD_ENTRY * thread_p, FILE * outfp, int is_contention)
     }
 
   /* Reset the wait back to the way it was */
-  (void) xlogtb_reset_wait_msecs (thread_p, old_wait_msecs);
+  (void) logtb_set_thread_wait_msecs_override (thread_p, old_wait_msecs);
 #endif /* !SERVER_MODE */
 }
 
@@ -10299,7 +10300,7 @@ lock_rep_read_tran (THREAD_ENTRY * thread_p, LOCK lock, int cond_flag)
     }
   else
     {
-      wait_msecs = logtb_find_wait_msecs (tran_index);
+      wait_msecs = logtb_find_current_wait_msecs (thread_p);
     }
 
   if (lock_internal_perform_lock_object

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -1140,6 +1140,8 @@ extern const char *logtb_find_current_client_hostname (THREAD_ENTRY * thread_p);
 extern LOG_LSA *logtb_find_current_tran_lsa (THREAD_ENTRY * thread_p);
 extern TRAN_STATE logtb_find_state (int tran_index);
 extern int logtb_find_wait_msecs (int tran_index);
+extern int logtb_find_current_wait_msecs (THREAD_ENTRY * thread_p);
+extern int logtb_set_thread_wait_msecs_override (THREAD_ENTRY * thread_p, int wait_msecs);
 
 extern int logtb_find_interrupt (int tran_index, bool * interrupt);
 extern TRAN_ISOLATION logtb_find_isolation (int tran_index);

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -7745,7 +7745,7 @@ log_rollback (THREAD_ENTRY * thread_p, LOG_TDES * tdes, const LOG_LSA * upto_lsa
    * end up with database corruption problems. That is, no timeouts during
    * rollback.
    */
-  old_wait_msecs = xlogtb_reset_wait_msecs (thread_p, TRAN_LOCK_INFINITE_WAIT);
+  old_wait_msecs = logtb_set_thread_wait_msecs_override (thread_p, TRAN_LOCK_INFINITE_WAIT);
 
   LSA_COPY (&prev_tranlsa, &tdes->undo_nxlsa);
   /*
@@ -7782,7 +7782,7 @@ log_rollback (THREAD_ENTRY * thread_p, LOG_TDES * tdes, const LOG_LSA * upto_lsa
 
       if ((logpb_fetch_page (thread_p, &log_lsa, LOG_CS_FORCE_USE, log_pgptr)) != NO_ERROR)
 	{
-	  (void) xlogtb_reset_wait_msecs (thread_p, old_wait_msecs);
+	  (void) logtb_set_thread_wait_msecs_override (thread_p, old_wait_msecs);
 	  logpb_fatal_error (thread_p, true, ARG_FILE_LINE, "log_rollback");
 	  if (log_unzip_ptr != NULL)
 	    {
@@ -8038,7 +8038,7 @@ log_rollback (THREAD_ENTRY * thread_p, LOG_TDES * tdes, const LOG_LSA * upto_lsa
 
   /* Remember the undo next lsa for partial rollbacks */
   LSA_COPY (&tdes->undo_nxlsa, &prev_tranlsa);
-  (void) xlogtb_reset_wait_msecs (thread_p, old_wait_msecs);
+  (void) logtb_set_thread_wait_msecs_override (thread_p, old_wait_msecs);
 
   if (log_unzip_ptr != NULL)
     {

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -2598,6 +2598,79 @@ logtb_find_wait_msecs (int tran_index)
 }
 
 /*
+ * logtb_find_current_wait_msecs - find waiting times for current transaction, honoring the
+ *                  thread-scoped override
+ *
+ * return: wait_msecs...
+ *
+ * Note: Returns the thread-scoped override set by logtb_set_thread_wait_msecs_override () if one
+ *       is active; otherwise falls back to the transaction descriptor's wait_msecs. Use this
+ *       (instead of logtb_find_wait_msecs) wherever the wait interval of the *requesting thread*
+ *       is wanted, so that short no-wait latch probes do not have to mutate the transaction-global
+ *       value shared with sibling threads of the same transaction.
+ */
+int
+logtb_find_current_wait_msecs (THREAD_ENTRY * thread_p)
+{
+  LOG_TDES *tdes;		/* Transaction descriptor */
+  int tran_index;
+
+  if (thread_p == NULL)
+    {
+      thread_p = thread_get_thread_entry_info ();
+    }
+
+  if (thread_p->wait_msecs_override != THREAD_WAIT_MSECS_NO_OVERRIDE)
+    {
+      return thread_p->wait_msecs_override;
+    }
+
+  tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
+  tdes = LOG_FIND_TDES (tran_index);
+  if (tdes != NULL)
+    {
+      return tdes->wait_msecs;
+    }
+  else
+    {
+      return 0;
+    }
+}
+
+/*
+ * logtb_set_thread_wait_msecs_override - set or clear the thread-scoped override of the current
+ *                  transaction's wait_msecs
+ *
+ * return: the previous override (THREAD_WAIT_MSECS_NO_OVERRIDE if none was active)
+ *
+ *   wait_msecs(in): wait interval to enforce for this thread only, or
+ *                   THREAD_WAIT_MSECS_NO_OVERRIDE to clear the override
+ *
+ * Note: Unlike xlogtb_reset_wait_msecs, this does not touch the transaction descriptor, which is
+ *       shared by every thread executing on behalf of the same transaction (parallel query
+ *       workers). Mutating the shared value from a latch probe opens a window where a sibling
+ *       thread's unconditional page fix is silently converted to a conditional one and fails
+ *       without setting an error, and two interleaved save/restore pairs can leave the whole
+ *       transaction stuck in no-wait mode. Callers must restore the returned value when the
+ *       probe is done.
+ */
+int
+logtb_set_thread_wait_msecs_override (THREAD_ENTRY * thread_p, int wait_msecs)
+{
+  int old_wait_msecs;
+
+  if (thread_p == NULL)
+    {
+      thread_p = thread_get_thread_entry_info ();
+    }
+
+  old_wait_msecs = thread_p->wait_msecs_override;
+  thread_p->wait_msecs_override = wait_msecs;
+
+  return old_wait_msecs;
+}
+
+/*
  * logtb_find_interrupt -
  *
  * return :


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27183>
<http://jira.cubrid.org/browse/CBRD-27355>

### Purpose

**페이지 래치 타임아웃 하나가 서버 abort 로 이어지는** 경로를 두 층에서 끊습니다.

| 커밋 | 이슈 | 무엇을 고치나 |
|---|---|---|
| `b0f2f3c78` | CBRD-27183 | **원인** — no-wait 래치 프로브가 트랜잭션 전역 `tdes->wait_msecs` 를 토글해, 같은 트랜잭션의 형제 스레드가 그 창에 걸리면 무조건 fix 가 조용히 조건부로 강등된다 |
| `3c58abb63` | CBRD-27355 | **계약** — zero-wait 래치 타임아웃이 **에러를 설정하지 않고** 실패해, 호출자의 `ASSERT_ERROR_AND_SET()` 이 `assert (er_errid () != NO_ERROR)` 로 죽는다 |

두 층이 필요한 이유는 아래 "왜 한 PR 인가" 에 적었습니다.

### Implementation

**1. 트랜잭션 전역 no-wait 프로브 → 스레드 스코프 override (CBRD-27183)**

`bestspace L1_fix`, `btree_set_error`, `xlock_dump` 의 no-wait 페이지 래치 프로브가
`xlogtb_reset_wait_msecs (thread_p, LK_FORCE_ZERO_WAIT)` 로 `tdes->wait_msecs` 를 토글했습니다. 이 값은
**트랜잭션 전역**이라 같은 트랜잭션의 병렬 질의 워커와 공유됩니다. 프로브 창 동안 형제 스레드의 무조건
페이지 fix 가 조용히 조건부로 바뀌어 에러 없이 실패할 수 있고, 두 스레드의 save/restore 가 엇갈리면
트랜잭션이 no-wait 모드에 영구히 갇힐 수도 있습니다.

`THREAD_ENTRY` 스코프 override(`logtb_set_thread_wait_msecs_override`)를 도입하고
`logtb_find_current_wait_msecs()` 가 이를 우선 반영하도록 했습니다. pgbuf fix 경로와 락 매니저가 그 값을
읽습니다. `pgbuf_find_current_wait_msecs()` 는 얇은 위임으로 남습니다.

**연산 스코프의 "여기서는 절대 타임아웃하지 말 것" 강제 4곳도 같은 override 로 옮겼습니다** —
`disk_is_page_sector_reserved_with_debug_crash()`, `heap_does_exist()`, `log_rollback()`, 온라인 인덱스
빌더의 락 복구(`btree_load.c`). 이들은 `LK_INFINITE_WAIT` 를 TDES 에 쓰고 있었습니다. 프로브만 스레드
override 로 가고 이들이 TDES 에 남으면 **스코프가 뒤집힙니다** — 조회가 override 를 먼저 보므로, 프로브
창 안에 중첩된 무한대기 강제가 프로브의 `LK_FORCE_ZERO_WAIT` 에 가려집니다. 수정 전에는 둘이 같은 변수를
써서 안쪽(무한대기)이 이겼습니다.

이 뒤집힘은 debug 빌드에서 즉시 드러났습니다(1차 CI test_shell 에서 **35케이스가 한 서명으로 코어**):

```
INSERT → heap_find_bestpage → bestspace::L1_fix            ← override = LK_FORCE_ZERO_WAIT
  → pgbuf_ordered_fix → pgbuf_fix_debug → [page_validation_level 기본 FETCH (!NDEBUG)]
    → disk_is_page_sector_reserved_with_debug_crash          ← TDES 에 LK_INFINITE_WAIT (가려짐)
      → disk_get_volheader → pgbuf_fix (UNCONDITIONAL)       ← override −2 로 조건부 강등
        → 볼륨헤더가 경쟁 중이면(동시 삽입의 파일 확장) 에러 없이 NULL
          → disk_manager.c:3235 ASSERT_ERROR_AND_SET → abort
```

로컬에서 **8세션 동시 삽입으로 2회 연속 재현**했습니다(debug 빌드, cub_master 의 server monitor 가 서버를
두 번 되살린 기록). 네 곳을 override 로 옮기면 한 스레드 변수 위의 LIFO 중첩이 복원돼 안쪽 스코프가 다시
이깁니다. release 빌드는 페이지 검증이 꺼져 있어 이 경로를 밟지 않지만, 다른 세 곳도 프로브 창 안에서
호출될 수 있는 이상 같은 뒤집힘의 대상이므로 함께 옮겼습니다.

**2. zero-wait 래치 타임아웃에 에러 설정 (CBRD-27355)**

`pgbuf_timed_sleep()` 의 `er_set_return` 블록은 세 갈래인데 마지막이 비어 있었습니다.

```c
if (old_wait_msecs == LK_INFINITE_WAIT)   { er_set (... ER_PAGE_LATCH_TIMEDOUT ...); assert (0); ... }
else if (old_wait_msecs > 0)              { er_set (... ER_PAGE_LATCH_TIMEDOUT ...); ... er_set (... ER_LK_PAGE_TIMEOUT ...); }
else                                      { PGBUF_BCB_UNLOCK (bufptr); }   /* 에러 미설정 */
return ER_FAILED;
```

전달 경로에 이를 메우는 곳이 없습니다.

```
pgbuf_timed_sleep          else 분기      → ER_FAILED (er_errid == NO_ERROR)
pgbuf_block_bcb            :7054          → ER_FAILED (er_set 없음)
pgbuf_latch_bcb_upon_fix   :6499          → ER_FAILED (er_set 없음)
pgbuf_fix_debug            :2411          → NULL      (er_set 없음)
호출자                      ASSERT_ERROR_AND_SET → assert 실패 → abort
```

`ER_LK_PAGE_TIMEOUT` 을 설정합니다 — `pgbuf_latch_bcb_upon_fix()` 의 zero-wait 거부 경로가 설정하는 것과
같고, 바로 위 `> 0` 분기도 마지막에 이 코드로 끝나 `er_errid()` 가 그 값이 됩니다. **래치 경쟁을
양성으로 처리하는 호출자가 이 코드를 특정해 검사**하기 때문입니다:

```c
/* bestspace.cpp */
if (error_code == ER_LK_PAGE_TIMEOUT) { er_clear (); return status::CONTENDED; }   /* 경쟁 → 재시도 */
...
if (er_errid () == NO_ERROR) { er_set (..., ER_FAILED, 0); }                        /* 에러 없는 실패를 이미 알고 있던 흔적 */
```

다른 코드를 넣으면 재시도 가능한 경쟁이 하드 실패로 바뀝니다.

### 왜 한 PR 인가

`452f92e36` 은 **zero-wait 창에 들어가는 한 가지 경로**를 없애지만, 타임아웃이 실제로 났을 때의 동작은
바꾸지 않습니다(그 커밋에 `er_set` 변경은 없습니다). zero-wait 는 그 뒤에도 남습니다 — 세션이
`lock_timeout=0`(`LK_ZERO_WAIT`)으로 도는 경우, 스레드가 **자기** 프로브 창에서 fix 하는 경우, 그리고
`logtb_find_current_wait_msecs()` 가 tdes 없음으로 0 을 반환하는 경우입니다. 그 상태에서 무조건 fix 가
타임아웃하면 여전히 에러 없는 NULL 이 올라가 abort 합니다. 반대로 계약만 고치면 abort 는 사라지지만
형제 스레드가 조용히 강등되는 레이스는 남습니다. **원인과 계약을 함께 닫아야 이 부류가 끝납니다.**

### Remarks

- 관측: PR #7658 CI test_sql (11.5.0.2532-0e85118, optdebug, CircleCI 150402 노드3)에서 `CREATE TABLE` 의
  카탈로그 반영 중 abort. 후속 10건이 `ER_BO_CONNECT_FAILED` 연쇄로 NOK 처리됐습니다.
- assert 지점은 **그 실패 잡의 코어덤프를 같은 워크플로 `build_debug` 잡의 바이너리로 해석**해
  확정했습니다.

  | 프레임 | 함수 | 위치 |
  |---|---|---|
  | [18] | `btree_split_node_and_advance` | **btree.c:30574** ← `ASSERT_ERROR_AND_SET` |
  | [17] | `btree_search_key_and_apply_functions` | btree.c:25773 |
  | [16] | `btree_insert_internal` | btree.c:29734 |
  | [15] | `btree_insert` | |
  | [14] | `locator_add_or_remove_index_internal` | locator_sr.c:7836 |
  | [13] | `catcls_insert_instance` | catalog_class.c:3868 |

  디스어셈블에서 `er_errid()` 반환값을 `test %eax,%eax` 로 검사한 직후 `mov $0x776e,%edx`(=30574)를
  `__assert_fail()` 인자로 싣는 것을 확인했습니다 — 깨진 assert 가 `er_errid () != NO_ERROR` 임이
  확정됩니다.
- **에러 없는 NULL 이 나오는 zero-wait 경로는 두 개**이고, 관측된 스택은 둘 모두와 정합합니다.
  ① `pgbuf_fix()` 는 무조건 요청이라도 현재 wait 가 zero-wait 면 **조건부로 조용히 강등**하는데
  (page_buffer.c:2231), 강등된 요청의 거부 경로는 `wait_msec == LK_ZERO_WAIT` 일 때만 에러를 설정하고
  `LK_FORCE_ZERO_WAIT`(−2)는 else 로 빠져 **에러 없이** 거부됩니다(:6467). ② `pgbuf_timed_sleep()` 의
  zero-wait 타임아웃 분기(본 수정 대상). CI abort 는 ①이 유력합니다 — 직전 케이스(cbrd_25372)가
  에러 경로 질의 수십 건으로 `btree_set_error` 프로브를 반복시켰고, save/restore 엇갈림으로
  `tdes->wait_msecs` 가 −2 에 고착되면(첫 커밋이 없애는 그 레이스) **`logtb_clear_tdes()` 가
  wait_msecs 를 리셋하지 않아 트랜잭션 경계를 넘어 유지**되므로, 다음 케이스의 CREATE TABLE 전체가
  no-wait 로 돌다 첫 경쟁 fix 에서 즉시 abort 합니다. 어느 쪽이든 zero-wait 이며(무한대기였다면
  `assert (0)` 로 `pgbuf_timed_sleep()` 안에서, 양수였다면 에러가 설정돼 다른 결과), 첫 커밋이 ①의
  원인을 제거하고 두 번째 커밋이 ②를 메웁니다. ①의 else 자체(자기 프로브의 내부 fix 가 조용히
  거부되는 것)는 프로브 호출자들이 처리하는 기존 설계라 이 PR 에서는 유지합니다.
- **결정적 재현은 미확립입니다.** 발화에 ① 무조건 래치 대기의 타임아웃과 ② 그 시점 zero-wait 가 겹쳐야
  하고, ①은 full-suite 규모의 카탈로그 페이지 경쟁에서 섭니다. 원인 확정은 위 스택 논증에 근거합니다.
  따라서 **CI 녹색이 곧 원인 확정의 증거는 아닙니다** — 원래 재발률이 낮은 타이밍 의존 건입니다.
- 이 PR 은 **래치 타임아웃 자체를 없애지 않습니다.** 수정 후에는 같은 상황에서 `ER_LK_PAGE_TIMEOUT` 이
  정상적으로 보고되고, 호출자에 따라 재시도되거나 질의 에러가 됩니다. 카탈로그 페이지 경쟁이 왜
  타임아웃까지 갔는지는 별건입니다.
- 같은 부류를 CBRD-27293(`f8f5b4401`)이 `pgbuf_block_bcb()` 의 인터럽트 경로에서 먼저 고쳤습니다 —
  그 코드의 "callers assert one is set" 주석이 그 흔적입니다.
- 로컬 검증: 변경된 11개 파일 코드 스타일 검사 통과, 각 파일 단일 컴파일 통과. 1차 CI 의 35건 코어를 로컬 debug 빌드에서 재현(2/2)했고, 수정 빌드로 같은 워크로드를 재실행해 확인합니다.
