### PR TITLE
[CBRD-27062] Disable fixed scan for a statement that generates NEXT_VALUE or CURRENT_VALUE

### DIFF
--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -9244,6 +9244,14 @@ pt_to_regu_variable (PARSER_CONTEXT * parser, PT_NODE * node, UNBOX unbox)
 
 			regu = pt_make_regu_arith (r1, r2, r3, op, domain);
 
+			/* Both serial operators re-enter storage mid-scan: nextval WRITE-latches
+			 * the _db_serial page, currval waits on the cache entry mutex a nextval
+			 * holds across that latch. A fixed (PEEK) scan deadlocks with either. */
+			if (parser->parent_proc_xasl != NULL)
+			  {
+			    XASL_SET_FLAG (parser->parent_proc_xasl, XASL_NO_FIXED_SCAN);
+			  }
+
 			parser_free_tree (parser, cached_num_node_p);
 		      }
 		    else


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27062

### Purpose

serial 연산자 두 개가 모두 감싸는 스캔이 SELECT-list 를 평가하는 도중에 스토리지로 재진입한다. 감싸는 스캔이 fixed(PEEK) 면 그때까지 `_db_serial` 페이지의 READ 래치를 쥐고 있다.

- `NEXT_VALUE` 는 그 페이지를 WRITE 래치로 잡고 갱신한다 (`xserial_get_next_value_internal()` → modify scancache → `spage_update()`, `src/query/serial.c:1081`). `SELECT s.NEXT_VALUE FROM db_serial` 처럼 스캔 대상이 serial 카탈로그면 같은 문장이 READ 로 쥔 페이지에 WRITE 를 요구하는 꼴이 된다. 여러 세션이 동시에 돌리면 탐지되지 않는 latch↔lock 순환이 되고, NOCACHE serial 은 OID 잠금을 아예 잡지 않아 순수 page-latch 순환이 된다. 결과는 스캔의 페이지 fix-count 가 음수로 내려가는 것이다 (`pgbuf_unlatch_bcb_upon_unfix()`, `src/storage/page_buffer.c:6591`) — release 는 `ER_PB_UNFIXED_PAGEPTR` (-19), debug 는 바로 윗줄 `assert (false)`. 단일 세션도 cold serial 캐시 풀에서는 자기 자신과 충돌해 promote 타임아웃으로만 빠져나온다 (`FROM db_serial` 6.9 초 대 `FROM db_root` 0.005 초).
- `CURRENT_VALUE` 는 그 페이지를 READ 로만 읽지만, 거기 닿기 전에 serial 캐시 엔트리 뮤텍스를 먼저 잡는다 — `serial_Cache_hashmap.find()` 가 엔트리를 잠근 채 돌려준다 (`src/query/serial.c:200`). nextval 은 같은 뮤텍스를 쥔 채 페이지를 WRITE 로 잡는다 (블록 소진 시 `serial_get_next_cached_value()` → `serial_update_cur_val_of_serial()`, 캐시 미스 시 `xserial_get_next_value_internal()`). 그래서 `SELECT s.CURRENT_VALUE FROM db_serial` 이 페이지 READ 래치를 쥔 채 뮤텍스를 기다리고, 그 뮤텍스 소유자는 같은 페이지의 WRITE 래치를 기다린다.

교착 탐지기의 wait-for 그래프는 lock manager 의 잠금만 보고 page buffer latch 도 뮤텍스도 보지 못하므로 어느 쪽이든 victim 이 선정되지 않는다. currval 쪽을 풀어 주는 것은 페이지 래치 타임아웃 (`page_latch_timeout_in_msecs`, 기본 300 초) 뿐이고, 상대편 nextval 은 serial 카탈로그를 스캔할 필요도 없다 — 캐시 블록을 소진하는 nextval 이면 무엇이든 성립한다. `db_serial` 은 public SELECT 이므로 일반 사용자도 도달한다.

`INSERT`, 사용자 테이블·`db_root` 스캔 같은 일반 자리는 감싸는 문장이 다른 페이지를 잡으므로 영향이 없다.

### Implementation

- `src/parser/xasl_generation.c` — `pt_to_regu_variable()` 의 `PT_CURRENT_VALUE`/`PT_NEXT_VALUE` case 에서 regu 를 만든 직후 감싸는 proc XASL 에 `XASL_NO_FIXED_SCAN` 을 세운다. 스캔이 COPY 로 열려 각 행을 복사하고 페이지 래치를 놓은 뒤 SELECT-list 를 평가하므로, 두 연산자 중 어느 쪽이 재진입하든 같은 문장이 쥔 래치가 없다.

엔진에 재진입하는 연산자에 이미 적용돼 있는 정책이다 — 같은 switch 의 `PT_INDEX_CARDINALITY` 와 `PT_ESTIMATED_*` 4개가 동일하게 플래그를 세우고, `parent_proc_xasl != NULL` 가드도 같다 (`SELECT s.NEXT_VALUE` 나 `INSERT ... VALUES` 처럼 감싸는 스캔이 없는 경우). 저장 포맷·복구·lock manager·`serial.c` 는 건드리지 않는다.

### Verification

release 빌드, db `t27062`.

`NEXT_VALUE` — 16 세션 동시 실행:

| 게이트 | 수정 전 | 수정 후 |
|---|---|---|
| NOCACHE serial 3 런, `ER_PB_UNFIXED_PAGEPTR` | +3 / +5 / +5 | 0 / 0 / 0 |
| cold pool 단일 세션 `SELECT nextval FROM db_serial` | 6.869 초, -19 ×1 | 0.006 초, 없음 |
| cold CACHE serial 동시 실행 | -19 ×1, 최대 6.96 초 | 없음, 최대 0.004 초 |

`CURRENT_VALUE` — `CACHE 2` serial 에 대해 12 세션이 `SELECT s.CURRENT_VALUE FROM <카탈로그>`, 8 세션이 `SELECT s.NEXT_VALUE FROM db_root` 를 각각 200 구문씩 동시 실행. `_db_serial` 63 행, 런이 끝나도록 `page_latch_timeout_in_msecs` 를 5000 으로 낮춤 (기본값 300 초). 내부 클래스와 공개 뷰 양쪽 모두 순환에 도달한다:

| 스캔 대상 | 게이트 | 수정 전 | 수정 후 |
|---|---|---|---|
| `_db_serial` | `ER_PAGE_LATCH_TIMEDOUT` | +57 | 0 / 0 |
| | 캡까지 끝나지 않은 세션 | 20/20 (300 초) | 0/20, 0/20 |
| | 전체 소요 | 300.3 초 (캡) | 1.005 / 1.004 초 |
| `db_serial` (뷰) | `ER_PAGE_LATCH_TIMEDOUT` | +21 | 0 |
| | 캡까지 끝나지 않은 세션 | 20/20 (120 초) | 0/20 |
| | 전체 소요 | 120.1 초 (캡) | 1.004 초 |

같은 바이너리에서 클라이언트 라이브러리만 되돌리면 두 재현이 모두 돌아온다. 기능 회귀는 `INSERT ... VALUES(nextval)`, `INSERT ... SELECT nextval`, `FROM db_root`, AUTO_INCREMENT 가 모두 값이 연속하고, 여러 행 스캔은 행마다 증가값을 하나씩, `CURRENT_VALUE` 는 모든 행에서 같은 값을 반환한다.

두 연산자가 든 문장은 감싸는 스캔 전체가 COPY 로 바뀌므로 대량 경로 비용을 1M 행으로 측정했다 — `SELECT max(s.next_value) FROM src` 0.260 → 0.259 초, `INSERT INTO dst SELECT s.next_value, a FROM src` 3.973 → 3.803 초, `SELECT max(s.current_value) FROM src` 0.139 → 0.131 초 (각 8 런 중앙값).

### Remarks

N/A
