### PR TITLE
[CBRD-27387] The processing of  (QC/CANCEL/X1) takes precedence over authentication, ACL, and SSL.

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -840,6 +840,21 @@ receiver_thr_f (void *arg)
       setsockopt (clt_sock_fd, IPPROTO_TCP, TCP_NODELAY, (char *) &one, sizeof (one));
       ut_set_keepalive (clt_sock_fd);
 
+      /* ACL check must run before any protocol handling (PING/ST/QC/CANCEL/X1 included) so that an
+       * unauthorized IP cannot reach the pre-auth query-cancel path. */
+      if (v3_acl != NULL)
+	{
+	  unsigned char ip_addr[4];
+
+	  memcpy (ip_addr, &(clt_sock_addr.sin_addr), 4);
+
+	  if (uw_acl_check (ip_addr) < 0)
+	    {
+	      CLOSE_SOCKET (clt_sock_fd);
+	      continue;
+	    }
+	}
+
       cas_client_type = CAS_CLIENT_NONE;
 
       /* read header */
@@ -936,9 +951,16 @@ receiver_thr_f (void *arg)
 		  if (shm_appl->as_info[i].service_flag == SERVICE_ON && shm_appl->as_info[i].pid == pid
 		      && shm_appl->as_info[i].uts_status == UTS_STATUS_BUSY)
 		    {
+		      /* Sender IP must always match the session owner's IP, regardless of which
+		       * cancel variant (QC/CANCEL/X1) was used. */
+		      if (memcmp (&shm_appl->as_info[i].cas_clt_ip, &clt_sock_addr.sin_addr, 4) != 0)
+			{
+			  continue;
+			}
+
+		      /* When the sender supplied a client port (QC only), it must also match. */
 		      if (cas_req_header[0] == 'Q' && client_port > 0
-			  && shm_appl->as_info[i].cas_clt_port != client_port
-			  && memcmp (&shm_appl->as_info[i].cas_clt_ip, &clt_sock_addr.sin_addr, 4) != 0)
+			  && shm_appl->as_info[i].cas_clt_port != client_port)
 			{
 			  continue;
 			}
@@ -1009,20 +1031,6 @@ receiver_thr_f (void *arg)
 	  if (client_version < CAS_MAKE_VER (8, 2, 0))
 	    {
 	      CAS_SEND_ERROR_CODE (clt_sock_fd, CAS_ER_COMMUNICATION);
-	      CLOSE_SOCKET (clt_sock_fd);
-	      continue;
-	    }
-	}
-
-      if (v3_acl != NULL)
-	{
-	  unsigned char ip_addr[4];
-
-	  memcpy (ip_addr, &(clt_sock_addr.sin_addr), 4);
-
-	  if (uw_acl_check (ip_addr) < 0)
-	    {
-	      send_error_to_driver (clt_sock_fd, CAS_ER_NOT_AUTHORIZED_CLIENT, cas_req_header);
 	      CLOSE_SOCKET (clt_sock_fd);
 	      continue;
 	    }


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27387>

### Purpose

CUBRID 브로커(cub_broker, 기본 리슨 0.0.0.0:30000)의 receiver_thr_f()가 접속 직후 10바이트 헤더의 query-cancel 요청(QC/CANCEL/X1)을 인증·SSL·ACL 검사보다 먼저 처리하는 오류와 발신자 검증 로직에도 두 가지 결함이 있어, DB 자격증명이 없는 원격 공격자가 PID만 알면 타인 세션의 실행 중 쿼리를 강제 중단시킬 수 있고, 응답 코드로 특정 CAS의 busy 상태를 무인증으로 식별이 가능한 문제를 해결.

### Implementation

1. ACL 검사를 PING / ST / QC 앞으로 이동
2. 발신자 IP 검증을 세 변형 전부에 적용

### Remarks

11.4 이하 버전에도 백포트해야 함.
