### PR TITLE
[CBRD-26051] backport to 11.4 remove windows build on jenkins build. 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,32 +101,6 @@ pipeline {
             }
           }
         }
-
-        stage('Windows Release') {
-          when {
-            not {
-              // Skip Windows Release stage for feature branches
-              branch 'feature/*'
-            }
-          }
-          agent {
-            node {
-              label 'windows'
-            }
-          }
-          steps {
-            echo 'Building...'
-            bat "win/build.bat build"
-
-            echo 'Packing...'
-            bat "win/build.bat /out ${OUTPUT_DIR} dist"
-          }
-          post {
-            always {
-              archiveArtifacts "${OUTPUT_DIR}/*"
-            }
-          }
-        }
       }
     }
   }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26051

remove windows build on jenkins build.


### Purpose

N/A

### Implementation

N/A

### Remarks

N/A
