### PR TITLE
[CBRD-27362] Count table references inside ON DUPLICATE KEY UPDATE when the INSERT target is remote

### DIFF
--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -11864,6 +11864,15 @@ pt_convert_dblink_dml_query (PARSER_CONTEXT * parser, PT_NODE * node,
 	      parser_walk_tree (parser, list, pt_get_server_name_list, snl, NULL, NULL);
 	    }
 	}
+
+      /* An ON DUPLICATE KEY UPDATE assignment can hold a subquery, so a table reference lives here too.
+       * Uncounted, the "local mixed remote DML" rejection below never fires and the statement goes out
+       * with @server stripped -- the remote then reads its own table of that name. */
+      if (remote_upd > 0 && node->info.insert.odku_assignments)
+	{
+	  parser_walk_tree (parser, node->info.insert.odku_assignments, pt_get_server_name_list, snl, NULL, NULL);
+	}
+
       sub_sel = NULL;
       break;
     case PT_DELETE:


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27362

### Purpose

CBRD-27362 backport to release/11.4.

원격 테이블을 대상으로 하는 `INSERT` 에서 로컬 테이블을 `ON DUPLICATE KEY UPDATE` 절
**안에서만** 참조하면 로컬/원격 혼합 거부가 발동하지 않는다. 문장이 SQL 텍스트로 만들어져
원격에 전송되는데, 그때 서버명이 빠지므로 **원격의 동명 테이블이 읽힌다.**

### Implementation

develop(#7847, `0c238b201`)과 같은 자리에 같은 워크를 넣는다. 이 브랜치에는 값 sink 계열
코드가 없어 `sub_sel_server_cnt`·`sink_kind` 가 존재하지 않으므로, cherry-pick 이 아니라
그 브랜치 모양에 맞춰 다시 만들었다. 조건(`remote_upd > 0`)과 콜백은 동일하다.

### Remarks

N/A
