### PR TITLE
[CBRD-27202] fix disk_set_boot_hfid() to memory-overread (#7631)

### DIFF
--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -1108,7 +1108,7 @@ disk_set_boot_hfid (THREAD_ENTRY * thread_p, INT16 volid, const HFID * hfid)
   vhdr = (DISK_VOLUME_HEADER *) addr.pgptr;
 
   log_append_undoredo_data (thread_p, RVDK_RESET_BOOT_HFID, &addr, sizeof (vhdr->boot_hfid), sizeof (*hfid),
-			    &vhdr->boot_hfid, &hfid);
+			    &vhdr->boot_hfid, hfid);
   HFID_COPY (&(vhdr->boot_hfid), hfid);
 
   (void) disk_verify_volume_header (thread_p, addr.pgptr);


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27202>

* fix memory-overread
* backport https://github.com/CUBRID/cubrid/pull/7631
