### PR TITLE
[CUBRIDQA-1501] Post the shell suite verdict as a commit status on the PR head SHA

### DIFF
--- a/.github/workflows/gha-ci.yml
+++ b/.github/workflows/gha-ci.yml
@@ -278,6 +278,49 @@ jobs:
           emit sabotage "$sab"
           echo "resolved: event=$EV test=$test_run namespace=$ns ccache_write=$cache_write"
 
+  # The suite takes 40-60 minutes. Without this the PR shows nothing until it ends,
+  # and "waiting for a status" would be the same picture as "nobody ran /run".
+  # Only the paths that carry a PR number post; pull_request and push build only.
+  status_pending:
+    name: status (pending)
+    needs: gate
+    if: ${{ needs.gate.outputs.run == 'true' && needs.gate.outputs.test == 'true' && needs.gate.outputs.pr != '' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      statuses: write # the only scope this job uses
+    steps:
+      - name: Mark the head commit pending
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          SHA: ${{ needs.gate.outputs.sha }}
+          CONTEXT: "gha-ci: test_shell"
+        run: |
+          set -eo pipefail
+          # gate already proved this is 40 hex. Re-checked because the value goes
+          # into a URL path.
+          if [[ ! "$SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::sha must be 40 lowercase hex characters, got: ${SHA}"; exit 1
+          fi
+          jq -n --arg c "$CONTEXT" \
+            --arg u "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            '{state:"pending", context:$c, target_url:$u, description:"shell suite running"}' \
+            > /tmp/st.json
+          code=$(curl -sS -o /tmp/resp.json -w '%{http_code}' -X POST \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/statuses/${SHA}" \
+            -d @/tmp/st.json)
+          echo "HTTP $code"
+          if [ "$code" != "201" ]; then
+            # A 403 here means statuses: write did not reach GITHUB_TOKEN.
+            echo "::error::could not post the pending status"
+            jq -r '.message // .' /tmp/resp.json 2>/dev/null | head -3
+            exit 1
+          fi
+          echo "pending posted on ${SHA}"
+
   # Both modes of the CircleCI baseline, which differ only in the build argument and
   # the ccache they use. One image serves both: the release build here is for testing,
   # not distribution, so it carries no glibc constraint.
@@ -773,6 +816,7 @@ jobs:
           LIMIT: ${{ steps.args.outputs.limit }}
           SABOTAGE: ${{ needs.gate.outputs.sabotage }}
           RERUN_FROM: ${{ needs.gate.outputs.rerun_from }}
+          SHA: ${{ needs.gate.outputs.sha }}
         run: |
           set -eo pipefail
 
@@ -789,6 +833,31 @@ jobs:
           if [ -n "$RERUN_FROM" ]; then
             src="$CI_ROOT/runs/$RERUN_FROM/failed.list"
             [ -f "$src" ] || { echo "::error::no failed.list: $src"; exit 1; }
+            # CircleCI's rerun-failed-tests "is created from the same commit as the
+            # failed workflow, not from subsequent commits", so a partial re-run
+            # there can never answer for a commit it did not test. /run rerun can:
+            # it takes an arbitrary run id, while gate re-resolves the PR head. From
+            # 9/10 that answer is a required check, so the two must match -- refuse
+            # the mismatch here rather than let plan build a list for the wrong tree.
+            #
+            # The source run's commit is in the build provenance its shards recorded.
+            # find, not a glob: no match under pipefail would kill the step. The
+            # `|| prev_sha=` matters too -- a missing results/ makes find exit 1, and
+            # under pipefail that would kill the step before the diagnostic below.
+            prev_sha=$(find "$CI_ROOT/runs/$RERUN_FROM/results" -mindepth 2 -maxdepth 2 \
+              -name build.read -exec awk -F= '/^sha=/ {print $2}' {} + 2>/dev/null | sort -u) \
+              || prev_sha=''
+            n_sha=$(printf '%s' "$prev_sha" | grep -c . || :)
+            if [ "$n_sha" -eq 0 ]; then
+              echo "::error::run $RERUN_FROM recorded no build provenance, so the commit it tested cannot be confirmed"
+              exit 1
+            fi
+            if [ "$n_sha" -ne 1 ] || [ "$prev_sha" != "$SHA" ]; then
+              echo "::error::run $RERUN_FROM tested $(echo $prev_sha), but this head is $SHA"
+              echo "  A re-run may only re-run the failures of the same commit. Use /run all."
+              exit 1
+            fi
+            echo "re-run pinned to the commit run $RERUN_FROM tested: $SHA"
             cut -f2 "$src" | sed 's#^#cubrid-testcases-private-ex/#' | sort -u > /tmp/want.list
             want=$(wc -l < /tmp/want.list)
             # Keep only what is in the tree now; cases deleted since are dropped.
@@ -1865,3 +1934,56 @@ jobs:
           else
             echo "nothing to remove: $seed"
           fi
+
+  # The check ticket 28 makes required.
+  #
+  # always(), not success(): a red verdict is exactly what the gate exists to show.
+  # Runs GitHub-hosted so an evicted collect pod still turns the status red.
+  #
+  # A /run rerun posts like any other run. That is CircleCI's behaviour, and hunk 2
+  # is what earns it: there a re-run cannot cross commits, and now neither can this
+  # one. The summary still says in words that only the failures were re-run.
+  status:
+    name: status
+    needs: [gate, collect]
+    if: ${{ always() && needs.gate.outputs.run == 'true' && needs.gate.outputs.test == 'true' && needs.gate.outputs.pr != '' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      statuses: write
+    steps:
+      - name: Post the verdict to the head commit
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          SHA: ${{ needs.gate.outputs.sha }}
+          CONTEXT: "gha-ci: test_shell"
+          # skipped and cancelled both mean no verdict was produced. Neither may
+          # read as green on a required check.
+          COLLECT: ${{ needs.collect.result }}
+        run: |
+          set -eo pipefail
+          if [[ ! "$SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::sha must be 40 lowercase hex characters, got: ${SHA}"; exit 1
+          fi
+          case "$COLLECT" in
+            success)   state=success; desc="shell suite passed" ;;
+            cancelled) state=failure; desc="run was superseded or cancelled" ;;
+            *)         state=failure; desc="shell suite failed -- see the run" ;;
+          esac
+          echo "collect=$COLLECT -> $state"
+          jq -n --arg s "$state" --arg c "$CONTEXT" --arg d "$desc" \
+            --arg u "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            '{state:$s, context:$c, target_url:$u, description:$d}' > /tmp/st.json
+          code=$(curl -sS -o /tmp/resp.json -w '%{http_code}' -X POST \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/statuses/${SHA}" \
+            -d @/tmp/st.json)
+          echo "HTTP $code"
+          if [ "$code" != "201" ]; then
+            echo "::error::could not post the verdict status"
+            jq -r '.message // .' /tmp/resp.json 2>/dev/null | head -3
+            exit 1
+          fi
+          echo "posted ${state} on ${SHA}"

--- a/.github/workflows/gha-ci.yml
+++ b/.github/workflows/gha-ci.yml
@@ -90,7 +90,9 @@ permissions: {} # jobs opt-in below
 # drops the second. dispatch is keyed on the SHA because two force_build dispatches for
 # one SHA would race the republish and pull the overlay lowerdir from a running shard.
 # The run group is per pull request because a comment carries no head SHA, and it tests
-# issue.pull_request the way the gate does -- issues share the PR number space.
+# issue.pull_request the way the gate does -- issues share the PR number space. A rerun
+# shares that group: both post the same commit status, so two in flight would race it,
+# and CircleCI cannot reach that state -- there a rerun starts from a finished workflow.
 concurrency:
   group: >-
     gha-ci-${{ github.event_name == 'push'
@@ -102,7 +104,7 @@ concurrency:
     || github.event.issue.pull_request != null
     && startsWith(github.event.comment.body, '/run')
     && contains(github.event.comment.body, 'rerun')
-    && format('pr-{0}-rerun-{1}', github.event.issue.number, github.event.comment.id)
+    && format('pr-{0}-run', github.event.issue.number)
     || github.event.issue.pull_request != null
     && startsWith(github.event.comment.body, '/run')
     && (contains(github.event.comment.body, 'shell')
@@ -278,9 +280,9 @@ jobs:
           emit sabotage "$sab"
           echo "resolved: event=$EV test=$test_run namespace=$ns ccache_write=$cache_write"
 
-  # The suite takes 40-60 minutes. Without this the PR shows nothing until it ends,
-  # and "waiting for a status" would be the same picture as "nobody ran /run".
-  # Only the paths that carry a PR number post; pull_request and push build only.
+  # The check ticket 28 makes required. Posted from here and not from collect: that
+  # job runs in a pod that can be evicted, and statuses: write must not reach a
+  # runner that executes testcase code.
   status_pending:
     name: status (pending)
     needs: gate
@@ -288,7 +290,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
-      statuses: write # the only scope this job uses
+      statuses: write
     steps:
       - name: Mark the head commit pending
         env:
@@ -297,8 +299,6 @@ jobs:
           CONTEXT: "gha-ci: test_shell"
         run: |
           set -eo pipefail
-          # gate already proved this is 40 hex. Re-checked because the value goes
-          # into a URL path.
           if [[ ! "$SHA" =~ ^[0-9a-f]{40}$ ]]; then
             echo "::error::sha must be 40 lowercase hex characters, got: ${SHA}"; exit 1
           fi
@@ -314,7 +314,6 @@ jobs:
             -d @/tmp/st.json)
           echo "HTTP $code"
           if [ "$code" != "201" ]; then
-            # A 403 here means statuses: write did not reach GITHUB_TOKEN.
             echo "::error::could not post the pending status"
             jq -r '.message // .' /tmp/resp.json 2>/dev/null | head -3
             exit 1
@@ -833,31 +832,17 @@ jobs:
           if [ -n "$RERUN_FROM" ]; then
             src="$CI_ROOT/runs/$RERUN_FROM/failed.list"
             [ -f "$src" ] || { echo "::error::no failed.list: $src"; exit 1; }
-            # CircleCI's rerun-failed-tests "is created from the same commit as the
-            # failed workflow, not from subsequent commits", so a partial re-run
-            # there can never answer for a commit it did not test. /run rerun can:
-            # it takes an arbitrary run id, while gate re-resolves the PR head. From
-            # 9/10 that answer is a required check, so the two must match -- refuse
-            # the mismatch here rather than let plan build a list for the wrong tree.
-            #
-            # The source run's commit is in the build provenance its shards recorded.
-            # find, not a glob: no match under pipefail would kill the step. The
-            # `|| prev_sha=` matters too -- a missing results/ makes find exit 1, and
-            # under pipefail that would kill the step before the diagnostic below.
+            # CircleCI's rerun runs the same commit as the workflow it came from.
+            # gate re-resolves the head, so hold that guarantee here.
             prev_sha=$(find "$CI_ROOT/runs/$RERUN_FROM/results" -mindepth 2 -maxdepth 2 \
               -name build.read -exec awk -F= '/^sha=/ {print $2}' {} + 2>/dev/null | sort -u) \
               || prev_sha=''
             n_sha=$(printf '%s' "$prev_sha" | grep -c . || :)
-            if [ "$n_sha" -eq 0 ]; then
-              echo "::error::run $RERUN_FROM recorded no build provenance, so the commit it tested cannot be confirmed"
-              exit 1
-            fi
             if [ "$n_sha" -ne 1 ] || [ "$prev_sha" != "$SHA" ]; then
-              echo "::error::run $RERUN_FROM tested $(echo $prev_sha), but this head is $SHA"
+              echo "::error::run $RERUN_FROM tested '$(echo $prev_sha)', not this head $SHA"
               echo "  A re-run may only re-run the failures of the same commit. Use /run all."
               exit 1
             fi
-            echo "re-run pinned to the commit run $RERUN_FROM tested: $SHA"
             cut -f2 "$src" | sed 's#^#cubrid-testcases-private-ex/#' | sort -u > /tmp/want.list
             want=$(wc -l < /tmp/want.list)
             # Keep only what is in the tree now; cases deleted since are dropped.
@@ -1935,14 +1920,7 @@ jobs:
             echo "nothing to remove: $seed"
           fi
 
-  # The check ticket 28 makes required.
-  #
-  # always(), not success(): a red verdict is exactly what the gate exists to show.
-  # Runs GitHub-hosted so an evicted collect pod still turns the status red.
-  #
-  # A /run rerun posts like any other run. That is CircleCI's behaviour, and hunk 2
-  # is what earns it: there a re-run cannot cross commits, and now neither can this
-  # one. The summary still says in words that only the failures were re-run.
+  # always(), not success(): a red verdict is what the gate exists to show.
   status:
     name: status
     needs: [gate, collect]
@@ -1957,8 +1935,6 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           SHA: ${{ needs.gate.outputs.sha }}
           CONTEXT: "gha-ci: test_shell"
-          # skipped and cancelled both mean no verdict was produced. Neither may
-          # read as green on a required check.
           COLLECT: ${{ needs.collect.result }}
         run: |
           set -eo pipefail


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBRIDQA-1501>

### Purpose

2026-09-10에 gha-ci의 shell 결과가 develop 머지 필수 체크가 된다 (CUBRIDQA-1501 확정 일정). **그런데 걸 체크가 없었다.**

`/run`은 `issue_comment` 이벤트다. 이 이벤트는 자기 ref가 없어 항상 default branch를 읽고, 그래서 이 워크플로가 만드는 check run도 PR 커밋이 아니라 develop에 붙는다. PR 7834에서 실측한 모습이다.

| 대상 | 무엇이 붙었나 |
|---|---|
| PR head `9b09ab17` | `collect` = `skipped` — `pull_request` run이 남긴 것. 3,272건을 돌린 결과가 아니다 |
| develop `2bebd8ce` | 실제 `/run all` run 33710472780의 `collect` |

그 `skipped`를 필수로 걸 수도 없다. GitHub 문서가 `Successful check statuses are success, skipped, and neutral`이라고 못 박는다 — 조건문으로 건너뛴 job은 성공으로 센다. 즉 `collect`를 필수로 걸면 **shell suite를 한 번도 안 돌려도 머지된다.**

### Implementation

`.github/workflows/gha-ci.yml`만 고친다. 다른 워크플로와 `.circleci/config.yml`은 안 건드린다.

**1. shell 결과를 PR head 커밋에 commit status로 붙인다.**

commit status는 붙일 SHA를 직접 지정한다. CircleCI가 `ci/circleci: *`로 같은 커밋에 닿는 방식이고, fork PR에서도 된다.

| job | 언제 | 무엇을 쏘나 |
|---|---|---|
| `status_pending` | `gate` 직후 | `pending` — 40~60분 동안 PR에 "돌고 있다"가 보인다 |
| `status` | `collect` 직후, `always()` | `collect` 결과대로 `success` 또는 `failure` |

context 문자열은 **`gha-ci: test_shell`** 이다. 이것이 branch protection에 들어갈 이름이다. 지금 필수인 `ci/circleci: test_shell`과 짝으로 읽히도록 맞췄다.

두 job은 self-hosted가 아니라 `ubuntu-24.04`에서 돈다. `collect`는 축출될 수 있는 pod에서 도는데 그때 status가 안 붙으면 PR이 "Expected — waiting for status"에 갇혀 "아무도 `/run`을 안 쳤다"와 구분이 안 된다. 그리고 `statuses: write`가 테스트케이스 코드를 돌리는 러너에 닿지 않는다.

**2. `/run rerun`을 CircleCI와 같게 만든다.**

CircleCI의 rerun-failed-tests는 `is created from the same commit as the failed workflow, not from subsequent commits`다. 그리고 **이미 끝난** workflow에서만 시작된다. 그래서 CircleCI에서는 부분 재실행이 게이트를 초록으로 칠해도 그 커밋을 테스트한 결과이고, 원본과 겹치지도 않는다. 전제조건 둘(`circleci tests run`, `store_test_results`)은 지금 `test_shell`이 이미 충족한다.

`/run rerun <id>`는 두 축 다 달랐다. 아래로 맞췄다.

| 축 | 전 | 후 |
|---|---|---|
| 커밋 | 임의의 run id를 받고 `gate`는 PR head를 새로 읽었다. 소스 run이 이 head를 테스트했는지 확인이 없었다 | `plan`이 소스 run의 build provenance(`build.read`의 `sha=`)를 읽어 지금 head와 다르면 거절한다 |
| 동시 실행 | concurrency group이 `pr-<N>-rerun-<comment_id>`라 `/run shell\|all`(`pr-<N>-run`)과 서로 취소하지 않았다. 둘이 겹치면 부분 실행의 7분 성공이 아직 도는 전 suite의 `pending`을 덮어 verdict 전에 머지 가능해진다 | rerun도 `pr-<N>-run`을 쓴다. `cancel-in-progress`가 이미 켜져 있어 PR당 shell verdict가 하나만 떠 있다 |

커밋이 같으면 rerun도 평소처럼 status를 쏜다 — CircleCI와 같은 동작이다.

### Remarks

**포크에서 실증했다 (tw-kang/cubrid#113·#114)**

포크에는 `cubrid-arc` 러너가 0이라 전 suite는 못 돈다. 그래서 두 번에 나눠 쳤다. #114는 포크 default branch를 이 브랜치로 두어 **수정하지 않은 이 파일**을 `issue_comment`가 읽게 한 것이고, #113은 `gate`·`status_pending`·`status`를 그대로 두고 `collect`만 stub으로 바꾼 것이다.

| 확인 | 결과 |
|---|---|
| `issue_comment` run이 PR head SHA에 status를 붙인다 | ✅ `pending` → verdict가 run마다 짝지어 붙는다 |
| default branch head에는 안 붙는다 | ✅ status 총계 0 |
| `collect` 성공 → `success` / 실패 → `failure` | ✅ 앞의 값을 덮는다 |
| `collect` 취소 → `failure` (허수 초록이 안 생긴다) | ✅ `status` job은 `always()`라 그래도 돈다 |
| rerun이 도는 전 suite를 취소한다 | ✅ 새 run은 앞 run이 죽을 때까지 대기했다 |
| rerun이 게이트를 초록으로 칠한다 | ✅ |

`plan`의 rerun 커밋 고정은 GlusterFS를 읽어 포크에서 안 돌아 픽스처 5종으로 확인했다 — 같은 SHA 통과, 다른 SHA·provenance 없음·SHA 섞임·run 없음 거절.

**머지 뒤 순서 (CUBRIDQA-1501 티켓 28)**

1. 아무 PR에서 `/run all` 또는 `/run shell`을 한 번 친다. `gha-ci: test_shell`이 그 PR head에 붙는 것을 확인한다. branch protection의 체크 선택 목록은 최근에 관측된 context만 보여주므로 이 한 번이 필요하다.
2. org admin이 develop branch protection에서 `gha-ci: test_shell`을 필수로 넣고 `ci/circleci: test_shell`을 필수에서 뺀다.

**사용자가 체감하는 변화**

- `/run all`을 치면 PR 체크 목록에 `gha-ci: test_shell`이 생긴다. 코멘트 요약은 그대로 온다.
- `/run`을 안 친 PR은 이 체크가 `pending`으로 남는다. 지금 `ci/circleci: test_shell`과 같은 동작이다.
- 새 커밋을 push하면 이전 커밋의 status는 따라오지 않는다. 다시 `/run`을 쳐야 한다. 이것도 지금과 같다.
- ⚠ **`/run rerun`이 돌고 있는 전 suite를 취소한다. 그 반대도 마찬가지다.** `/run all` 두 건 사이에 이미 있던 동작과 같다.
- `/run rerun`을 다른 커밋의 run id로 치면 `plan`이 명시적으로 거절한다. 전에는 그대로 돌았다.

**주의**

- ⚠ 밀려난 run의 `failure`가 새 run의 `pending`보다 늦게 도착할 수 있다. 그러면 run이 도는 동안 PR이 잠시 빨강으로 보인다. 초록으로 잘못 보이는 방향이 아니라 게이트는 안전하고, 새 run의 verdict가 덮는다.
- 이 PR은 branch protection을 건드리지 않는다. 필수화는 org admin이 별도로 한다.
