### PR TITLE
[CBRD-27040] Downgrade UPDATE STATISTICS WITH FULLSCAN to sampling above a page-count cap - log a notification

### DIFF
--- a/msg/en_US.utf8/cubrid.msg
+++ b/msg/en_US.utf8/cubrid.msg
@@ -1467,7 +1467,9 @@ Check the path of the key file (_keys) and make sure that it includes proper key
 
 1370 CDC: the extraction position (%1$lld|%2$d) handed to the client keeps archive log volume %3$d.
 
-1371 Last Error
+1371 WITH FULLSCAN is downgraded to sampling (class "%1$s", heap pages : %2$d, stats_fullscan_max_pages : %3$d).
+
+1372 Last Error
 
 $set 6 MSGCAT_SET_INTERNAL
 1 Error in error subsystem (line %1$d):

--- a/msg/ko_KR.utf8/cubrid.msg
+++ b/msg/ko_KR.utf8/cubrid.msg
@@ -1466,7 +1466,9 @@ $ LOADDB
 
 1370 CDC: 클라이언트에 전달한 추출 위치 (%1$lld|%2$d) 때문에 archive log 볼륨 %3$d 를 보존합니다.
 
-1371 마지막 에러
+1371 WITH FULLSCAN이 샘플링 방식으로 전환되었습니다. (class "%1$s", heap pages : %2$d, stats_fullscan_max_pages : %3$d)
+
+1372 마지막 에러
 
 $set 6 MSGCAT_SET_INTERNAL
 1 에러 서브 시스템에 에러 발생(라인 %1$d):

--- a/src/base/error_code.h
+++ b/src/base/error_code.h
@@ -1757,7 +1757,9 @@
 
 #define ER_CDC_ARCHIVE_KEPT                         -1370
 
-#define ER_LAST_ERROR                               -1371
+#define ER_STATS_FULLSCAN_TO_SAMPLING               -1371
+
+#define ER_LAST_ERROR                               -1372
 
 
 /*

--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -6640,7 +6640,7 @@ SYSPRM_PARAM prm_Def[] = {
    (DUP_PRM_FUNC) NULL},
   {PRM_ID_STATS_FULLSCAN_MAX_PAGES,
    PRM_NAME_STATS_FULLSCAN_MAX_PAGES,
-   (PRM_FOR_CLIENT | PRM_FOR_SERVER | PRM_USER_CHANGE | PRM_HIDDEN),
+   (PRM_FOR_CLIENT | PRM_USER_CHANGE | PRM_HIDDEN),
    PRM_INTEGER,
    &prm_stats_fullscan_max_pages_flag,
    (void *) &prm_stats_fullscan_max_pages_default,

--- a/src/storage/statistics_cl.c
+++ b/src/storage/statistics_cl.c
@@ -558,8 +558,9 @@ stats_get_ndv_by_query (const MOP class_mop, CLASS_ATTR_NDV * class_attr_ndv, FI
 	{
 	  er_clear ();		/* clear the error a failed probe may have raised; it does not fail the update */
 	  with_fullscan = STATS_WITH_SAMPLING;
-	  er_log_debug (ARG_FILE_LINE, "update stats: %s WITH FULLSCAN -> sampling (pages %d, max %d)\n",
-			class_name_p, npages, max_pages);
+
+	  er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_STATS_FULLSCAN_TO_SAMPLING, 3, class_name_p, npages,
+		  max_pages);
 	}
     }
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27040>

### Purpose

#7445 에서 `UPDATE STATISTICS ... WITH FULLSCAN` 이 `stats_fullscan_max_pages` 상한 초과로
샘플링 스캔으로 전환될 때, 전환 사실이 `er_log_debug` 로만 남아 있어 히든 파라미터
`er_log_debug` 를 켜지 않으면 확인할 방법이 없습니다. 이 때문에 수집된 통계가 샘플링
추정치라는 것을 사용자가 알 수 없다는 문제가 검증 과정에서 제기되어, 전환 사실을 기본
설정에서 에러 로그에 기록하도록 #7445 의 내용을 수정합니다.


```sql
create table rt(actdt varchar(14), docid varchar(35));
 
insert into rt
    select
        case when mod(rownum,50000)=0 then lpad(cast(rownum as varchar),14,'0') else null end,
        lpad(cast(rownum as varchar),35,'0')
    from db_class a, db_class b, db_class c, db_class d, db_class e limit 8000000;

create index ix on rt(actdt, docid);

update statistics on rt with fullscan;
;info stats rt
```

```
--csql.err
NOTIFICATION *** file /home/cubrid/dev/cubrid/src/storage/statistics_cl.c, line 562  CODE = -1371, Tran = 1, EID = 2
WITH FULLSCAN is downgraded to sampling (class "dba.rt", heap pages : 35088, stats_fullscan_max_pages : 10000).
```

### Implementation

- `stats_get_ndv_by_query ()` 의 `er_log_debug` 를 신규 에러 코드
  `ER_STATS_FULLSCAN_TO_SAMPLING` 을 사용하는 `ER_NOTIFICATION_SEVERITY` 수준의
  `er_set` 으로 교체. `error_log_level` 기본값(notification).
- 메시지 카탈로그(en_US, ko_KR)에 신규 메시지 추가. 형식은 기존 통계 갱신 시작/완료
알림(1115/1116)을 따랐습니다.
- `stats_fullscan_max_pages` 파라미터에서 `PRM_FOR_SERVER` 제거. 이 파라미터를 읽는
곳은 클라이언트 측 NDV 쿼리 경로뿐입니다.

### Remarks

N/A
