### PR TITLE
[CBRD-27206] fix stack-use-after-scope in heap_rv_mvcc_redo_insert() (#7647)

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -15615,6 +15615,7 @@ heap_rv_mvcc_redo_insert (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
   MVCC_REC_HEADER mvcc_rec_header;
   INT16 record_type;
   bool vacuum_status_change = false;
+  char data_buffer[IO_DEFAULT_PAGE_SIZE + OR_MVCC_MAX_HEADER_SIZE + MAX_ALIGNMENT];
 
   assert (rcv->pgptr != NULL);
   assert (MVCCID_IS_NORMAL (rcv->mvcc_id));
@@ -15636,7 +15637,6 @@ heap_rv_mvcc_redo_insert (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
     }
   else
     {
-      char data_buffer[IO_DEFAULT_PAGE_SIZE + OR_MVCC_MAX_HEADER_SIZE + MAX_ALIGNMENT];
       int repid_and_flags, offset, mvcc_flag, offset_size;
 
       offset = sizeof (record_type);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27206

* Fix stack-use-after-scope issue in heap_rv_mvcc_redo_insert()
* backport #7647 
