### PR TITLE
[CBRD-27374] add runtime check of select list length against the number of INTO variables for SYS_REFCURSOR- #7868

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
@@ -1562,6 +1562,17 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
     // StmtCursorFetch
     //
 
+    private static String[] tmplCheckSelectListLength =
+            new String[] {
+                "ResultSetMetaData rsmd_%'LEVEL'% = rs.getMetaData();",
+                "if (rsmd_%'LEVEL'% == null) {",
+                "  throw new SQL_ERROR(\"failed to get the result set meta data of the FETCH statement\");",
+                "}",
+                "if (%'INTO-VAR-COUNT'% != rsmd_%'LEVEL'%.getColumnCount()) {",
+                "  throw new SQL_ERROR(\"length of the SELECT list and the nuber of variables in the INTO clause do not match\");",
+                "}"
+            };
+
     private static String[] tmplStmtCursorFetch =
             new String[] {
                 "try { // cursor fetch",
@@ -1570,6 +1581,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                 "  }",
                 "  ResultSet rs = %'CURSOR'%.rs;",
                 "  if (%'CURSOR'%.fetch()) {",
+                "    %'+OPT-CHECK-SELECT-LIST-LENGTH'%",
                 "    %'+SET-INTO-VARIABLES'%",
                 "  }",
                 "} catch (SQLException e) {",
@@ -1596,6 +1608,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
 
             String resultStr;
             if (node.columnTypeList == null) {
+                // cursor is a SYS_REFCURSOR
                 resultStr = String.format("rs.getObject(%d)", i + 1);
             } else {
                 resultStr =
@@ -1618,13 +1631,28 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
     @Override
     public CodeToResolve visitStmtCursorFetch(StmtCursorFetch node) {
 
+        Object optCheckSelectListLength =
+                node.columnTypeList != null
+                        ? ""
+                        : new CodeTemplate(
+                                "Select list length check in StmtCursorFetch",
+                                Misc.UNKNOWN_LINE_COLUMN,
+                                tmplCheckSelectListLength,
+                                "%'LEVEL'%",
+                                Integer.toString(node.id.scope.level),
+                                "%'INTO-VAR-COUNT'%",
+                                Integer.toString(node.intoTargetList.size()));
+
         String[] setIntoTargets = getSetIntoTargetsCode(node);
+
         return new CodeTemplate(
                 "StmtCursorFetch",
                 Misc.getLineColumnOf(node.ctx),
                 tmplStmtCursorFetch,
                 "%'CURSOR'%",
                 node.id.javaCode(),
+                "%'+OPT-CHECK-SELECT-LIST-LENGTH'%",
+                optCheckSelectListLength,
                 "%'+SET-INTO-VARIABLES'%",
                 setIntoTargets);
     }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
@@ -1563,7 +1563,8 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
     //
 
     private static String[] tmplCheckSelectListLength =
-            new String[] {
+            new String[] {"%'CURSOR'%.checkSelectListLength(%'INTO-VAR-COUNT'%);"
+                /*
                 "ResultSetMetaData rsmd_%'LEVEL'% = rs.getMetaData();",
                 "if (rsmd_%'LEVEL'% == null) {",
                 "  throw new SQL_ERROR(\"failed to get the result set meta data of the FETCH statement\");",
@@ -1571,6 +1572,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                 "if (%'INTO-VAR-COUNT'% != rsmd_%'LEVEL'%.getColumnCount()) {",
                 "  throw new SQL_ERROR(\"length of the SELECT list and the number of variables in the INTO clause do not match\");",
                 "}"
+                 */
             };
 
     private static String[] tmplStmtCursorFetch =
@@ -1579,9 +1581,9 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                 "  if (%'CURSOR'% == null) {",
                 "    throw new INVALID_CURSOR(\"the cursor is NULL\");",
                 "  }",
+                "  %'+OPT-CHECK-SELECT-LIST-LENGTH'%",
                 "  ResultSet rs = %'CURSOR'%.rs;",
                 "  if (%'CURSOR'%.fetch()) {",
-                "    %'+OPT-CHECK-SELECT-LIST-LENGTH'%",
                 "    %'+SET-INTO-VARIABLES'%",
                 "  }",
                 "} catch (SQLException e) {",
@@ -1638,8 +1640,6 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                                 "Select list length check in StmtCursorFetch",
                                 Misc.UNKNOWN_LINE_COLUMN,
                                 tmplCheckSelectListLength,
-                                "%'LEVEL'%",
-                                Integer.toString(node.id.scope.level),
                                 "%'INTO-VAR-COUNT'%",
                                 Integer.toString(node.intoTargetList.size()));
 
@@ -1649,10 +1649,10 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                 "StmtCursorFetch",
                 Misc.getLineColumnOf(node.ctx),
                 tmplStmtCursorFetch,
-                "%'CURSOR'%",
-                node.id.javaCode(),
                 "%'+OPT-CHECK-SELECT-LIST-LENGTH'%",
                 optCheckSelectListLength,
+                "%'CURSOR'%",
+                node.id.javaCode(),
                 "%'+SET-INTO-VARIABLES'%",
                 setIntoTargets);
     }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
@@ -1562,19 +1562,6 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
     // StmtCursorFetch
     //
 
-    private static String[] tmplCheckSelectListLength =
-            new String[] {"%'CURSOR'%.checkSelectListLength(%'INTO-VAR-COUNT'%);"
-                /*
-                "ResultSetMetaData rsmd_%'LEVEL'% = rs.getMetaData();",
-                "if (rsmd_%'LEVEL'% == null) {",
-                "  throw new SQL_ERROR(\"failed to get the result set meta data of the FETCH statement\");",
-                "}",
-                "if (%'INTO-VAR-COUNT'% != rsmd_%'LEVEL'%.getColumnCount()) {",
-                "  throw new SQL_ERROR(\"length of the SELECT list and the number of variables in the INTO clause do not match\");",
-                "}"
-                 */
-            };
-
     private static String[] tmplStmtCursorFetch =
             new String[] {
                 "try { // cursor fetch",
@@ -1639,7 +1626,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                         : new CodeTemplate(
                                 "Select list length check in StmtCursorFetch",
                                 Misc.UNKNOWN_LINE_COLUMN,
-                                tmplCheckSelectListLength,
+                                "%'CURSOR'%.checkSelectListLength(%'INTO-VAR-COUNT'%);",
                                 "%'INTO-VAR-COUNT'%",
                                 Integer.toString(node.intoTargetList.size()));
 

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
@@ -1569,7 +1569,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                 "  throw new SQL_ERROR(\"failed to get the result set meta data of the FETCH statement\");",
                 "}",
                 "if (%'INTO-VAR-COUNT'% != rsmd_%'LEVEL'%.getColumnCount()) {",
-                "  throw new SQL_ERROR(\"length of the SELECT list and the nuber of variables in the INTO clause do not match\");",
+                "  throw new SQL_ERROR(\"length of the SELECT list and the number of variables in the INTO clause do not match\");",
                 "}"
             };
 

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -613,6 +613,7 @@ public class SpLib {
         public int rowCount = -1;
 
         private PreparedStatement myStmt;
+        private int selectListLength = -1;
 
         public Query(String query) {
             this(query, false);
@@ -697,6 +698,8 @@ public class SpLib {
             }
 
             try {
+                selectListLength = -1;
+
                 if (myStmt == null) {
                     // no need to close the statement because it was declared and is closed outside
                     // of this Query close only the result set.
@@ -790,6 +793,36 @@ public class SpLib {
                 rowCount = rs.getRow();
             } catch (SQLException e) {
                 throw new SQL_ERROR(e.getMessage());
+            }
+        }
+
+        // Only called by FETCH statements with SYS_REFCURSOR.
+        // Runtime check of select list length against the count of INTO variables.
+        // The check is done during the compile time for ordinary cursors.
+        public void checkSelectListLength(int intoVarCount) {
+            if (!isOpen()) {
+                throw new INVALID_CURSOR("attempted to read a meta data of an unopened cursor");
+            }
+
+            try {
+                if (selectListLength < 0) {
+                    ResultSetMetaData rsmd = myStmt.getMetaData();
+                    if (rsmd == null) {
+                        throw new SQL_ERROR(
+                                "failed to get the result set meta data of the prepared statement");
+                    }
+                    selectListLength = rsmd.getColumnCount();
+                }
+            } catch (SQLException e) {
+                throw new SQL_ERROR(e.getMessage());
+            }
+
+            if (selectListLength != intoVarCount) {
+                throw new SQL_ERROR(
+                        String.format(
+                                "length (%d) of the SELECT list and "
+                                        + "the number (%d) of variables in the INTO clause do not match",
+                                selectListLength, intoVarCount));
             }
         }
     }


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27374>

### Purpose

OPEN FOR 로 연 SYS_REFCURSOR 커서의 select list 길이를 FETCH 문 실행할 때 검사합니다.
그 길이는 INTO 절 안의 변수 갯수와 일치해야 합니다.
참고: SYS_REFCURSOR 가 아닌 일반 커서의 경우는 컴파일 시간에 길이 검사를 하고 있습니다.

### Implementation

develop 브랜치의 변경을 git cherry-pick 로 동일하게 반영했습니다. 


