### PR TITLE
[CUBRIDQA-1501] Verify the gha-ci shell commit status lands on the PR head (do not merge)

### DIFF
--- a/.cubridqa-1501-verify
+++ b/.cubridqa-1501-verify
@@ -1,0 +1,2 @@
+CUBRIDQA-1501 ticket 32 verification. Throwaway: checks that gha-ci: test_shell
+lands on this pull request head SHA. Not for merge.


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBRIDQA-1501>

### Purpose

⚠ **머지하지 않는다. 확인이 끝나면 닫는다.**

#7861이 머지되면서 `gha-ci.yml`에 `gha-ci: test_shell` commit status가 들어갔다. 그 딱지가 실제로 PR head SHA에 붙는지 확인하려면 머지 뒤에 PR이 하나 필요하다 — `issue_comment`는 default branch의 워크플로를 읽으므로 머지 전에는 확인할 수 없었다.

이 PR이 그 확인용이다. 남의 PR을 태우지 않으려고 따로 열었다.

### Implementation

내용은 루트의 빈 표식 파일 하나뿐이다. 엔진 코드는 건드리지 않는다.

### Remarks

`/run all`을 한 번 치고 `gha-ci: test_shell`이 이 PR head SHA에 초록으로 붙는지 본다. 그 다음 이 PR과 딸린 TC PR을 닫는다.

확인이 끝나면 2026-09-10 required check 전환(CUBRIDQA-1501)에서 그 이름을 branch protection에 넣는다.
