### PR TITLE
[CBRD-27386] Multiply correlated subquery cost by the rows that reach the subquery term

### DIFF
--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -836,13 +836,16 @@ qo_term_is_evaluated_before (QO_TERM * term1, QO_TERM * term2)
  *
  * Note: The sarg terms of a scan are split by is_normal_access_term ()/is_normal_if_term () in plan_generation.c:
  *   a term containing a subquery (or of class QO_TC_OTHER) goes to the if-predicate, every other term to the access
- *   predicate of the scan. The if-predicate is evaluated only for the rows that passed the access predicate, and
- *   its terms are AND-ed with short-circuit in the order given by qo_term_is_evaluated_before (). So the subquery
- *   term is evaluated for scan_rows * (selectivity of all access terms) * (selectivity of the if-predicate terms
- *   evaluated before it) rows. Neither the subquery term itself nor the if-predicate terms evaluated after it
- *   reduce the number of evaluations. The index range and key filter terms of an index scan are already reflected
- *   in scan_rows. For other plans, or when the subquery is not attached to a sarg term of this scan, it is assumed
- *   to be evaluated for every row of scan_rows.
+ *   predicate of the scan (the after-join classes never reach a scan plan; they are listed here only to mirror
+ *   is_normal_access_term ()). An OR-derived restriction that make_pred_from_plan () drops from the data filter
+ *   (too expensive, or letting most rows through) is not evaluated at all and must not be counted either. The
+ *   if-predicate is evaluated only for the rows that passed the access predicate, and its terms are AND-ed with
+ *   short-circuit in the order given by qo_term_is_evaluated_before (). So the subquery term is evaluated for
+ *   scan_rows * (selectivity of all access terms) * (selectivity of the if-predicate terms evaluated before it)
+ *   rows. Neither the subquery term itself nor the if-predicate terms evaluated after it reduce the number of
+ *   evaluations. The index range and key filter terms of an index scan are already reflected in scan_rows. For
+ *   other plans, or when the subquery is not attached to a sarg term of this scan, it is assumed to be evaluated
+ *   for every row of scan_rows.
  */
 static double
 qo_plan_subquery_eval_rows (QO_PLAN * plan, int subq_idx)
@@ -888,14 +891,24 @@ qo_plan_subquery_eval_rows (QO_PLAN * plan, int subq_idx)
 	  continue;
 	}
 
-      if (bitset_is_empty (&(QO_TERM_SUBQUERIES (term))) && QO_TERM_CLASS (term) != QO_TC_OTHER)
+      /* dropped from the data filter by make_pred_from_plan (): not evaluated at the scan */
+      if (QO_TERM_IS_FLAGED (term, QO_TERM_OR_DERIVED_EXPENSIVE)
+	  || (QO_TERM_IS_FLAGED (term, QO_TERM_OR_DERIVED) && QO_TERM_SELECTIVITY (term) > 0.5))
 	{
-	  /* access predicate term: always evaluated before the if-predicate */
-	  sel *= QO_TERM_SELECTIVITY (term);
+	  continue;
 	}
-      else if (qo_term_is_evaluated_before (term, subq_term))
+
+      if (!bitset_is_empty (&(QO_TERM_SUBQUERIES (term))) || QO_TERM_CLASS (term) == QO_TC_OTHER)
 	{
-	  /* if-predicate term evaluated before the subquery term */
+	  /* if-predicate term (is_normal_if_term ()): counts only if evaluated before the subquery term */
+	  if (qo_term_is_evaluated_before (term, subq_term))
+	    {
+	      sel *= QO_TERM_SELECTIVITY (term);
+	    }
+	}
+      else if (QO_TERM_CLASS (term) != QO_TC_AFTER_JOIN && QO_TERM_CLASS (term) != QO_TC_TOTALLY_AFTER_JOIN)
+	{
+	  /* access predicate term (is_normal_access_term ()): always evaluated before the if-predicate */
 	  sel *= QO_TERM_SELECTIVITY (term);
 	}
     }

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -188,6 +188,8 @@ static void qo_follow_walk (QO_PLAN *, void (*)(QO_PLAN *, void *), void *, void
 
 static void qo_plan_compute_cost (QO_PLAN *);
 static void qo_plan_compute_subquery_cost (PT_NODE *, double *, double *);
+static bool qo_term_is_evaluated_before (QO_TERM * term1, QO_TERM * term2);
+static double qo_plan_subquery_eval_rows (QO_PLAN * plan, int subq_idx);
 static void qo_sscan_cost (QO_PLAN *);
 static void qo_iscan_cost (QO_PLAN *);
 static bool qo_index_forbids_key_filter (QO_INDEX_ENTRY *);
@@ -756,45 +758,153 @@ qo_plan_compute_cost (QO_PLAN * plan)
   QO_ENV *env;
   QO_SUBQUERY *subq;
   PT_NODE *query;
-  double temp_cpu_cost, temp_io_cost;
-  double subq_cpu_cost, subq_io_cost;
+  double subq_cpu_cost, subq_io_cost, eval_rows;
   int i;
   BITSET_ITERATOR iter;
 
-  /* When computing the cost for a WORST_PLAN, we'll get in here without a backing info node; just work around it. */
-  env = plan->info ? (plan->info)->env : NULL;
-  subq_cpu_cost = subq_io_cost = 0.0;
+  /* This computes the specific cost characteristics for each plan. */
+  (*(plan->vtbl)->cost_fn) (plan);
 
-  /* Compute the costs for all of the subqueries. Each of the pinned subqueries is intended to be evaluated once for
-   * each row produced by this plan; the cost of each such evaluation in the fixed cost of the subquery plus one trip
-   * through the result, i.e.,
+  /* When computing the cost for a WORST_PLAN, we'll get in here without a backing info node; just work around it. */
+  if (plan->info == NULL)
+    {
+      return;
+    }
+  env = (plan->info)->env;
+
+  /* Now add in the costs for all of the subqueries. The cost of each evaluation is the fixed cost of the subquery
+   * plus one trip through the result, i.e.,
    *
    * QO_PLAN_FIXED_COST(subplan) + QO_PLAN_ACCESS_COST(subplan)
    *
    * The cost info for the subplan has (probably) been squirreled away in a QO_SUMMARY structure reachable from the
    * original select node.
+   *
+   * A pinned subquery is not evaluated for every scanned row: a term containing a subquery is never put on the
+   * access predicate of the scan but on the if-predicate, which is evaluated only for the rows that survived the
+   * access predicate. Multiply the cost by that estimated number of evaluations (see qo_plan_subquery_eval_rows ()).
    */
-
   for (i = bitset_iterate (&(plan->subqueries), &iter); i != -1; i = bitset_next_member (&iter))
     {
-      subq = env ? &env->subqueries[i] : NULL;
-      query = subq ? subq->node : NULL;
-      qo_plan_compute_subquery_cost (query, &temp_cpu_cost, &temp_io_cost);
-      subq_cpu_cost += temp_cpu_cost;
-      subq_io_cost += temp_io_cost;
+      subq = &env->subqueries[i];
+      query = subq->node;
+      qo_plan_compute_subquery_cost (query, &subq_cpu_cost, &subq_io_cost);
+      eval_rows = qo_plan_subquery_eval_rows (plan, i);
+
+      plan->variable_cpu_cost += eval_rows * subq_cpu_cost;
+      plan->variable_io_cost += eval_rows * subq_io_cost;
     }
+}
 
-  /* This computes the specific cost characteristics for each plan. */
-  (*(plan->vtbl)->cost_fn) (plan);
-
-  /* Now add in the subquery costs; this cost is incurred for each row produced by this plan, so multiply it by the
-   * estimated scan_rows and add it to the access cost.
-   */
-  if (plan->info)
+/*
+ * qo_term_is_evaluated_before () - Tells whether term1 is evaluated before term2 when both are AND-ed terms of the
+ *				    same predicate
+ *   return: true if term1 is evaluated first
+ *   term1(in):
+ *   term2(in):
+ *
+ * Note: This mirrors the ordering used by make_pred_from_bitset () in plan_generation.c, which is the order the
+ *   terms of a predicate are evaluated in at run time (eval_pred () short-circuits an AND on the first false
+ *   operand): pred_order desc, selectivity asc, rank asc, and finally the term index for a complete tie.
+ */
+static bool
+qo_term_is_evaluated_before (QO_TERM * term1, QO_TERM * term2)
+{
+  if (QO_TERM_PRED_ORDER (term1) != QO_TERM_PRED_ORDER (term2))
     {
-      plan->variable_cpu_cost += (plan->info)->scan_rows * subq_cpu_cost;
-      plan->variable_io_cost += (plan->info)->scan_rows * subq_io_cost;
+      return QO_TERM_PRED_ORDER (term1) > QO_TERM_PRED_ORDER (term2);
     }
+
+  if (QO_TERM_SELECTIVITY (term1) != QO_TERM_SELECTIVITY (term2))
+    {
+      return QO_TERM_SELECTIVITY (term1) < QO_TERM_SELECTIVITY (term2);
+    }
+
+  if (QO_TERM_RANK (term1) != QO_TERM_RANK (term2))
+    {
+      return QO_TERM_RANK (term1) < QO_TERM_RANK (term2);
+    }
+
+  return QO_TERM_IDX (term1) < QO_TERM_IDX (term2);
+}
+
+/*
+ * qo_plan_subquery_eval_rows () - Estimate how many times a pinned subquery is evaluated by the plan
+ *   return: estimated number of evaluations (an expectation; may be fractional)
+ *   plan(in): plan the subquery is pinned to
+ *   subq_idx(in): index of the subquery in env->subqueries
+ *
+ * Note: The sarg terms of a scan are split by is_normal_access_term ()/is_normal_if_term () in plan_generation.c:
+ *   a term containing a subquery (or of class QO_TC_OTHER) goes to the if-predicate, every other term to the access
+ *   predicate of the scan. The if-predicate is evaluated only for the rows that passed the access predicate, and
+ *   its terms are AND-ed with short-circuit in the order given by qo_term_is_evaluated_before (). So the subquery
+ *   term is evaluated for scan_rows * (selectivity of all access terms) * (selectivity of the if-predicate terms
+ *   evaluated before it) rows. Neither the subquery term itself nor the if-predicate terms evaluated after it
+ *   reduce the number of evaluations. The index range and key filter terms of an index scan are already reflected
+ *   in scan_rows. For other plans, or when the subquery is not attached to a sarg term of this scan, it is assumed
+ *   to be evaluated for every row of scan_rows.
+ */
+static double
+qo_plan_subquery_eval_rows (QO_PLAN * plan, int subq_idx)
+{
+  QO_ENV *env;
+  QO_TERM *term, *subq_term;
+  BITSET_ITERATOR iter;
+  double sel;
+  int t;
+
+  assert (plan->info != NULL);
+  env = (plan->info)->env;
+
+  if (plan->plan_type != QO_PLANTYPE_SCAN)
+    {
+      return (plan->info)->scan_rows;
+    }
+
+  /* find the sarg term of this scan which contains the subquery */
+  subq_term = NULL;
+  for (t = bitset_iterate (&(plan->sarged_terms), &iter); t != -1; t = bitset_next_member (&iter))
+    {
+      term = QO_ENV_TERM (env, t);
+      if (BITSET_MEMBER (QO_TERM_SUBQUERIES (term), subq_idx))
+	{
+	  subq_term = term;
+	  break;
+	}
+    }
+
+  if (subq_term == NULL)
+    {
+      return (plan->info)->scan_rows;
+    }
+
+  /* rows reaching the subquery term = scan_rows * selectivity of the sarg terms evaluated before it */
+  sel = 1.0;
+  for (t = bitset_iterate (&(plan->sarged_terms), &iter); t != -1; t = bitset_next_member (&iter))
+    {
+      term = QO_ENV_TERM (env, t);
+      if (term == subq_term || QO_IS_FAKE_TERM (term))
+	{
+	  continue;
+	}
+
+      if (bitset_is_empty (&(QO_TERM_SUBQUERIES (term))) && QO_TERM_CLASS (term) != QO_TC_OTHER)
+	{
+	  /* access predicate term: always evaluated before the if-predicate */
+	  sel *= QO_TERM_SELECTIVITY (term);
+	}
+      else if (qo_term_is_evaluated_before (term, subq_term))
+	{
+	  /* if-predicate term evaluated before the subquery term */
+	  sel *= QO_TERM_SELECTIVITY (term);
+	}
+    }
+
+  /* No lower bound: this is an expectation. Flooring it at one evaluation would charge the inner side of a
+   * nested-loop join (scan_rows of 1 per probe) with a full evaluation per probe even when almost no probed row
+   * reaches the subquery term.
+   */
+  return (plan->info)->scan_rows * sel;
 }
 
 /*


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27386

## Purpose
CBRD-26403(#6667)에서 상관 부질의 비용을 `subquery cost × scan_rows`(sscan은 테이블 전체 행 수, iscan은 힙 접근 행 수)로 바꾸었으나, 힙 sarg 필터를 전혀 반영하지 않아 비용이 과대 산정됩니다(RND-2834, 11.4.6 내부 릴리즈에서 보고).

실제 실행에서 부질의를 포함한 항은 `plan_generation.c:is_normal_access_term()`에 의해 스캔의 access predicate가 아니라 **if-predicate**에 놓이고, if-predicate는 access predicate를 통과한 행에 대해서만 평가됩니다. 즉 부질의는 다른 sarg 항을 모두 통과한 행에 대해서만 실행되는데, 비용은 스캔 행 수 전체에 부과되고 있었습니다.

- 티켓 CASE 1: 실제 부질의 실행 1회, cost 30116 (11.4.5: 75)
- 비용 표시 왜곡에 그치지 않고 플랜이 바뀝니다. sscan에는 전체 행 수, iscan에는 인덱스 선택도만 곱해지는 비대칭 때문에, 부질의가 붙으면 선택도가 나쁜 인덱스(sel 0.5)의 iscan이 sscan을 이깁니다(아래 W03).

## Implementation
`query_planner.c`
- `qo_plan_subquery_eval_rows()` 추가: 스캔 플랜에 pin된 부질의의 예상 실행 횟수를 `scan_rows × Π sel(access predicate 항) × Π sel(if-predicate 항 중 해당 항보다 먼저 평가되는 항)`으로 산정합니다(하한 1). access/if 분리는 `is_normal_access_term()`과 동일 기준(부질의 포함 또는 `QO_TC_OTHER`면 if-predicate), if-predicate 내부 순서는 `make_pred_from_bitset()`과 동일 기준(pred_order desc, selectivity asc, rank asc, term idx)을 `qo_term_is_evaluated_before()`로 재현합니다.
- `qo_plan_compute_cost()`: 부질의별로 위 실행 횟수를 곱해 가산합니다. 이를 위해 `cost_fn` 호출을 앞으로 옮겼습니다(`scan_rows`가 `cost_fn`에서 설정됨). 스캔이 아닌 플랜이나 sarg 항에 붙지 않은 부질의는 기존대로 `scan_rows`를 곱합니다.
- RND-2640(CBRD-26403의 동기) 형태, 즉 부질의 항 외 sarg가 없는 테이블은 배수가 그대로 `scan_rows`이므로 보호가 유지됩니다(W11).

평가 순서 모델은 실측으로 확인했습니다(develop, SA 모드, ta 10만 행 / tb 20만 행):
| 질의 | 시간 | 해석 |
|---|---|---|
| 부질의 단독 | 0.354s | 10만 회 실행 |
| `k1 IN (1,2)`(sel 0.19) AND 부질의 | 0.097s | sel이 부질의(0.1)보다 커도 access 항이 먼저 평가 |
| `k3<100` AND C(false) AND E(고비용) | 0.06s | if-predicate 내 short-circuit 존재 |
| `k3<100` AND E(고비용) AND C(false) | 3.0s | if-predicate 내 순서 = sel asc → term idx |

## Remarks
**A/B 검증 (upstream develop a557b8a8c base vs fix, 동일 DB, SA 모드)**

화이트박스 34케이스(결과 전부 동일):
| 케이스 | base cost | fix cost | 플랜 |
|---|---|---|---|
| W01 티켓 CASE1 (sscan, val_text sel 1e-4) | 30116 | 69 | 동일 (11.4.5: 75) |
| W02 티켓 CASE2 (iscan + 힙필터) | 315 | 18 | 동일 (11.4.5: 11) |
| W03 flag(sel 0.5) 인덱스 + 유니크 텍스트 + 부질의 | 598040 (iscan) | 1108 (sscan) | **sscan으로 복귀**, 부질의 없는 동일 질의(1105)와 일치. 실측 0.080s → 0.043s |
| W04 flag=1 (sel 0.95) + 부질의 | 301164 | 286256 | 동일 |
| W11 RND-2640 형태(부질의 항만 있는 테이블 조인) | 204 | 204 | 동일 (드라이빙 유지) |
| W14 부질의 2개 tie | 601414 | 330963 | 동일 |
| W26 부질의 항만 있는 iscan | 287516 | 287516 | 동일 |
| W27 `k1 IN` (sel 0.19) + 부질의 | 301164 | 57758 | 동일 |

랜덤 블랙박스 퍼저(상관 부질의 1~2개 + 무작위 필터 0~3개, 조인/뷰/OR/EXISTS/IN/LIMIT/GROUP BY 혼합): seed 3종 × 600건 = 1800건(base develop vs fix, 동일 DB)
| 항목 | 결과 |
|---|---|
| 결과(row) 불일치 | 0 |
| 에러 불일치 | 0 |
| 플랜 동일 질의에서 비용 증가 | 0 |
| 플랜 변경 | 90건 (iscan→sscan 25, 조인순서 13, ORDER BY LIMIT 41, 기타 11) |

디버그 빌드(assert 활성)로 화이트박스 + 퍼저 600건 추가 실행: assert 발화·크래시 0, 결과 불일치 0 (화이트박스 34 + 퍼저 600건).

플랜이 바뀐 질의의 실행 시간 A/B: 플랜이 바뀐 127건(하한 제거 전 집계 기준)을 양쪽에서 2회 실행해 2회차 시간 비교(웜캐시, 10ms 초과 차이만 집계):
| 플랜 변경 유형 | 건수 | fix 느림 | fix 빠름 | 비고 |
|---|---|---|---|---|
| iscan → sscan | 25 | 0 | 16 | 선택도 나쁜 인덱스 회피(W03 유형) |
| 조인 순서/방식 | 13 | 0 | 3 | 처음 `MAX(1, …)` 하한을 두었을 때 19건이 느려졌는데(nl-join inner는 probe당 scan_rows≈1이라 매 probe에 부질의 1회가 과금됨), 하한을 제거하니 38건이 base와 같은 플랜으로 돌아오고 회귀 0 |
| ORDER BY … LIMIT | 41 | **32** | 4 | 아래 설명 |
| 기타 | 10 | 1 | 4 | |

**남은 회귀(ORDER BY … LIMIT)**: base에서는 부질의 비용이 부풀려져 orderby-skip pk iscan(예: 604121)과 정렬 플랜(10462)의 비용비가 10배를 넘어 비용으로 결정됐는데, fix에서 비용이 정확해지자(2649 vs 672) 두 대안이 `RBO_CHECK_LIMIT_RATIO`(10배) 밴드 안으로 들어와 `qo_plan_cmp()`의 규칙(LIMIT이 있으면 orderby-skip 인덱스 선호)이 비용을 덮어쓰고 pk 전체 워크 플랜을 고릅니다(10만 행 테이블에서 0.002s → 0.045s). fix의 비용 자체는 정렬 플랜이 4배 저렴하다고 올바르게 말하고 있고, 부질의가 없는 같은 질의도 정렬 플랜을 고르므로, 이는 이 PR이 드러낸 기존 RBO 규칙의 한계입니다. 이 PR에서는 다루지 않고 후속 이슈로 분리하는 것을 제안합니다.

**영향 범위**: 상관 부질의가 WHERE sarg에 있는 질의의 비용/플랜만 영향. 조인 플랜 및 select list 부질의는 변화 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
