### PR TITLE
[CBRD-27389] Added session ID validation to  — Receipt and validation of CCI/JDBC extended protocols

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -840,6 +840,21 @@ receiver_thr_f (void *arg)
       setsockopt (clt_sock_fd, IPPROTO_TCP, TCP_NODELAY, (char *) &one, sizeof (one));
       ut_set_keepalive (clt_sock_fd);
 
+      /* ACL check must run before any protocol handling (PING/ST/QC/CANCEL/X1 included) so that an
+       * unauthorized IP cannot reach the pre-auth query-cancel path. */
+      if (v3_acl != NULL)
+	{
+	  unsigned char ip_addr[4];
+
+	  memcpy (ip_addr, &(clt_sock_addr.sin_addr), 4);
+
+	  if (uw_acl_check (ip_addr) < 0)
+	    {
+	      CLOSE_SOCKET (clt_sock_fd);
+	      continue;
+	    }
+	}
+
       cas_client_type = CAS_CLIENT_NONE;
 
       /* read header */
@@ -903,6 +918,11 @@ receiver_thr_f (void *arg)
        *   |COMMAND("QC",2)|PID(4)|CLIENT_PORT(2)|RESERVED(2)|
        *
        *   CLIENT_PORT can be 0 if the client failed to get its local port.
+       *
+       * - Optionally, when the sender sets the BROKER_SUPPORT_SESSION_CANCEL bit
+       *   (in cas_req_header[8] for "QC", in cas_req_header[3] for "X1"), a
+       *   SESSION_ID_SIZE-byte CAS session id is appended right after the header
+       *   above and is verified against the CAS-issued session id (see KVE-2026-1827).
        */
       else if (strncmp (cas_req_header, "QC", 2) == 0 || strncmp (cas_req_header, "CANCEL", 6) == 0
 	       || strncmp (cas_req_header, "X1", 2) == 0)
@@ -911,6 +931,8 @@ receiver_thr_f (void *arg)
 #if !defined(WINDOWS)
 	  int pid, i;
 	  unsigned short client_port = 0;
+	  bool has_session_id = false;
+	  unsigned int req_session_id = 0;
 #endif
 
 #if !defined(WINDOWS)
@@ -920,11 +942,29 @@ receiver_thr_f (void *arg)
 	      memcpy ((char *) &client_port, cas_req_header + 6, 2);
 	      pid = ntohl (pid);
 	      client_port = ntohs (client_port);
+	      has_session_id = ((cas_req_header[8] & BROKER_SUPPORT_SESSION_CANCEL) != 0);
 	    }
 	  else
 	    {
 	      memcpy ((char *) &pid, cas_req_header + 6, 4);
 	      pid = ntohl (pid);
+	      if (cas_req_header[0] == 'X')
+		{
+		  has_session_id = ((cas_req_header[3] & BROKER_SUPPORT_SESSION_CANCEL) != 0);
+		}
+	    }
+
+	  if (has_session_id)
+	    {
+	      int session_read_len;
+
+	      session_read_len = read_nbytes_from_client (clt_sock_fd, (char *) &req_session_id, SESSION_ID_SIZE);
+	      if (session_read_len < 0)
+		{
+		  CLOSE_SOCKET (clt_sock_fd);
+		  continue;
+		}
+	      req_session_id = ntohl (req_session_id);
 	    }
 
 	  ret_code = CAS_ER_QUERY_CANCEL;
@@ -936,9 +976,24 @@ receiver_thr_f (void *arg)
 		  if (shm_appl->as_info[i].service_flag == SERVICE_ON && shm_appl->as_info[i].pid == pid
 		      && shm_appl->as_info[i].uts_status == UTS_STATUS_BUSY)
 		    {
+		      /* Sender IP must always match the session owner's IP, regardless of which
+		       * cancel variant (QC/CANCEL/X1) was used. */
+		      if (memcmp (&shm_appl->as_info[i].cas_clt_ip, &clt_sock_addr.sin_addr, 4) != 0)
+			{
+			  continue;
+			}
+
+		      /* When the sender supplied a client port (QC only), it must also match. */
 		      if (cas_req_header[0] == 'Q' && client_port > 0
-			  && shm_appl->as_info[i].cas_clt_port != client_port
-			  && memcmp (&shm_appl->as_info[i].cas_clt_ip, &clt_sock_addr.sin_addr, 4) != 0)
+			  && shm_appl->as_info[i].cas_clt_port != client_port)
+			{
+			  continue;
+			}
+
+		      /* When the client advertised session-token support, the CAS-issued session id
+		       * is the authoritative check; the IP/port checks above remain as defense-in-depth
+		       * for clients that have not been upgraded yet. */
+		      if (has_session_id && req_session_id != shm_appl->as_info[i].session_id)
 			{
 			  continue;
 			}
@@ -1009,20 +1064,6 @@ receiver_thr_f (void *arg)
 	  if (client_version < CAS_MAKE_VER (8, 2, 0))
 	    {
 	      CAS_SEND_ERROR_CODE (clt_sock_fd, CAS_ER_COMMUNICATION);
-	      CLOSE_SOCKET (clt_sock_fd);
-	      continue;
-	    }
-	}
-
-      if (v3_acl != NULL)
-	{
-	  unsigned char ip_addr[4];
-
-	  memcpy (ip_addr, &(clt_sock_addr.sin_addr), 4);
-
-	  if (uw_acl_check (ip_addr) < 0)
-	    {
-	      send_error_to_driver (clt_sock_fd, CAS_ER_NOT_AUTHORIZED_CLIENT, cas_req_header);
 	      CLOSE_SOCKET (clt_sock_fd);
 	      continue;
 	    }

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -840,21 +840,6 @@ receiver_thr_f (void *arg)
       setsockopt (clt_sock_fd, IPPROTO_TCP, TCP_NODELAY, (char *) &one, sizeof (one));
       ut_set_keepalive (clt_sock_fd);
 
-      /* ACL check must run before any protocol handling (PING/ST/QC/CANCEL/X1 included) so that an
-       * unauthorized IP cannot reach the pre-auth query-cancel path. */
-      if (v3_acl != NULL)
-	{
-	  unsigned char ip_addr[4];
-
-	  memcpy (ip_addr, &(clt_sock_addr.sin_addr), 4);
-
-	  if (uw_acl_check (ip_addr) < 0)
-	    {
-	      CLOSE_SOCKET (clt_sock_fd);
-	      continue;
-	    }
-	}
-
       cas_client_type = CAS_CLIENT_NONE;
 
       /* read header */
@@ -863,6 +848,24 @@ receiver_thr_f (void *arg)
 	{
 	  CLOSE_SOCKET (clt_sock_fd);
 	  continue;
+	}
+
+      /* ACL check must run before any protocol handling (PING/ST/QC/CANCEL/X1 included) so that an
+       * unauthorized IP cannot reach the pre-auth query-cancel path. It is placed right here, as soon
+       * as the header is available and before any command-specific branch below, so a rejected client
+       * still gets the usual CAS_ER_NOT_AUTHORIZED_CLIENT response instead of a bare disconnect. */
+      if (v3_acl != NULL)
+	{
+	  unsigned char ip_addr[4];
+
+	  memcpy (ip_addr, &(clt_sock_addr.sin_addr), 4);
+
+	  if (uw_acl_check (ip_addr) < 0)
+	    {
+	      send_error_to_driver (clt_sock_fd, CAS_ER_NOT_AUTHORIZED_CLIENT, cas_req_header);
+	      CLOSE_SOCKET (clt_sock_fd);
+	      continue;
+	    }
 	}
 
       if (strncmp (cas_req_header, "PING", 4) == 0)
@@ -922,7 +925,16 @@ receiver_thr_f (void *arg)
        * - Optionally, when the sender sets the BROKER_SUPPORT_SESSION_CANCEL bit
        *   (in cas_req_header[8] for "QC", in cas_req_header[3] for "X1"), a
        *   SESSION_ID_SIZE-byte CAS session id is appended right after the header
-       *   above and is verified against the CAS-issued session id (see KVE-2026-1827).
+       *   above and is verified against the CAS-issued session id.
+       *   That bit is set by the (unauthenticated) sender of this very cancel request, so
+       *   by itself it cannot force the check to be mandatory: a forged request can simply
+       *   omit it. Whether it is actually required is instead decided from the TARGET
+       *   session's own recorded clt_version (shm_appl->as_info[i].clt_version), which was
+       *   set from that session's own real connect handshake and so cannot be forged by an
+       *   unrelated cancel request. Once a session's clt_version is PROTOCOL_V13 or later,
+       *   a QC/X1 cancel for it must carry a matching session id; older sessions keep using
+       *   the legacy IP/port-only check. Legacy CANCEL never carries a session id and always
+       *   uses the IP-only check.
        */
       else if (strncmp (cas_req_header, "QC", 2) == 0 || strncmp (cas_req_header, "CANCEL", 6) == 0
 	       || strncmp (cas_req_header, "X1", 2) == 0)
@@ -994,6 +1006,21 @@ receiver_thr_f (void *arg)
 		       * is the authoritative check; the IP/port checks above remain as defense-in-depth
 		       * for clients that have not been upgraded yet. */
 		      if (has_session_id && req_session_id != shm_appl->as_info[i].session_id)
+			{
+			  continue;
+			}
+
+		      /* has_session_id is a bit the sender sets on this very (unauthenticated) cancel
+		       * request, so an attacker who otherwise matches the IP/port checks above could
+		       * defeat the session-id check entirely just by not setting it.
+		       * Rather than trust that self-declared bit to decide whether the
+		       * check is mandatory, ask whether the TARGET session's own client is new enough
+		       * to be expected to send it, using clt_version as recorded from that session's
+		       * real connect handshake; a forged cancel request cannot alter that value.
+		       * Legacy CANCEL never carries a session id and always keeps using the
+		       * IP/port-only check below. */
+		      if (cas_req_header[0] != 'C' && !has_session_id
+			  && DOES_CLIENT_UNDERSTAND_THE_PROTOCOL (shm_appl->as_info[i].clt_version, PROTOCOL_V13))
 			{
 			  continue;
 			}

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1012,14 +1012,18 @@ receiver_thr_f (void *arg)
 
 		      /* has_session_id is a bit the sender sets on this very (unauthenticated) cancel
 		       * request, so an attacker who otherwise matches the IP/port checks above could
-		       * defeat the session-id check entirely just by not setting it.
+		       * defeat the session-id check entirely just by not setting it (e.g. by using the
+		       * legacy "CANCEL" wire format, which cannot carry a session id at all).
 		       * Rather than trust that self-declared bit to decide whether the
 		       * check is mandatory, ask whether the TARGET session's own client is new enough
 		       * to be expected to send it, using clt_version as recorded from that session's
-		       * real connect handshake; a forged cancel request cannot alter that value.
-		       * Legacy CANCEL never carries a session id and always keeps using the
-		       * IP/port-only check below. */
-		      if (cas_req_header[0] != 'C' && !has_session_id
+		       * real connect handshake; a forged cancel request cannot alter that value. A
+		       * genuine client whose session is PROTOCOL_V13-or-later never issues a bare
+		       * "CANCEL" for itself (it always has QC/X1 available), so this applies uniformly
+		       * to QC/CANCEL/X1 with no legitimate-client fallout; it only forces an attacker
+		       * using "CANCEL" against such a session to be rejected here instead of falling
+		       * through to the IP/port-only check below. */
+		      if (!has_session_id
 			  && DOES_CLIENT_UNDERSTAND_THE_PROTOCOL (shm_appl->as_info[i].clt_version, PROTOCOL_V13))
 			{
 			  continue;

--- a/src/broker/cas_protocol.h
+++ b/src/broker/cas_protocol.h
@@ -131,6 +131,14 @@ extern "C"
 #define BROKER_SUPPORT_HOLDABLE_RESULT          0x40
 /* Do not remove or rename BROKER_RECONNECT_WHEN_SERVER_DOWN */
 #define BROKER_RECONNECT_WHEN_SERVER_DOWN       0x20
+/* Client announces that a SESSION_ID_SIZE-byte session id is appended after the standard
+ * 10-byte query-cancel header (QC/X1 only; see KVE-2026-1827 hardening), so the broker can
+ * verify the cancel request against the CAS-issued session id in addition to source IP/port.
+ * For "X1" this bit is carried in the function-flag byte (cas_req_header[3]); for "QC" it is
+ * carried in the first reserved byte (cas_req_header[8]).
+ * NOTE: cci repository's mirrored copy (src/cci/broker_cas_protocol.h) must define the same
+ * bit once the CCI driver adds support for sending the session id. */
+#define BROKER_SUPPORT_SESSION_CANCEL           0x10
 
 /* For backward compatibility */
 #define BROKER_INFO_MAJOR_VERSION               (BROKER_INFO_PROTO_VERSION)

--- a/src/broker/cas_protocol.h
+++ b/src/broker/cas_protocol.h
@@ -132,12 +132,18 @@ extern "C"
 /* Do not remove or rename BROKER_RECONNECT_WHEN_SERVER_DOWN */
 #define BROKER_RECONNECT_WHEN_SERVER_DOWN       0x20
 /* Client announces that a SESSION_ID_SIZE-byte session id is appended after the standard
- * 10-byte query-cancel header (QC/X1 only; see KVE-2026-1827 hardening), so the broker can
+ * 10-byte query-cancel header (QC/X1 only), so the broker can
  * verify the cancel request against the CAS-issued session id in addition to source IP/port.
  * For "X1" this bit is carried in the function-flag byte (cas_req_header[3]); for "QC" it is
  * carried in the first reserved byte (cas_req_header[8]).
  * NOTE: cci repository's mirrored copy (src/cci/broker_cas_protocol.h) must define the same
- * bit once the CCI driver adds support for sending the session id. */
+ * bit once the CCI driver adds support for sending the session id.
+ * NOTE: this bit is set by the sender of the cancel request itself, i.e. on the unauthenticated,
+ * out-of-band connection being cancelled, not on the session being targeted; a forged cancel
+ * request can simply omit it. It only controls wire framing (whether the extra 4 bytes are read).
+ * Whether the session id is actually REQUIRED is decided separately in broker.c from the target
+ * session's own PROTOCOL_V13-or-later clt_version, which was recorded from that session's real,
+ * authenticated connect handshake and so cannot be forged by an unrelated cancel request. */
 #define BROKER_SUPPORT_SESSION_CANCEL           0x10
 
 /* For backward compatibility */
@@ -251,7 +257,9 @@ extern "C"
     PROTOCOL_V10 = 10,		/* Secure Broker/CAS using SSL */
     PROTOCOL_V11 = 11,		/* make out resultset */
     PROTOCOL_V12 = 12,		/* Remove trailing zeros from double and float types */
-    CURRENT_PROTOCOL = PROTOCOL_V12
+    PROTOCOL_V13 = 13,		/* CAS-issued session id required (not just optionally checked) for
+				 * QC/X1 query cancel */
+    CURRENT_PROTOCOL = PROTOCOL_V13
   };
   typedef enum t_cas_protocol T_CAS_PROTOCOL;
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27389>

### Purpose

CBRD-27387 취소 (QC/CANCEL/X1) 처리에 ACL 선행 검사 이동과 발신자 IP 검증을 추가했으나, 이는 즉각적인 무인증 원격 공격면을 닫았을 뿐이고, 여전히 "동일 IP에서 왔는가"만 보는 약한 검증이다. 근본 해결은 CAS가 발급한 세션ID를 브로커가 대조 — 이미 ST 명령에 존재하는 패턴을 취소 경로에도 적용

### Implementation

 cas_protocol.h에 아래의 flag를 추가

 #define BROKER_SUPPORT_SESSION_CANCEL 0x10

 아래의 코드롤 프로토콜에 session_id가 포함되는지 확인
 has_session_id = ((cas_req_header[3] & BROKER_SUPPORT_SESSION_CANCEL) != 0);

### Remarks

11.4 이하 버전에 백포트 필요
