### PR TITLE
[CUBRIDQA-1501] Stop posting the gha-ci result summary as a PR comment

### DIFF
--- a/.github/workflows/gha-ci.yml
+++ b/.github/workflows/gha-ci.yml
@@ -1389,8 +1389,6 @@ jobs:
       # The wall-clock step reads the run start time. Public repos need no scope --
       # stated so it does not fail silently if this repository ever becomes private.
       actions: read
-      # Posts the result summary. The only place here that needs write.
-      pull-requests: write
     runs-on: cubrid-arc
     timeout-minutes: 30
     container:
@@ -1797,8 +1795,6 @@ jobs:
 
           echo "=== summary ==="
           cat "$GITHUB_STEP_SUMMARY"
-          # The summary file is append-only; leave a copy for the next step.
-          cp "$GITHUB_STEP_SUMMARY" /tmp/summary.md
 
           # Guard 3 of 3: a shard dying whole is invisible to guard 2.
           rc=0
@@ -1848,48 +1844,6 @@ jobs:
           fi
           [ "$rc" -eq 0 ] && echo "completed with no failures."
           exit $rc
-
-      - name: Post to the PR
-        # always(): a failure is exactly when the PR needs to hear about it.
-        if: always() && needs.gate.outputs.pr != ''
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          PR: ${{ needs.gate.outputs.pr }}
-        run: |
-          set -eo pipefail
-          # A job summary lives on the run page only; it does not reach the PR thread.
-          if [[ ! "$PR" =~ ^[0-9]{1,7}$ ]]; then
-            echo "::error::pr must be an integer"; exit 1
-          fi
-          if [ ! -f /tmp/summary.md ]; then
-            printf '## gha-ci: shell suite\n\nCould not build a summary. Check the run.\n' > /tmp/summary.md
-          fi
-
-          {
-            cat /tmp/summary.md
-            echo
-            echo "<sub>gha-ci / run [\`${GITHUB_RUN_ID}\`](https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}) - artifacts \`${RUNDIR}\`</sub>"
-          } > /tmp/body.md
-
-          # Comment bodies cap at 65536 characters, so long failure lists are trimmed.
-          head -c 60000 /tmp/body.md > /tmp/body.trim.md
-          jq -Rs '{body: .}' < /tmp/body.trim.md > /tmp/comment.json
-
-          code=$(curl -sS -o /tmp/resp.json -w '%{http_code}' -X POST \
-            -H "Authorization: Bearer $GITHUB_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" \
-            -d @/tmp/comment.json)
-
-          echo "HTTP $code"
-          if [ "$code" != "201" ]; then
-          # A 403 here means pull-requests: write did not reach GITHUB_TOKEN.
-            echo "::error::failed to post the PR comment"
-            jq -r '.message // .' /tmp/resp.json 2>/dev/null | head -3
-            exit 1
-          fi
-          echo "posted: $(jq -r '.html_url' /tmp/resp.json)"
 
       # 59MB per run, nothing worth keeping, and the cleanup CronJob does not see it.
       #


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBRIDQA-1501>

### Purpose

`/run shell`을 칠 때마다 gha-ci가 결과 summary 전문을 PR 코멘트로 게시했다. run이 쌓이면 PR 스레드가 결과 코멘트로 길어진다. 리뷰 대화가 그 사이에 묻힌다.

결과를 보는 경로는 이미 따로 있다. PR 커밋에 붙는 commit status `gha-ci: test_shell`의 초록·빨강 딱지를 누르면 워크플로 run 화면으로 간다. 같은 summary가 거기에 있다. 코멘트는 같은 내용을 한 번 더 쓰는 일이다.

### Implementation

`collect` job에서 PR 코멘트 게시를 없앴다. 삭제한 것은 셋이다.

- step `Post to the PR` — `POST /repos/{repo}/issues/{pr}/comments` 호출.
- `$GITHUB_STEP_SUMMARY`를 `/tmp/summary.md`로 복사하던 줄. 위 step만 이 파일을 읽었다.
- `collect`의 `pull-requests: write` 권한. 위 step만 이 권한을 썼다. `actions: read`는 `Wall clock` step이 쓰므로 남겼다.

바뀐 동작은 하나다. `/run shell`·`/run all`·`/run rerun` 뒤에 PR에 gha-ci 코멘트가 달리지 않는다. 판정과 진입 경로는 그대로다. commit status `gha-ci: test_shell`이 초록·빨강으로 붙는다. 딱지 링크는 run 화면으로 간다. summary 자체는 손대지 않았다.

### Remarks

- 결과를 보려면 PR 커밋의 `gha-ci: test_shell` 딱지를 눌러 run으로 들어간다. 그 run의 Summary가 결과 화면이다.
- 삭제만 한 변경이다. 46줄 삭제, 추가 0줄.
- summary의 `Artifacts:` 경로를 다운로드 링크로 바꾸는 일과, 실패 케이스의 수행 로그를 summary에 넣는 일은 별도 PR로 온다.
