### PR TITLE
[CBRD-27034] Introduce transient row locks and transaction MVCC lock waits for DELETE/UPDATE

### DIFF
--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -514,6 +514,7 @@ set(STORAGE_SOURCES
   ${STORAGE_DIR}/bestspace.cpp
   ${STORAGE_DIR}/btree.c
   ${STORAGE_DIR}/btree_load.c
+  ${STORAGE_DIR}/btree_object_lock.cpp
   ${STORAGE_DIR}/btree_unique.cpp
   ${STORAGE_DIR}/byte_order.c
   ${STORAGE_DIR}/catalog_class.c

--- a/sa/CMakeLists.txt
+++ b/sa/CMakeLists.txt
@@ -516,6 +516,7 @@ set(STORAGE_SOURCES
   ${STORAGE_DIR}/bestspace.cpp
   ${STORAGE_DIR}/btree.c
   ${STORAGE_DIR}/btree_load.c
+  ${STORAGE_DIR}/btree_object_lock.cpp
   ${STORAGE_DIR}/btree_unique.cpp
   ${STORAGE_DIR}/byte_order.c
   ${STORAGE_DIR}/catalog_class.c

--- a/src/query/dblink_global_tran_catalog.c
+++ b/src/query/dblink_global_tran_catalog.c
@@ -179,7 +179,7 @@ dblink_global_tran_insert_row (THREAD_ENTRY * thread_p, int gtrid, int bqual,
   error = locator_attribute_info_force (thread_p, hfid_p, &oid, &attr_info, NULL, 0,
 					LC_FLUSH_INSERT, SINGLE_ROW_INSERT, &scan, &force_count,
 					true, REPL_INFO_TYPE_RBR_NORMAL, DB_NOT_PARTITIONED_CLASS,
-					NULL, NULL, NULL, UPDATE_INPLACE_NONE, NULL, false);
+					NULL, NULL, NULL, UPDATE_INPLACE_NONE, NULL, LOCATOR_LOCK_AT_SELECT);
 
 cleanup:
   if (attr_inited)
@@ -311,7 +311,7 @@ dblink_global_tran_update_state (THREAD_ENTRY * thread_p, int gtrid, int bqual, 
   error = locator_attribute_info_force (thread_p, hfid_p, &oid, &attr_info, NULL, 0,
 					LC_FLUSH_UPDATE, SINGLE_ROW_UPDATE, &scan, &force_count,
 					true, REPL_INFO_TYPE_RBR_NORMAL, DB_NOT_PARTITIONED_CLASS,
-					NULL, NULL, NULL, UPDATE_INPLACE_NONE, NULL, false);
+					NULL, NULL, NULL, UPDATE_INPLACE_NONE, NULL, LOCATOR_LOCK_AT_SELECT);
 
 cleanup:
   if (attr_inited)
@@ -373,7 +373,9 @@ dblink_global_tran_delete_row (THREAD_ENTRY * thread_p, int gtrid, int bqual)
       goto cleanup;
     }
 
-  error = locator_delete_force (thread_p, hfid_p, &oid, true, SINGLE_ROW_DELETE, &scan, &force_count, NULL, false);
+  error =
+    locator_delete_force (thread_p, hfid_p, &oid, true, SINGLE_ROW_DELETE, &scan, &force_count, NULL,
+			  LOCATOR_LOCK_AT_SELECT);
 
 cleanup:
   if (attr_inited)

--- a/src/query/parallel/px_scan/px_scan_task.cpp
+++ b/src/query/parallel/px_scan/px_scan_task.cpp
@@ -198,7 +198,7 @@ namespace parallel_scan
 		      }
 		  }
 		bool iscan_oid_order = m_scan_id->s.isid.iscan_oid_order;
-		err_code = scan_open_index_scan (&thread_ref, m_scan_id, false, S_SELECT,
+		err_code = scan_open_index_scan (&thread_ref, m_scan_id, false, false, S_SELECT,
 						 m_is_fixed, m_is_grouped, spec->single_fetch, spec->s_dbval,
 						 m_xasl->val_list, m_vd, spec->indexptr, &m_cls_oid, &m_hfid,
 						 cls->cls_regu_list_key, spec->where_key,
@@ -221,7 +221,7 @@ namespace parallel_scan
 	      }
 	    else
 	      {
-		scan_open_heap_scan (&thread_ref, m_scan_id, false, S_SELECT,
+		scan_open_heap_scan (&thread_ref, m_scan_id, false, false, S_SELECT,
 				     m_is_fixed, m_is_grouped, spec->single_fetch, spec->s_dbval,
 				     m_xasl->val_list, m_vd, &m_cls_oid, &m_hfid,
 				     cls->cls_regu_list_pred, spec->where_pred, cls->cls_regu_list_rest,
@@ -296,7 +296,7 @@ namespace parallel_scan
 			 * m_is_cached_scan. Intermediate scans of the chain always open with cached
 			 * scan off (defaulted last argument), matching the serial-path gate in
 			 * qexec_execute_mainblock_internal (). */
-			err_code = scan_open_heap_scan (&thread_ref, &specp->s_id, false,
+			err_code = scan_open_heap_scan (&thread_ref, &specp->s_id, false, false,
 							S_SELECT, fixed_scan, specp->s_id.grouped,
 							specp->single_fetch, specp->s_dbval, xptr->val_list, m_vd,
 							&scan_info.oid, &scan_info.hfid, specp->s.cls_node.cls_regu_list_pred, specp->where_pred,
@@ -317,7 +317,7 @@ namespace parallel_scan
 			bool iscan_oid_order = specp->s_id.s.isid.iscan_oid_order;
 			specp->indexptr->btid = scan_info.btid;
 			err_code =
-				scan_open_index_scan (&thread_ref, &specp->s_id, false,
+				scan_open_index_scan (&thread_ref, &specp->s_id, false, false,
 						      S_SELECT, fixed_scan, specp->s_id.grouped,
 						      specp->single_fetch, specp->s_dbval, xptr->val_list, m_vd,
 						      specp->indexptr, &scan_info.oid, &scan_info.hfid, specp->s.cls_node.cls_regu_list_key,

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -379,6 +379,11 @@ struct upddel_class_info_internal
   HEAP_SCANCACHE *scan_cache;
 
   OID prev_class_oid;		/* previous class oid */
+  bool is_mvcc_class;		/* whether MVCC applies to class_oid; set when the class changes, because
+				 * mvcc_is_mvcc_disabled_class () is too slow to ask per row */
+  OID lock_policy_class;	/* the class the two answers below were given for */
+  bool has_online_index;	/* an index of class_oid is being built online; set when the class changes,
+				 * because reading the class representation is too slow to ask per row */
   HEAP_CACHE_ATTRINFO attr_info;	/* attribute cache info */
   bool is_attr_info_inited;	/* true if attr_info has valid data */
   int needs_pruning;		/* partition pruning information */
@@ -543,7 +548,7 @@ static int qexec_merge_listfiles (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XAS
 static int qexec_open_scan (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * curr_spec, VAL_LIST * val_list, VAL_DESCR * vd,
 			    bool force_select_lock, int fixed, int grouped, bool iscan_oid_order, SCAN_ID * s_id,
 			    QUERY_ID query_id, SCAN_OPERATION_TYPE scan_op_type, bool scan_immediately_stop,
-			    bool * p_mvcc_select_lock_needed, XASL_NODE * xasl);
+			    bool * p_mvcc_select_lock_needed, XASL_NODE * xasl, bool upddel_stmt);
 static void qexec_close_scan (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * curr_spec);
 static void qexec_end_scan (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * curr_spec);
 static SCAN_CODE qexec_next_merge_block (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE ** spec);
@@ -702,6 +707,8 @@ static UPDDEL_MVCC_COND_REEVAL *qexec_mvcc_cond_reev_set_scan_order (XASL_NODE *
 								     int num_reev_classes, UPDDEL_CLASS_INFO * classes,
 								     int num_classes);
 static void qexec_clear_internal_classes (THREAD_ENTRY * thread_p, UPDDEL_CLASS_INFO_INTERNAL * classes, int count);
+static bool qexec_class_ends_locks_with_statement (THREAD_ENTRY * thread_p,
+						   UPDDEL_CLASS_INFO_INTERNAL * internal_class, const OID * class_oid);
 static int qexec_upddel_setup_current_class (THREAD_ENTRY * thread_p, UPDDEL_CLASS_INFO * class_,
 					     UPDDEL_CLASS_INFO_INTERNAL * class_info, int op_type, OID * current_oid);
 static int qexec_upddel_mvcc_set_filters (THREAD_ENTRY * thread_p, XASL_NODE * aptr_list,
@@ -7463,14 +7470,14 @@ qexec_merge_listfiles (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * x
       assert (xasl->scan_op_type == S_SELECT);
       if (qexec_open_scan (thread_p, outer_spec, xasl->proc.mergelist.outer_val_list, &xasl_state->vd, false,
 			   outer_spec->fixed_scan, outer_spec->grouped_scan, true, &outer_spec->s_id,
-			   xasl_state->query_id, S_SELECT, false, NULL, xasl) != NO_ERROR)
+			   xasl_state->query_id, S_SELECT, false, NULL, xasl, xasl->upd_del_class_cnt > 0) != NO_ERROR)
 	{
 	  GOTO_EXIT_ON_ERROR;
 	}
 
       if (qexec_open_scan (thread_p, inner_spec, xasl->proc.mergelist.inner_val_list, &xasl_state->vd, false,
 			   inner_spec->fixed_scan, inner_spec->grouped_scan, true, &inner_spec->s_id,
-			   xasl_state->query_id, S_SELECT, false, NULL, xasl) != NO_ERROR)
+			   xasl_state->query_id, S_SELECT, false, NULL, xasl, xasl->upd_del_class_cnt > 0) != NO_ERROR)
 	{
 	  GOTO_EXIT_ON_ERROR;
 	}
@@ -7556,9 +7563,10 @@ static int
 qexec_open_scan (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * curr_spec, VAL_LIST * val_list, VAL_DESCR * vd,
 		 bool force_select_lock, int fixed, int grouped, bool iscan_oid_order, SCAN_ID * s_id,
 		 QUERY_ID query_id, SCAN_OPERATION_TYPE scan_op_type, bool scan_immediately_stop,
-		 bool * p_mvcc_select_lock_needed, XASL_NODE * xasl)
+		 bool * p_mvcc_select_lock_needed, XASL_NODE * xasl, bool upddel_stmt)
 {
   bool mvcc_select_lock_needed = false;
+  bool upddel_target_scan = false;
   int error_code = NO_ERROR;
 
   if (curr_spec->pruning_type == DB_PARTITIONED_CLASS && !curr_spec->pruned)
@@ -7593,6 +7601,16 @@ qexec_open_scan (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * curr_spec, VAL_LIST
 	  mvcc_select_lock_needed = ACCESS_SPEC_IS_FLAGED (curr_spec, ACCESS_SPEC_FLAG_FOR_UPDATE);
 	}
     }
+
+  /* Whether these row locks are the statement's to give back at its end.  The spec flag does not tell
+   * a DML target from SELECT ... FOR UPDATE (same flag, but FOR UPDATE's locks are the transaction's);
+   * what separates them is upd_del_class_cnt, a statement-level fact the caller passes in rather than
+   * this function reading it -- the node here is one scan-chain level, and the count sits on the top
+   * node alone, so a join's inner class would read 0 and hold its rows to commit.  The class-level
+   * half is added by the opener, which knows the class (the pruned partition, after a switch). */
+  upddel_target_scan = (mvcc_select_lock_needed && upddel_stmt
+			&& lock_transient_scope_is_outermost (thread_p)
+			&& logtb_find_current_isolation (thread_p) <= TRAN_READ_COMMITTED);
 
   /* Finalize cached-scan activation once per open, before dispatching on access method. The
    * driving-scan gate is assigned next to fixed_scan in qexec_execute_mainblock_internal ();
@@ -7636,7 +7654,8 @@ qexec_open_scan (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * curr_spec, VAL_LIST
 		    }
 #endif /* SERVER_MODE && !WINDOWS */
 		  error_code =
-		    scan_open_heap_scan (thread_p, s_id, mvcc_select_lock_needed, scan_op_type, fixed, grouped,
+		    scan_open_heap_scan (thread_p, s_id, mvcc_select_lock_needed, upddel_target_scan, scan_op_type,
+					 fixed, grouped,
 					 curr_spec->single_fetch, curr_spec->s_dbval, val_list, vd,
 					 &ACCESS_SPEC_CLS_OID (curr_spec), &ACCESS_SPEC_HFID (curr_spec),
 					 curr_spec->s.cls_node.cls_regu_list_pred, curr_spec->where_pred,
@@ -7661,7 +7680,8 @@ qexec_open_scan (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * curr_spec, VAL_LIST
 	    {
 	      SCAN_TYPE scan_type = S_HEAP_SCAN_RECORD_INFO;
 
-	      error_code = scan_open_heap_scan (thread_p, s_id, mvcc_select_lock_needed, scan_op_type, fixed, grouped,
+	      error_code = scan_open_heap_scan (thread_p, s_id, mvcc_select_lock_needed, upddel_target_scan,
+						scan_op_type, fixed, grouped,
 						curr_spec->single_fetch, curr_spec->s_dbval, val_list, vd,
 						&ACCESS_SPEC_CLS_OID (curr_spec), &ACCESS_SPEC_HFID (curr_spec),
 						curr_spec->s.cls_node.cls_regu_list_pred, curr_spec->where_pred,
@@ -7694,7 +7714,8 @@ qexec_open_scan (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * curr_spec, VAL_LIST
 	    break;
 
 	  case ACCESS_METHOD_INDEX:
-	    error_code = scan_open_index_scan (thread_p, s_id, mvcc_select_lock_needed, scan_op_type, fixed, grouped,
+	    error_code = scan_open_index_scan (thread_p, s_id, mvcc_select_lock_needed, upddel_target_scan,
+					       scan_op_type, fixed, grouped,
 					       curr_spec->single_fetch, curr_spec->s_dbval, val_list, vd,
 					       curr_spec->indexptr, &ACCESS_SPEC_CLS_OID (curr_spec),
 					       &ACCESS_SPEC_HFID (curr_spec), curr_spec->s.cls_node.cls_regu_list_key,
@@ -9188,6 +9209,7 @@ qexec_init_next_partition (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * spec, XAS
 #endif /* SERVER_MODE && !WINDOWS */
 		  error =
 		    scan_open_heap_scan (thread_p, &spec->s_id, spec->s_id.mvcc_select_lock_needed,
+					 spec->s_id.upddel_target_scan,
 					 spec->s_id.scan_op_type, spec->s_id.fixed, spec->s_id.grouped,
 					 spec->s_id.single_fetch, spec->s_dbval, spec->s_id.val_list, spec->s_id.vd,
 					 &class_oid, &class_hfid, spec->s.cls_node.cls_regu_list_pred, spec->where_pred,
@@ -9230,7 +9252,8 @@ qexec_init_next_partition (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * spec, XAS
 	      hsidp->scancache_inited = false;
 
 	      error =
-		scan_open_heap_scan (thread_p, &spec->s_id, spec->s_id.mvcc_select_lock_needed, spec->s_id.scan_op_type,
+		scan_open_heap_scan (thread_p, &spec->s_id, spec->s_id.mvcc_select_lock_needed,
+				     spec->s_id.upddel_target_scan, spec->s_id.scan_op_type,
 				     spec->s_id.fixed, spec->s_id.grouped, spec->s_id.single_fetch, spec->s_dbval,
 				     spec->s_id.val_list, spec->s_id.vd, &class_oid, &class_hfid,
 				     spec->s.cls_node.cls_regu_list_pred, spec->where_pred,
@@ -9304,6 +9327,7 @@ qexec_init_next_partition (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * spec, XAS
 
 	      error =
 		scan_open_index_scan (thread_p, &spec->s_id, spec->s_id.mvcc_select_lock_needed,
+				      spec->s_id.upddel_target_scan,
 				      spec->s_id.scan_op_type, spec->s_id.fixed, spec->s_id.grouped,
 				      spec->s_id.single_fetch, spec->s_dbval, spec->s_id.val_list, spec->s_id.vd,
 				      spec->indexptr, &class_oid, &class_hfid, spec->s.cls_node.cls_regu_list_key,
@@ -10469,8 +10493,13 @@ qexec_execute_update (THREAD_ENTRY * thread_p, XASL_NODE * xasl, bool has_delete
   MVCC_REEV_DATA mvcc_reev_data;
   UPDDEL_MVCC_COND_REEVAL *mvcc_reev_classes = NULL, *mvcc_reev_class = NULL;
   UPDATE_MVCC_REEV_ASSIGNMENT *mvcc_reev_assigns = NULL;
-  bool need_locking;
+  LOCATOR_LOCK_POLICY base_lock_policy;	/* what the select phase left for the force phase to do */
+  bool outermost_transient_scope;	/* a statement nested in another one keeps its locks to commit */
+  LOCATOR_LOCK_POLICY lock_policy = LOCATOR_LOCK_AT_SELECT;	/* the same, narrowed by the current class */
   UPDDEL_CLASS_INSTANCE_LOCK_INFO class_instance_lock_info, *p_class_instance_lock_info = NULL;
+
+  /* from here every exit runs through one of the two lock_transient_scope_end () calls below */
+  outermost_transient_scope = lock_transient_scope_start (thread_p);
 
   thread_p->no_logging = (bool) update->no_logging;
 
@@ -10520,7 +10549,8 @@ qexec_execute_update (THREAD_ENTRY * thread_p, XASL_NODE * xasl, bool has_delete
       p_class_instance_lock_info = &class_instance_lock_info;
     }
 
-  if (qexec_execute_mainblock (thread_p, aptr, xasl_state, p_class_instance_lock_info) != NO_ERROR)
+  error = qexec_execute_mainblock (thread_p, aptr, xasl_state, p_class_instance_lock_info);
+  if (error != NO_ERROR)
     {
       GOTO_EXIT_ON_ERROR;
     }
@@ -10528,12 +10558,12 @@ qexec_execute_update (THREAD_ENTRY * thread_p, XASL_NODE * xasl, bool has_delete
   if (p_class_instance_lock_info && p_class_instance_lock_info->instances_locked)
     {
       /* already locked in select phase. Avoid locking again the same instances at update phase */
-      need_locking = false;
+      base_lock_policy = LOCATOR_LOCK_AT_SELECT;
     }
   else
     {
       /* not locked in select phase, need locking at update phase */
-      need_locking = true;
+      base_lock_policy = LOCATOR_LOCK_AT_FORCE;
     }
 
   /* This guarantees that the result list file will have a type list. Copying a list_id structure fails unless it has a
@@ -10570,7 +10600,8 @@ qexec_execute_update (THREAD_ENTRY * thread_p, XASL_NODE * xasl, bool has_delete
   /* force_select_lock = false */
   assert (xasl->scan_op_type == S_SELECT);
   if (qexec_open_scan (thread_p, specp, xasl->val_list, &xasl_state->vd, false, specp->fixed_scan, specp->grouped_scan,
-		       true, &specp->s_id, xasl_state->query_id, S_SELECT, false, NULL, xasl) != NO_ERROR)
+		       true, &specp->s_id, xasl_state->query_id, S_SELECT, false, NULL, xasl,
+		       xasl->upd_del_class_cnt > 0) != NO_ERROR)
     {
       GOTO_EXIT_ON_ERROR;
     }
@@ -10722,6 +10753,8 @@ qexec_execute_update (THREAD_ENTRY * thread_p, XASL_NODE * xasl, bool has_delete
 		      er_log_debug (ARG_FILE_LINE, "qexec_execute_update: class OID is not correct\n");
 		      GOTO_EXIT_ON_ERROR;
 		    }
+		  internal_class->is_mvcc_class = !mvcc_is_mvcc_disabled_class (class_oid);
+		  internal_class->has_online_index = locator_class_has_online_index (thread_p, class_oid);
 
 		  /* temporary disable set filters when needs prunning */
 		  if (mvcc_reev_class != NULL)
@@ -10816,13 +10849,31 @@ qexec_execute_update (THREAD_ENTRY * thread_p, XASL_NODE * xasl, bool has_delete
 			}
 		    }
 
+		  /* Row-lock lifetime is the class's, not the row's -- decided per class here (see
+		   * qexec_class_ends_locks_with_statement). */
+		  lock_policy = base_lock_policy;
+		  if (outermost_transient_scope
+		      && qexec_class_ends_locks_with_statement (thread_p, internal_class, class_oid))
+		    {
+		      if (lock_policy == LOCATOR_LOCK_AT_FORCE)
+			{
+			  lock_policy = LOCATOR_LOCK_AT_FORCE_TRANSIENT;
+			}
+		      else if (lock_policy == LOCATOR_LOCK_AT_SELECT)
+			{
+			  /* the select phase took a request on this row for this statement; it ends with the
+			   * statement as well, so the row is not held past it just because the scan locked it */
+			  lock_policy = LOCATOR_LOCK_AT_SELECT_TRANSIENT;
+			}
+		    }
+
 		  force_count = 0;
 		  error =
 		    locator_attribute_info_force (thread_p, internal_class->class_hfid, internal_class->oid, NULL, NULL,
 						  0, LC_FLUSH_DELETE, current_op_type, internal_class->scan_cache,
 						  &force_count, false, REPL_INFO_TYPE_RBR_NORMAL,
 						  DB_NOT_PARTITIONED_CLASS, NULL, NULL, &mvcc_reev_data,
-						  UPDATE_INPLACE_NONE, NULL, need_locking);
+						  UPDATE_INPLACE_NONE, NULL, lock_policy);
 
 		  if (error == ER_MVCC_NOT_SATISFIED_REEVALUATION)
 		    {
@@ -10998,12 +11049,30 @@ qexec_execute_update (THREAD_ENTRY * thread_p, XASL_NODE * xasl, bool has_delete
 	      mvcc_upddel_reev_data.curr_extra_assign_cnt = internal_class->extra_assign_reev_cnt;
 	      mvcc_upddel_reev_data.curr_assigns = internal_class->mvcc_reev_assigns;
 	      mvcc_upddel_reev_data.curr_attrinfo = &internal_class->attr_info;
+
+	      /* Row-lock lifetime is the class's, not the row's -- decided per class here (see
+	       * qexec_class_ends_locks_with_statement). */
+	      lock_policy = base_lock_policy;
+	      if (outermost_transient_scope
+		  && qexec_class_ends_locks_with_statement (thread_p, internal_class, class_oid))
+		{
+		  if (lock_policy == LOCATOR_LOCK_AT_FORCE)
+		    {
+		      lock_policy = LOCATOR_LOCK_AT_FORCE_TRANSIENT;
+		    }
+		  else if (lock_policy == LOCATOR_LOCK_AT_SELECT)
+		    {
+		      /* the select phase took a request on this row for this statement; it ends with the
+		       * statement as well, so the row is not held past it just because the scan locked it */
+		      lock_policy = LOCATOR_LOCK_AT_SELECT_TRANSIENT;
+		    }
+		}
 	      error =
 		locator_attribute_info_force (thread_p, internal_class->class_hfid, oid, &internal_class->attr_info,
 					      &upd_cls->att_id[internal_class->subclass_idx * upd_cls->num_attrs],
 					      upd_cls->num_attrs, LC_FLUSH_UPDATE, op_type, internal_class->scan_cache,
 					      &force_count, false, repl_info, internal_class->needs_pruning, pcontext,
-					      NULL, &mvcc_reev_data, UPDATE_INPLACE_NONE, NULL, need_locking);
+					      NULL, &mvcc_reev_data, UPDATE_INPLACE_NONE, NULL, lock_policy);
 	      if (error == ER_MVCC_NOT_SATISFIED_REEVALUATION)
 		{
 		  error = NO_ERROR;
@@ -11070,6 +11139,11 @@ qexec_execute_update (THREAD_ENTRY * thread_p, XASL_NODE * xasl, bool has_delete
 	}
     }
 
+  /* Updates published: late arrivals settle on our MVCCID self-lock, so these row locks end with the
+   * statement -- but kept to commit under a savepoint, whose partial rollback could undo the change
+   * while a writer parks on our MVCCID. */
+  lock_transient_scope_end (thread_p, !logtb_has_active_savepoint (thread_p));
+
   qexec_close_scan (thread_p, specp);
 
   if (has_delete)
@@ -11129,6 +11203,9 @@ qexec_execute_update (THREAD_ENTRY * thread_p, XASL_NODE * xasl, bool has_delete
   return NO_ERROR;
 
 exit_on_error:
+  /* the statement failed, so its rows keep their locks to commit.  Drop the counts, though -- they name
+   * no statement, and the next statement to release would give back requests it never took. */
+  lock_transient_scope_end (thread_p, false);
 
   if (scan_open)
     {
@@ -11332,7 +11409,9 @@ qexec_execute_delete (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
   MVCC_REEV_DATA mvcc_reev_data;
   MVCC_UPDDEL_REEV_DATA mvcc_upddel_reev_data;
   UPDDEL_MVCC_COND_REEVAL *mvcc_reev_classes = NULL, *mvcc_reev_class = NULL;
-  bool need_locking;
+  LOCATOR_LOCK_POLICY base_lock_policy;	/* what the select phase left for the force phase to do */
+  bool outermost_transient_scope;	/* a statement nested in another one keeps its locks to commit */
+  LOCATOR_LOCK_POLICY lock_policy = LOCATOR_LOCK_AT_SELECT;	/* the same, narrowed by the current class */
   UPDDEL_CLASS_INSTANCE_LOCK_INFO class_instance_lock_info, *p_class_instance_lock_info = NULL;
 
   /* remote DELETE + local subquery sink: evaluate the WHERE subquery locally and push one remote
@@ -11342,6 +11421,9 @@ qexec_execute_delete (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
     {
       return qexec_execute_remote_delete_subquery (thread_p, xasl, xasl_state);
     }
+
+  /* from here every exit runs through one of the two lock_transient_scope_end () calls below */
+  outermost_transient_scope = lock_transient_scope_start (thread_p);
 
   thread_p->no_logging = (bool) delete_->no_logging;
 
@@ -11391,7 +11473,8 @@ qexec_execute_delete (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
       p_class_instance_lock_info = &class_instance_lock_info;
     }
 
-  if (qexec_execute_mainblock (thread_p, aptr, xasl_state, p_class_instance_lock_info) != NO_ERROR)
+  error = qexec_execute_mainblock (thread_p, aptr, xasl_state, p_class_instance_lock_info);
+  if (error != NO_ERROR)
     {
       GOTO_EXIT_ON_ERROR;
     }
@@ -11399,12 +11482,16 @@ qexec_execute_delete (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
   if (p_class_instance_lock_info && p_class_instance_lock_info->instances_locked)
     {
       /* already locked in select phase. Avoid locking again the same instances at delete phase. */
-      need_locking = false;
+      base_lock_policy = LOCATOR_LOCK_AT_SELECT;
     }
   else
     {
       /* not locked in select phase, need locking at update phase */
-      need_locking = true;
+      base_lock_policy = LOCATOR_LOCK_AT_FORCE;
+
+      /* No reevaluation class means no predicate to re-check -- pt_to_delete_xasl () keeps the
+       * select-phase lock for one it cannot replay -- so a changed version is deleted, not skipped.
+       * The skip below is for the subclass that turns out to carry no access spec. */
     }
 
   /* This guarantees that the result list file will have a type list. Copying a list_id structure fails unless it has a
@@ -11441,7 +11528,8 @@ qexec_execute_delete (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
   assert (xasl->scan_op_type == S_SELECT);
   /* force_select_lock = false */
   if (qexec_open_scan (thread_p, specp, xasl->val_list, &xasl_state->vd, false, specp->fixed_scan, specp->grouped_scan,
-		       true, &specp->s_id, xasl_state->query_id, S_SELECT, false, NULL, xasl) != NO_ERROR)
+		       true, &specp->s_id, xasl_state->query_id, S_SELECT, false, NULL, xasl,
+		       xasl->upd_del_class_cnt > 0) != NO_ERROR)
     {
       GOTO_EXIT_ON_ERROR;
     }
@@ -11524,6 +11612,8 @@ qexec_execute_delete (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
 			  er_log_debug (ARG_FILE_LINE, "qexec_execute_delete: class OID is not correct\n");
 			  GOTO_EXIT_ON_ERROR;
 			}
+		      internal_class->is_mvcc_class = !mvcc_is_mvcc_disabled_class (class_oid);
+		      internal_class->has_online_index = locator_class_has_online_index (thread_p, class_oid);
 
 		      if (internal_class->num_lob_attrs)
 			{
@@ -11570,6 +11660,24 @@ qexec_execute_delete (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
 	      internal_class = &internal_classes[class_oid_idx];
 	      oid = internal_class->oid;
 	      class_oid = internal_class->class_oid;
+
+	      /* Row-lock lifetime is the class's, not the row's -- decided per class here (a multi-class
+	       * DELETE gets a different answer for each; see qexec_class_ends_locks_with_statement). */
+	      lock_policy = base_lock_policy;
+	      if (outermost_transient_scope
+		  && qexec_class_ends_locks_with_statement (thread_p, internal_class, class_oid))
+		{
+		  if (lock_policy == LOCATOR_LOCK_AT_FORCE)
+		    {
+		      lock_policy = LOCATOR_LOCK_AT_FORCE_TRANSIENT;
+		    }
+		  else if (lock_policy == LOCATOR_LOCK_AT_SELECT)
+		    {
+		      /* the select phase took a request on this row for this statement; it ends with the
+		       * statement as well, so the row is not held past it just because the scan locked it */
+		      lock_policy = LOCATOR_LOCK_AT_SELECT_TRANSIENT;
+		    }
+		}
 
 	      if (mvcc_reev_class_cnt && mvcc_reev_classes[mvcc_reev_class_idx].class_index == class_oid_idx)
 		{
@@ -11639,7 +11747,7 @@ qexec_execute_delete (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
 		locator_attribute_info_force (thread_p, internal_class->class_hfid, oid, NULL, NULL, 0, LC_FLUSH_DELETE,
 					      op_type, internal_class->scan_cache, &force_count, false,
 					      REPL_INFO_TYPE_RBR_NORMAL, DB_NOT_PARTITIONED_CLASS, NULL, NULL,
-					      &mvcc_reev_data, UPDATE_INPLACE_NONE, NULL, need_locking);
+					      &mvcc_reev_data, UPDATE_INPLACE_NONE, NULL, lock_policy);
 	      if (error == ER_MVCC_NOT_SATISFIED_REEVALUATION)
 		{
 		  error = NO_ERROR;
@@ -11707,6 +11815,14 @@ qexec_execute_delete (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
 	}
     }
 
+  /* Deletes published: late arrivals settle on our MVCCID self-lock (persisted across 2PC by the prepare
+   * record), so these row locks end with the statement -- but kept to commit under a savepoint, whose
+   * partial rollback could undo the delete while a writer parks on our MVCCID.
+   * TODO: logtb_has_active_savepoint () does not tell a user savepoint from a DDL/trigger system one, so a
+   *       transaction that ran DDL earlier forgoes the release (correct, but conservative).  CBRD-27238
+   *       adds a user-savepoint-only flag on tdes for both paths. */
+  lock_transient_scope_end (thread_p, !logtb_has_active_savepoint (thread_p));
+
   qexec_close_scan (thread_p, specp);
 
   qexec_free_delete_lob_info_list (thread_p, &del_lob_info_list);
@@ -11758,6 +11874,10 @@ qexec_execute_delete (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
   return NO_ERROR;
 
 exit_on_error:
+  /* the statement failed, so its rows keep their locks to commit.  Drop the counts, though -- they name
+   * no statement, and the next statement to release would give back requests it never took. */
+  lock_transient_scope_end (thread_p, false);
+
   if (scan_open)
     {
       qexec_end_scan (thread_p, specp);
@@ -12092,7 +12212,7 @@ qexec_remove_duplicates_for_replace (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * s
 	    locator_attribute_info_force (thread_p, &pruned_hfid, &unique_oid, NULL, NULL, 0, LC_FLUSH_DELETE,
 					  local_op_type, local_scan_cache, &force_count, false,
 					  REPL_INFO_TYPE_RBR_NORMAL, DB_NOT_PARTITIONED_CLASS, NULL, NULL, NULL,
-					  UPDATE_INPLACE_NONE, NULL, false);
+					  UPDATE_INPLACE_NONE, NULL, LOCATOR_LOCK_AT_SELECT);
 
 	  if (error_code == ER_MVCC_NOT_SATISFIED_REEVALUATION)
 	    {
@@ -12405,11 +12525,13 @@ qexec_execute_duplicate_key_update (THREAD_ENTRY * thread_p, ODKU_INFO * odku, H
   int error = NO_ERROR;
   bool need_clear = 0;
   OID unique_oid;
+  OID unique_class_oid;
   int local_op_type = SINGLE_ROW_UPDATE;
   HEAP_SCANCACHE *local_scan_cache = NULL;
   int ispeeking;
 
   OID_SET_NULL (&unique_oid);
+  OID_SET_NULL (&unique_class_oid);
 
   local_scan_cache = scan_cache;
 
@@ -12431,12 +12553,29 @@ qexec_execute_duplicate_key_update (THREAD_ENTRY * thread_p, ODKU_INFO * odku, H
   /* get attribute values */
   ispeeking = ((local_scan_cache != NULL && local_scan_cache->cache_last_fix_page) ? PEEK : COPY);
 
-  scan_code =
-    heap_get_visible_version (thread_p, &unique_oid, NULL, &rec_descriptor, local_scan_cache, ispeeking, NULL_CHN);
+  /* A duplicate whose delete is in progress carries no row lock once the deleter has published, and the
+   * visible version hides that delete -- updating it would overwrite a record the deleter still has to
+   * undo. Fetch through the lock path instead: it waits the deleter out and re-reads. */
+  scan_code = heap_get_class_oid (thread_p, &unique_oid, &unique_class_oid);
   if (scan_code != S_SUCCESS)
     {
-      assert (er_errid () == ER_INTERRUPTED);
-      error = ER_FAILED;
+      ASSERT_ERROR_AND_SET (error);
+      goto exit_on_error;
+    }
+
+  scan_code =
+    locator_lock_and_get_object (thread_p, &unique_oid, &unique_class_oid, &rec_descriptor, local_scan_cache, X_LOCK,
+				 ispeeking, NULL_CHN, LOG_WARNING_IF_DELETED, false, false);
+  if (scan_code == S_DOESNT_EXIST)
+    {
+      /* the deleter committed: the key is free, so this row is no longer a duplicate and the caller inserts */
+      er_clear ();
+      *force_count = 0;
+      return NO_ERROR;
+    }
+  if (scan_code != S_SUCCESS)
+    {
+      ASSERT_ERROR_AND_SET (error);
       goto exit_on_error;
     }
 
@@ -12520,7 +12659,8 @@ qexec_execute_duplicate_key_update (THREAD_ENTRY * thread_p, ODKU_INFO * odku, H
   error =
     locator_attribute_info_force (thread_p, hfid, &unique_oid, attr_info, odku->attr_ids, odku->num_assigns,
 				  LC_FLUSH_UPDATE, local_op_type, local_scan_cache, force_count, false, repl_info,
-				  pruning_type, pcontext, NULL, NULL, UPDATE_INPLACE_NONE, &rec_descriptor, false);
+				  pruning_type, pcontext, NULL, NULL, UPDATE_INPLACE_NONE, &rec_descriptor,
+				  LOCATOR_LOCK_AT_SELECT);
   if (error == ER_MVCC_NOT_SATISFIED_REEVALUATION)
     {
       er_clear ();
@@ -12727,7 +12867,7 @@ qexec_execute_remote_dml_sink (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_S
   /* open local scan on the SELECT / WHERE-subquery result */
   if (qexec_open_scan (thread_p, specp, xasl->val_list, &xasl_state->vd, false, specp->fixed_scan,
 		       specp->grouped_scan, true, &specp->s_id, xasl_state->query_id, S_SELECT, false,
-		       NULL, xasl) != NO_ERROR)
+		       NULL, xasl, xasl->upd_del_class_cnt > 0) != NO_ERROR)
     {
       qexec_failure_line (__LINE__, xasl_state);
       goto exit_on_error;
@@ -13527,7 +13667,7 @@ qexec_execute_insert (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
       /* force_select_lock = false */
       if (qexec_open_scan (thread_p, specp, xasl->val_list, &xasl_state->vd, false, specp->fixed_scan,
 			   specp->grouped_scan, true, &specp->s_id, xasl_state->query_id, S_SELECT, false,
-			   NULL, xasl) != NO_ERROR)
+			   NULL, xasl, xasl->upd_del_class_cnt > 0) != NO_ERROR)
 	{
 	  if (savepoint_used)
 	    {
@@ -13657,7 +13797,8 @@ qexec_execute_insert (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
 	      if (locator_attribute_info_force (thread_p, &insert->class_hfid, &oid, &attr_info, NULL, 0, operation,
 						scan_cache_op_type, &scan_cache, &force_count, false,
 						REPL_INFO_TYPE_RBR_NORMAL, insert->pruning_type, pcontext,
-						func_indx_preds, NULL, UPDATE_INPLACE_NONE, NULL, false) != NO_ERROR)
+						func_indx_preds, NULL, UPDATE_INPLACE_NONE, NULL,
+						LOCATOR_LOCK_AT_SELECT) != NO_ERROR)
 		{
 		  GOTO_EXIT_ON_ERROR;
 		}
@@ -13837,7 +13978,7 @@ qexec_execute_insert (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
 	      if (locator_attribute_info_force (thread_p, &insert->class_hfid, &oid, &attr_info, NULL, 0, operation,
 						scan_cache_op_type, &scan_cache, &force_count, false,
 						REPL_INFO_TYPE_RBR_NORMAL, insert->pruning_type, pcontext, NULL, NULL,
-						UPDATE_INPLACE_NONE, NULL, false) != NO_ERROR)
+						UPDATE_INPLACE_NONE, NULL, LOCATOR_LOCK_AT_SELECT) != NO_ERROR)
 		{
 		  GOTO_EXIT_ON_ERROR;
 		}
@@ -14490,7 +14631,7 @@ exit_on_error:
  *   attrid(in) :
  *   n_increment(in)    :
  *   pruning_type(in)	:
- *   need_locking(in)	: true, if need locking
+ *   lock_policy(in)	: where the row lock is taken and how long it is kept
  */
 static int
 qexec_execute_increment (THREAD_ENTRY * thread_p, const OID * oid, const OID * class_oid, const HFID * class_hfid,
@@ -14551,7 +14692,7 @@ qexec_execute_increment (THREAD_ENTRY * thread_p, const OID * oid, const OID * c
       error =
 	locator_attribute_info_force (thread_p, class_hfid, &copy_oid, &attr_info, &attrid, 1, area_op, op_type,
 				      &scan_cache, &force_count, false, REPL_INFO_TYPE_RBR_NORMAL, pruning_type, NULL,
-				      NULL, NULL, UPDATE_INPLACE_NONE, NULL, false);
+				      NULL, NULL, UPDATE_INPLACE_NONE, NULL, LOCATOR_LOCK_AT_SELECT);
       if (error == ER_MVCC_NOT_SATISFIED_REEVALUATION)
 	{
 	  assert (force_count == 0);
@@ -14868,7 +15009,7 @@ qexec_execute_selupd_list (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE
 	      scan_code =
 		locator_lock_and_get_object_with_evaluation (thread_p, &crt_incr_info.m_oid, &crt_incr_info.m_class_oid,
 							     NULL, &scan_cache, COPY, NULL_CHN, p_mvcc_reev_data,
-							     LOG_WARNING_IF_DELETED);
+							     LOG_WARNING_IF_DELETED, false, false);
 	      if (scan_code != S_SUCCESS)
 		{
 		  int er_id = er_errid ();
@@ -16672,7 +16813,8 @@ qexec_execute_mainblock_internal (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XAS
 			  if (qexec_open_scan (thread_p, specp, xptr->merge_val_list, &xasl_state->vd,
 					       force_select_lock, specp->fixed_scan, specp->grouped_scan,
 					       iscan_oid_order, &specp->s_id, xasl_state->query_id, xasl->scan_op_type,
-					       scan_immediately_stop, &mvcc_select_lock_needed, xasl) != NO_ERROR)
+					       scan_immediately_stop, &mvcc_select_lock_needed, xasl,
+					       xasl->upd_del_class_cnt > 0) != NO_ERROR)
 			    {
 			      qexec_clear_mainblock_iterations (thread_p, xasl);
 			      GOTO_EXIT_ON_ERROR;
@@ -16698,7 +16840,7 @@ qexec_execute_mainblock_internal (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XAS
 			  if (qexec_open_scan (thread_p, specp, xptr->val_list, &xasl_state->vd, force_select_lock,
 					       specp->fixed_scan, specp->grouped_scan, iscan_oid_order, &specp->s_id,
 					       xasl_state->query_id, xptr->scan_op_type, scan_immediately_stop,
-					       &mvcc_select_lock_needed, xptr) != NO_ERROR)
+					       &mvcc_select_lock_needed, xptr, xasl->upd_del_class_cnt > 0) != NO_ERROR)
 			    {
 			      qexec_clear_mainblock_iterations (thread_p, xasl);
 			      GOTO_EXIT_ON_ERROR;
@@ -17864,7 +18006,8 @@ qexec_execute_connect_by (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE 
 
   /* start the scanner on "input" */
   if (qexec_open_scan (thread_p, xasl->spec_list, xasl->val_list, &xasl_state->vd, false, true, false,
-		       false, &xasl->spec_list->s_id, xasl_state->query_id, S_SELECT, false, NULL, xasl) != NO_ERROR)
+		       false, &xasl->spec_list->s_id, xasl_state->query_id, S_SELECT, false, NULL, xasl,
+		       xasl->upd_del_class_cnt > 0) != NO_ERROR)
     {
       GOTO_EXIT_ON_ERROR;
     }
@@ -26470,6 +26613,8 @@ qexec_create_internal_classes (THREAD_ENTRY * thread_p, UPDDEL_CLASS_INFO * quer
       class_->class_oid = NULL;
       class_->needs_pruning = DB_NOT_PARTITIONED_CLASS;
       class_->subclass_idx = -1;
+      class_->is_mvcc_class = false;
+      class_->has_online_index = false;
       class_->scan_cache = NULL;
       OID_SET_NULL (&class_->prev_class_oid);
       class_->is_attr_info_inited = 0;
@@ -26678,6 +26823,36 @@ qexec_upddel_mvcc_set_filters (THREAD_ENTRY * thread_p, XASL_NODE * aptr_list,
 }
 
 /*
+ * qexec_class_ends_locks_with_statement () - Whether this class lets a row lock end with the statement
+ *   return: true when the class puts nothing in the way
+ *   thread_p(in): thread entry
+ *   internal_class(in/out): the class the force phase is on; carries the memo
+ *   class_oid(in): its OID -- the pruned partition, where pruning applies
+ *
+ * Note: answered per class, not per row.  Two classes keep their row locks to commit: one under an online
+ *	index build (its entry state names no owner, so the row lock serializes two writers there) and one
+ *	MVCC does not apply to.  Memoized on the class because a multi-target statement does not bind every
+ *	target through the same path.
+ */
+static bool
+qexec_class_ends_locks_with_statement (THREAD_ENTRY * thread_p, UPDDEL_CLASS_INFO_INTERNAL * internal_class,
+				       const OID * class_oid)
+{
+  if (class_oid == NULL || OID_ISNULL (class_oid))
+    {
+      return false;
+    }
+  if (!OID_EQ (&internal_class->lock_policy_class, class_oid))
+    {
+      COPY_OID (&internal_class->lock_policy_class, class_oid);
+      internal_class->is_mvcc_class = !mvcc_is_mvcc_disabled_class (class_oid);
+      internal_class->has_online_index = locator_class_has_online_index (thread_p, class_oid);
+    }
+
+  return internal_class->is_mvcc_class && !internal_class->has_online_index;
+}
+
+/*
  * qexec_upddel_setup_current_class () - setup current class info in a class
  *					 hierarchy
  * return : error code or NO_ERROR
@@ -26821,6 +26996,12 @@ qexec_execute_merge (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xas
   int error = NO_ERROR;
   int savepoint_used = 0;
   LOG_LSA lsa;
+
+  /* No transient scope is opened here: MERGE's driving select is excluded by the upd_del_class_cnt > 0
+   * test in qexec_open_scan (), so the halves never mark their row locks transient and there is nothing
+   * for a scope to keep from being released between them.  If a future change let a MERGE half take a
+   * transient row lock, this would need to open a scope (making each half not-outermost) so the abort of
+   * the enclosing system operation cannot undo a stamp whose row lock was already given back. */
 
   /* start a topop */
   error = xtran_server_start_topop (thread_p, &lsa);

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -3191,6 +3191,9 @@ scan_init_scan_id (SCAN_ID * scan_id, bool mvcc_select_lock_needed, SCAN_OPERATI
   scan_id->direction = S_FORWARD;
 
   scan_id->mvcc_select_lock_needed = mvcc_select_lock_needed;
+  /* set by the two openers that reach a row-lock site; every other scan type leaves them off */
+  scan_id->upddel_target_scan = false;
+  scan_id->lock_ends_with_statement = false;
   scan_id->scan_op_type = scan_op_type;
   scan_id->fixed = fixed;
 
@@ -3208,6 +3211,28 @@ scan_init_scan_id (SCAN_ID * scan_id, bool mvcc_select_lock_needed, SCAN_OPERATI
   scan_id->val_list = val_list;	/* points to the XASL tree */
   scan_id->vd = vd;		/* set value descriptor pointer */
   scan_id->scan_immediately_stop = false;
+}
+
+/*
+ * scan_set_upddel_target () - Say whether the row locks this scan takes end with the statement
+ *   return: void
+ *   thread_p(in): thread entry
+ *   scan_id(in/out): the scan being opened
+ *   upddel_target_scan(in): the statement already answered that this spec feeds its force phase
+ *   cls_oid(in): the class this scan is on -- the pruned partition, on a partition switch
+ *
+ * Note: the statement-level half of the answer arrives in upddel_target_scan and is sticky: a partition
+ *	switch reopens the scan and hands it back.  The class-level half is answered here, because it is
+ *	answered per class -- a class under an online index build keeps its row locks to commit, and so
+ *	does a class MVCC does not apply to -- and a partition can differ from the class it partitions.
+ */
+static void
+scan_set_upddel_target (THREAD_ENTRY * thread_p, SCAN_ID * scan_id, bool upddel_target_scan, const OID * cls_oid)
+{
+  scan_id->upddel_target_scan = upddel_target_scan;
+  scan_id->lock_ends_with_statement = (upddel_target_scan && cls_oid != NULL && !OID_ISNULL (cls_oid)
+				       && !mvcc_is_mvcc_disabled_class (cls_oid)
+				       && !locator_class_has_online_index (thread_p, cls_oid));
 }
 
 /*
@@ -3241,7 +3266,8 @@ scan_init_scan_id (SCAN_ID * scan_id, bool mvcc_select_lock_needed, SCAN_OPERATI
 int
 scan_open_heap_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id,
 		     /* fields of SCAN_ID */
-		     bool mvcc_select_lock_needed, SCAN_OPERATION_TYPE scan_op_type, int fixed, int grouped,
+		     bool mvcc_select_lock_needed, bool upddel_target_scan, SCAN_OPERATION_TYPE scan_op_type,
+		     int fixed, int grouped,
 		     QPROC_SINGLE_FETCH single_fetch, DB_VALUE * join_dbval, val_list_node * val_list, VAL_DESCR * vd,
 		     /* fields of HEAP_SCAN_ID */
 		     OID * cls_oid, HFID * hfid, regu_variable_list_node * regu_list_pred, PRED_EXPR * pr,
@@ -3265,6 +3291,7 @@ scan_open_heap_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id,
   /* initialize SCAN_ID structure */
   scan_init_scan_id (scan_id, mvcc_select_lock_needed, scan_op_type, fixed, grouped, single_fetch, join_dbval, val_list,
 		     vd);
+  scan_set_upddel_target (thread_p, scan_id, upddel_target_scan, cls_oid);
 
   /* initialize HEAP_SCAN_ID structure */
   hsidp = &scan_id->s.hsid;
@@ -3456,7 +3483,8 @@ scan_open_class_attr_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id,
 int
 scan_open_index_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id,
 		      /* fields of SCAN_ID */
-		      bool mvcc_select_lock_needed, SCAN_OPERATION_TYPE scan_op_type, int fixed, int grouped,
+		      bool mvcc_select_lock_needed, bool upddel_target_scan, SCAN_OPERATION_TYPE scan_op_type,
+		      int fixed, int grouped,
 		      QPROC_SINGLE_FETCH single_fetch, DB_VALUE * join_dbval, val_list_node * val_list, VAL_DESCR * vd,
 		      /* fields of INDX_SCAN_ID */
 		      indx_info * indx_info, OID * cls_oid, HFID * hfid, regu_variable_list_node * regu_list_key,
@@ -3488,6 +3516,7 @@ scan_open_index_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id,
   /* initialize SCAN_ID structure */
   scan_init_scan_id (scan_id, mvcc_select_lock_needed, scan_op_type, fixed, grouped, single_fetch, join_dbval, val_list,
 		     vd);
+  scan_set_upddel_target (thread_p, scan_id, upddel_target_scan, cls_oid);
 
   /* read Root page header info */
   btid = &indx_info->btid;
@@ -6047,7 +6076,9 @@ scan_next_heap_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 	  /* get with lock and reevaluate if the visible version wasn't the latest version */
 	  sp_scan =
 	    locator_lock_and_get_object_with_evaluation (thread_p, &current_oid, NULL, &recdes, &hsidp->scan_cache,
-							 is_peeking, NULL_CHN, &mvcc_reev_data, LOG_WARNING_IF_DELETED);
+							 is_peeking, NULL_CHN, &mvcc_reev_data, LOG_WARNING_IF_DELETED,
+							 scan_id->lock_ends_with_statement,
+							 scan_id->lock_ends_with_statement);
 	  if (sp_scan == S_SUCCESS && mvcc_reev_data.filter_result == V_FALSE)
 	    {
 	      continue;
@@ -6866,7 +6897,9 @@ scan_next_index_lookup_heap (THREAD_ENTRY * thread_p, SCAN_ID * scan_id, INDX_SC
 
       sp_scan = locator_lock_and_get_object_with_evaluation (thread_p, isidp->curr_oidp, NULL, &recdes,
 							     &isidp->scan_cache, scan_id->fixed, NULL_CHN,
-							     &mvcc_reev_data, LOG_WARNING_IF_DELETED);
+							     &mvcc_reev_data, LOG_WARNING_IF_DELETED,
+							     scan_id->lock_ends_with_statement,
+							     scan_id->lock_ends_with_statement);
       if (sp_scan == S_SUCCESS)
 	{
 	  switch (mvcc_reev_data.filter_result)

--- a/src/query/scan_manager.h
+++ b/src/query/scan_manager.h
@@ -486,6 +486,10 @@ struct scan_id_struct
   SCAN_POSITION position;	/* Scan Position */
   SCAN_DIRECTION direction;	/* Forward/Backward Direction */
   bool mvcc_select_lock_needed;	/* true if lock at scanning needed in mvcc */
+  bool upddel_target_scan;	/* the scan feeds the force phase of this statement, so the row locks it takes
+				 * are the statement's -- SELECT ... FOR UPDATE reaches the same lock site and its
+				 * locks are the transaction's.  Sticky across a partition switch. */
+  bool lock_ends_with_statement;	/* the same, narrowed by the class this scan is on now */
   SCAN_OPERATION_TYPE scan_op_type;	/* SELECT, DELETE, UPDATE */
 
   int fixed;			/* if true, pages containing scan items in a group keep fixed */
@@ -534,7 +538,8 @@ struct scan_id_struct
 
 extern int scan_open_heap_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id,
 				/* fields of SCAN_ID */
-				bool mvcc_select_lock_needed, SCAN_OPERATION_TYPE scan_op_type, int fixed, int grouped,
+				bool mvcc_select_lock_needed, bool upddel_target_scan,
+				SCAN_OPERATION_TYPE scan_op_type, int fixed, int grouped,
 				QPROC_SINGLE_FETCH single_fetch, DB_VALUE * join_dbval, val_list_node * val_list,
 				val_descr * vd,
 				/* fields of HEAP_SCAN_ID */
@@ -560,7 +565,8 @@ extern int scan_open_class_attr_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id
 				      ATTR_ID * attrids_rest, HEAP_CACHE_ATTRINFO * cache_rest);
 extern int scan_open_index_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id,
 				 /* fields of SCAN_ID */
-				 bool mvcc_select_lock_needed, SCAN_OPERATION_TYPE scan_op_type, int fixed, int grouped,
+				 bool mvcc_select_lock_needed, bool upddel_target_scan,
+				 SCAN_OPERATION_TYPE scan_op_type, int fixed, int grouped,
 				 QPROC_SINGLE_FETCH single_fetch, DB_VALUE * join_dbval, val_list_node * val_list,
 				 val_descr * vd,
 				 /* fields of INDX_SCAN_ID */

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -30,6 +30,7 @@
 #include "btree.h"
 
 #include "btree_load.h"
+#include "btree_object_lock.hpp"
 #include "config.h"
 #include "db_value_printer.hpp"
 #include "deduplicate_key.h"
@@ -386,54 +387,6 @@ struct btree_search_key_helper
 #define BTREE_SEARCH_KEY_HELPER_INITIALIZER \
   { BTREE_KEY_NOTFOUND, NULL_SLOTID, btree_search_key_helper::NO_FENCE_KEY }
 // *INDENT-ON*
-
-/* BTREE_FIND_UNIQUE_HELPER -
- * Structure used by find unique functions.
- *
- * Functions:
- * btree_key_find_unique_version_oid.
- * btree_key_find_and_lock_unique.
- * btree_key_find_and_lock_unique_of_unique.
- * btree_key_find_and_lock_unique_of_non_unique.
- */
-typedef struct btree_find_unique_helper BTREE_FIND_UNIQUE_HELPER;
-struct btree_find_unique_helper
-{
-  OID oid;			/* OID of found object (if found). */
-  OID match_class_oid;		/* Object is only considered if its class OID matches this class OID. */
-  LOCK lock_mode;		/* Lock mode for found unique object. */
-  MVCC_SNAPSHOT *snapshot;	/* Snapshot used to filter objects not visible. If NULL, objects are not filtered. */
-  bool found_object;		/* Set to true if object was found. */
-
-  PERF_UTIME_TRACKER time_track;
-
-#if defined (SERVER_MODE)
-  OID locked_oid;		/* Locked object. */
-  OID locked_class_oid;		/* Locked object class OID. */
-#endif				/* SERVER_MODE */
-};
-/* BTREE_FIND_UNIQUE_HELPER static initializer. */
-#if defined (SERVER_MODE)
-#define BTREE_FIND_UNIQUE_HELPER_INITIALIZER \
-  { OID_INITIALIZER, /* oid */ \
-    OID_INITIALIZER, /* match_class_oid */ \
-    NULL_LOCK, /* lock_mode */ \
-    NULL, /* snapshot */ \
-    false, /* found_object */ \
-    PERF_UTIME_TRACKER_INITIALIZER, /* time_track */ \
-    OID_INITIALIZER, /* locked_oid */ \
-    OID_INITIALIZER /* locked_class_oid */ \
-  }
-#else	/* !SERVER_MODE */		   /* SA_MODE */
-#define BTREE_FIND_UNIQUE_HELPER_INITIALIZER \
-  { OID_INITIALIZER, /* oid */ \
-    OID_INITIALIZER, /* match_class_oid */ \
-    NULL_LOCK, /* lock_mode */ \
-    NULL, /* snapshot */ \
-    false, /* found_object */ \
-    PERF_UTIME_TRACKER_INITIALIZER /* time_track */ \
-  }
-#endif /* !SA_MODE */
 
 /* BTREE_REC_SATISFIES_SNAPSHOT_HELPER -
  * Structure used as helper for btree_record_satisfies_snapshot function.
@@ -1577,6 +1530,9 @@ static int btree_key_online_index_IB_insert (THREAD_ENTRY * thread_p, BTID_INT *
 					     void *other_args);
 static int btree_key_insert_new_key (THREAD_ENTRY * thread_p, BTID_INT * btid_int, DB_VALUE * key, PAGE_PTR leaf_page,
 				     BTREE_INSERT_HELPER * insert_helper, BTREE_SEARCH_KEY_HELPER * search_key);
+static bool btree_key_find_active_delete_owner (THREAD_ENTRY * thread_p, BTID_INT * btid_int,
+						BTREE_INSERT_HELPER * insert_helper, RECDES * record,
+						int offset_after_key, MVCCID * owner_mvccid);
 static int btree_key_find_and_insert_delete_mvccid (THREAD_ENTRY * thread_p, BTID_INT * btid_int, DB_VALUE * key,
 						    PAGE_PTR * leaf_page, BTREE_SEARCH_KEY_HELPER * search_key,
 						    bool * restart, void *other_args);
@@ -26210,114 +26166,6 @@ btree_key_find_and_lock_unique (THREAD_ENTRY * thread_p, BTID_INT * btid_int, DB
     }
 }
 
-#if defined (SERVER_MODE)
-/*
- * btree_is_active_other_inserter () - Is insert_mvccid an in-progress insert by another transaction?
- *
- * return	      : true if some other transaction is still inserting under insert_mvccid.
- * thread_p (in)      : Thread entry.
- * insert_mvccid (in) : Candidate inserter MVCCID (e.g. BTREE_MVCC_INFO_INSID of the record).
- *
- * Note: guards the "wait for the inserter to end" paths. False when the id is invalid, is our own
- *	 insert, or the inserter has already ended -- in those cases there is nothing to wait on.
- */
-static bool
-btree_is_active_other_inserter (THREAD_ENTRY * thread_p, MVCCID insert_mvccid)
-{
-  return MVCCID_IS_NORMAL (insert_mvccid) && !logtb_is_current_mvccid (thread_p, insert_mvccid)
-    && log_Gl.mvcc_table.is_active (insert_mvccid);
-}
-
-/*
- * btree_wait_for_inserter_end () - Block until the transaction inserting under insert_mvccid ends:
- *				    S_LOCK on its MVCCID self-lock, then release.
- *
- * return	      : NO_ERROR once the inserter has ended. An error if the lock failed, or if the
- *			self-lock invariant is breached (grant while the inserter is still active) --
- *			the wait was a no-op and waiting again cannot recover it, so fail the
- *			statement rather than spin.
- * thread_p (in)      : Thread entry.
- * insert_mvccid (in) : MVCCID of the in-progress inserter to wait out.
- *
- * Note: call with no page latch held.
- */
-static int
-btree_wait_for_inserter_end (THREAD_ENTRY * thread_p, MVCCID insert_mvccid)
-{
-  int error_code;
-
-  if (lock_transaction_mvccid (thread_p, insert_mvccid, S_LOCK, LK_UNCOND_LOCK) != LK_GRANTED)
-    {
-      error_code = er_errid ();
-      if (error_code == NO_ERROR)
-	{
-	  error_code = ER_CANNOT_GET_LOCK;
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_code, 0);
-	}
-      return error_code;
-    }
-  lock_unlock_transaction_mvccid (thread_p, insert_mvccid, S_LOCK);
-
-  if (log_Gl.mvcc_table.is_active (insert_mvccid))
-    {
-      /* Invariant breach: no-op grant while the inserter is still active. */
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CANNOT_GET_LOCK, 0);
-      assert (false);
-      return ER_CANNOT_GET_LOCK;
-    }
-  return NO_ERROR;
-}
-
-/*
- * btree_key_wait_for_insert_mvccid () - Wait for the transaction inserting a conflicting object to
- *					 end, then signal a restart from root.
- *
- * return	       : Error code (NO_ERROR on success, with *restart set to true).
- * thread_p (in)       : Thread entry.
- * insert_mvccid (in)  : MVCCID of the in-progress inserter to wait on.
- * find_unique_helper (in/out) : Find-unique state; any object it has locked is released first.
- * leaf_page (in/out)  : Leaf node page latch; unfixed before suspending and left NULL.
- * overflow_page (in/out) : Optional overflow node page latch (..._of_non_unique () scans overflow pages);
- *			    unfixed before suspending and left NULL. NULL when there is no overflow page.
- * restart (out)       : Set to true so the caller re-reads the key from root.
- *
- * Note: shared by ..._of_unique () and ..._of_non_unique (); blocks on the inserter transaction
- *	 (S_LOCK then release) since appended rows take no per-row X-lock, then restarts from root.
- *	 All page latches must be released before blocking on the lock (never wait while holding a latch).
- */
-static int
-btree_key_wait_for_insert_mvccid (THREAD_ENTRY * thread_p, MVCCID insert_mvccid,
-				  BTREE_FIND_UNIQUE_HELPER * find_unique_helper, PAGE_PTR * leaf_page,
-				  PAGE_PTR * overflow_page, bool * restart)
-{
-  int error_code = NO_ERROR;
-
-  /* Release any previously locked object before suspending. */
-  if (!OID_ISNULL (&find_unique_helper->locked_oid))
-    {
-      lock_unlock_object_donot_move_to_non2pl (thread_p, &find_unique_helper->locked_oid,
-					       &find_unique_helper->locked_class_oid, find_unique_helper->lock_mode);
-      OID_SET_NULL (&find_unique_helper->locked_oid);
-    }
-  /* Release page latches before blocking on the lock. */
-  if (overflow_page != NULL && *overflow_page != NULL)
-    {
-      pgbuf_unfix_and_init (thread_p, *overflow_page);
-    }
-  pgbuf_unfix_and_init (thread_p, *leaf_page);
-
-  error_code = btree_wait_for_inserter_end (thread_p, insert_mvccid);
-  if (error_code != NO_ERROR)
-    {
-      return error_code;
-    }
-
-  /* Inserter has ended; the page may have changed during the wait, so re-read the key from root. */
-  *restart = true;
-  return NO_ERROR;
-}
-#endif /* SERVER_MODE */
-
 /*
  * btree_key_find_and_lock_unique_of_unique () - Find key and lock its first object (if not deleted or dirty).
  *
@@ -26378,14 +26226,10 @@ btree_key_find_and_lock_unique_of_unique (THREAD_ENTRY * thread_p, BTID_INT * bt
       goto error_or_not_found;
     }
 
-  /* Lock key non-dirty version to protect it. Non-dirty or newest key version is always kept first. Locking object is
-   * possible if object is not deleted and it is not dirty (its inserter/deleter is not active). If inserter or
-   * deleter is active, or if conditional lock on object failed, current transaction must suspend until the object lock
-   * holder is completed. This also means unfixing leaf page first. Current algorithm tries to avoid traversing the
-   * b-tree back from root after resume. If conditional lock on object fails, leaf node must be unfixed and then fixed
-   * again after object is locked. If page no longer exists or if the page is no longer usable (key is not in page),
-   * the process is restarted (while holding the lock however). NOTE: Stand-alone mode doesn't require locking. It
-   * should only check whether the first key object is deleted or not. */
+  /* Lock the key's first object; the non-dirty or newest version is always kept first. A live inserter or
+   * deleter is waited out by transaction end, not by the object lock -- see
+   * btree_key_wait_out_conflicting_writer (). NOTE: Stand-alone mode doesn't require locking. It should only
+   * check whether the first key object is deleted or not. */
 
   /* Initialize unique_oid */
   OID_SET_NULL (&unique_oid);
@@ -26446,18 +26290,18 @@ btree_key_find_and_lock_unique_of_unique (THREAD_ENTRY * thread_p, BTID_INT * bt
 	  error_code = ER_FAILED;
 	  goto error_or_not_found;
 #else	/* !SA_MODE */	       /* SERVER_MODE */
-	  if (satisfies_delete == DELETE_RECORD_INSERT_IN_PROGRESS)
+	  error_code = btree_key_wait_out_conflicting_writer (thread_p, satisfies_delete, &mvcc_header,
+							      find_unique_helper, leaf_page, NULL, restart);
+	  if (error_code != NO_ERROR)
 	    {
-	      /* Conflicting object still being inserted: wait for that transaction to end, then restart. */
-	      MVCCID insert_mvccid = BTREE_MVCC_INFO_INSID (&mvcc_info);
-	      if (btree_is_active_other_inserter (thread_p, insert_mvccid))
-		{
-		  return btree_key_wait_for_insert_mvccid (thread_p, insert_mvccid, find_unique_helper, leaf_page,
-							   NULL, restart);
-		}
-	      /* No active inserter (e.g. our own in-progress insert) -- fall through to the row-lock path. */
+	      return error_code;
 	    }
-	  /* Object is being inserted/deleted. We need to lock and suspend until it's fate is decided. */
+	  if (*restart)
+	    {
+	      return NO_ERROR;
+	    }
+
+	  /* No writer left to wait out (our own insert, or one that just ended): lock the object as usual. */
 	  assert (!lock_has_lock_on_object (&unique_oid, &unique_class_oid, find_unique_helper->lock_mode));
 #endif /* SERVER_MODE */
 	  [[fallthrough]];
@@ -26508,7 +26352,7 @@ btree_key_find_and_lock_unique_of_unique (THREAD_ENTRY * thread_p, BTID_INT * bt
 	    {
 	      /* Key was found but we still need to re-check first object. Since page was re-fixed, it may have
 	       * changed. */
-	      break;		/* switch (satisfies_delete) */
+	      continue;
 	    }
 	  else
 	    {
@@ -26629,15 +26473,10 @@ btree_key_find_and_lock_unique_of_non_unique (THREAD_ENTRY * thread_p, BTID_INT 
       goto error_or_not_found;
     }
 
-  /* Lock key non-dirty version to protect it. Since this is not an unique index, but can have only one non-dirty
-   * version, this must be searched through the leaf/overflow records. Locking object is possible if object is not
-   * deleted and it is not dirty (its inserter/deleter is not active). If inserter or deleter is active, or if
-   * conditional lock on object failed, current transaction must suspend until the object lock holder is completed.
-   * This also means unfixing leaf/overflow pages first. Current algorithm tries to avoid traversing the b-tree back
-   * from root after resume. If conditional lock on object fails, leaf/overflow nodes must be unfixed and then fixed
-   * again after object is locked. If leaf page no longer exists or if the page is no longer usable (key is not in
-   * page), the process is restarted from root. If leaf page is still valid, leaf/overflow records are processed again.
-   * NOTE: Stand-alone mode doesn't require locking. It should only check whether the first key object is deleted or not. */
+  /* Lock the key's non-dirty version; since this is not a unique index it must be searched through the
+   * leaf/overflow records. A live inserter or deleter is waited out by transaction end, not by the object
+   * lock -- see btree_key_wait_out_conflicting_writer (). NOTE: Stand-alone mode doesn't require locking. It
+   * should only check whether the first key object is deleted or not. */
 
   /* Initialize unique_oid */
   OID_SET_NULL (&unique_oid);
@@ -26769,18 +26608,18 @@ btree_key_find_and_lock_unique_of_non_unique (THREAD_ENTRY * thread_p, BTID_INT 
 	  error_code = ER_FAILED;
 	  goto error_or_not_found;
 #else	/* !SA_MODE */	       /* SERVER_MODE */
-	  if (satisfies_delete == DELETE_RECORD_INSERT_IN_PROGRESS)
+	  error_code = btree_key_wait_out_conflicting_writer (thread_p, satisfies_delete, &mvcc_header,
+							      find_unique_helper, leaf_page, &overflow_page, restart);
+	  if (error_code != NO_ERROR)
 	    {
-	      /* Conflicting object still being inserted: wait for that transaction to end, then restart. */
-	      MVCCID insert_mvccid = BTREE_MVCC_INFO_INSID (&mvcc_info);
-	      if (btree_is_active_other_inserter (thread_p, insert_mvccid))
-		{
-		  return btree_key_wait_for_insert_mvccid (thread_p, insert_mvccid, find_unique_helper, leaf_page,
-							   &overflow_page, restart);
-		}
-	      /* No active inserter (e.g. our own in-progress insert) -- fall through to the row-lock path. */
+	      return error_code;
 	    }
-	  /* Object is being inserted/deleted. We need to lock and suspend until it's fate is decided. */
+	  if (*restart)
+	    {
+	      return NO_ERROR;
+	    }
+
+	  /* No writer left to wait out (our own insert, or one that just ended): lock the object as usual. */
 	  assert (!lock_has_lock_on_object (&unique_oid, &unique_class_oid, find_unique_helper->lock_mode));
 #endif /* SERVER_MODE */
 	  [[fallthrough]];
@@ -26850,7 +26689,7 @@ btree_key_find_and_lock_unique_of_non_unique (THREAD_ENTRY * thread_p, BTID_INT 
 	      was_page_refixed = false;
 	      /* Safe guard: overflow page must be unfixed. */
 	      assert (overflow_page == NULL);
-	      break;		/* switch (satisfies_delete) */
+	      continue;
 	    }
 	  else
 	    {
@@ -26871,9 +26710,8 @@ btree_key_find_and_lock_unique_of_non_unique (THREAD_ENTRY * thread_p, BTID_INT 
 
 	case DELETE_RECORD_DELETED:
 	case DELETE_RECORD_SELF_DELETED:
-	  /* This object is deleted. */
-	  /* Continue to next object. */
-	  break;
+	  /* This object is deleted; go on to the next one. */
+	  continue;
 
 	default:
 	  /* Unhandled/unexpected case. */
@@ -29358,9 +29196,7 @@ btree_range_scan_find_fk_any_object (THREAD_ENTRY * thread_p, BTREE_SCAN * bts)
  * find_fk_obj (in/out): FK-find state; any object it has locked is released.
  * class_oid (in)      : Class OID of the locked object.
  *
- * Note: shared by the INSERT_IN_PROGRESS and DELETE_IN_PROGRESS paths of btree_fk_object_does_exist ();
- *       both must drop all latches before blocking on the conflicting transaction. The two paths differ
- *       only in how they then wait (transaction self-lock vs. object lock), which stays at the call site.
+ * Note: every caller must drop all latches before blocking on the conflicting transaction.
  */
 static void
 btree_fk_release_pages_and_locks (THREAD_ENTRY * thread_p, BTREE_SCAN * bts, BTREE_FK_EXIST_ARG * fk_arg,
@@ -29431,45 +29267,29 @@ btree_fk_object_does_exist (THREAD_ENTRY * thread_p, BTID_INT * btid_int, RECDES
       return NO_ERROR;
 
     case DELETE_RECORD_INSERT_IN_PROGRESS:
+    case DELETE_RECORD_DELETE_IN_PROGRESS:
 #if defined (SERVER_MODE)
-      /* Referenced row still being inserted. */
+      /* Neither writer holds a row lock the object lock could suspend on, so that lock would be granted at
+       * once and the re-check would spin. Wait for the writer's transaction to end instead. */
       {
-	MVCCID fk_insert_mvccid = BTREE_MVCC_INFO_INSID (mvcc_info);
-	int fk_wait_error;
+	MVCCID fk_writer_mvccid = (satisfy_delete == DELETE_RECORD_INSERT_IN_PROGRESS)
+	  ? BTREE_MVCC_INFO_INSID (mvcc_info) : BTREE_MVCC_INFO_DELID (mvcc_info);
 
-	if (!btree_is_active_other_inserter (thread_p, fk_insert_mvccid))
-	  {
-	    /* Inserter ended in the race since mvcc_satisfies_delete: re-read the key rather than consume the stale
-	     * INSERT_IN_PROGRESS as "not found" (mirrors the unique-scan recheck). */
-	    btree_fk_release_pages_and_locks (thread_p, bts, fk_arg, find_fk_obj, class_oid);
-	    *stop = true;
-	    return NO_ERROR;
-	  }
-
-	/* Wait for that transaction to end before deciding whether the FK reference holds: release all page
-	 * latches and any locked object, then wait out the inserter. */
+	/* The writer may have ended in the race since mvcc_satisfies_delete (), so the verdict can be stale:
+	 * re-read the key either way rather than consume it. */
 	btree_fk_release_pages_and_locks (thread_p, bts, fk_arg, find_fk_obj, class_oid);
-	fk_wait_error = btree_wait_for_inserter_end (thread_p, fk_insert_mvccid);
-	if (fk_wait_error != NO_ERROR)
+	if (logtb_is_active_other_mvccid (thread_p, fk_writer_mvccid))
 	  {
-	    return fk_wait_error;
-	  }
+	    int fk_wait_error = logtb_wait_for_tran_end (thread_p, fk_writer_mvccid);
 
-	/* Inserter ended; trigger re-check. */
+	    if (fk_wait_error != NO_ERROR)
+	      {
+		return fk_wait_error;
+	      }
+	  }
 	*stop = true;
 	return NO_ERROR;
       }
-#else	/* !SERVER_MODE */		   /* SA_MODE */
-      /* Impossible: no other active transactions. */
-      assert_release (false);
-      return ER_FAILED;
-#endif /* SA_MODE */
-
-    case DELETE_RECORD_DELETE_IN_PROGRESS:
-#if defined (SERVER_MODE)
-      /* Object is being deleted by an active transaction. We have to wait for that transaction to commit. Fall through
-       * to suspend. */
-      break;
 #else	/* !SERVER_MODE */		   /* SA_MODE */
       /* Impossible: no other active transactions. */
       assert_release (false);
@@ -32120,6 +31940,59 @@ btree_key_append_object_into_ovf (THREAD_ENTRY * thread_p, BTID_INT * btid_int, 
 }
 
 /*
+ * btree_key_find_active_delete_owner () - Is this object already stamped by a running transaction?
+ *
+ * return		 : True when the object is in this key with a delete MVCCID owned by another
+ *			   running transaction; that MVCCID is output.
+ * thread_p (in)	 : Thread entry.
+ * btid_int (in)	 : B-tree info.
+ * insert_helper (in)	 : Names the object we came to stamp.
+ * record (in)		 : The key's leaf record.
+ * offset_after_key (in) : Offset in the record where the packed key ends.
+ * owner_mvccid (out)	 : The owning MVCCID.
+ *
+ * Note: only the leaf record is walked; an object that moved to an overflow page is not found here.
+ *	The waiting half of this mechanism is btree_key_wait_for_tran_end () in btree_object_lock.cpp; this
+ *	half stays in btree.c because it reads the leaf record layout.
+ */
+static bool
+btree_key_find_active_delete_owner (THREAD_ENTRY * thread_p, BTID_INT * btid_int, BTREE_INSERT_HELPER * insert_helper,
+				    RECDES * record, int offset_after_key, MVCCID * owner_mvccid)
+{
+#if defined (SERVER_MODE)
+  OR_BUF buf;
+  OID inst_oid, class_oid;
+  BTREE_MVCC_INFO mvcc_info;
+  bool is_first = true;
+
+  assert (owner_mvccid != NULL);
+
+  BTREE_RECORD_OR_BUF_INIT (buf, record);
+  while (buf.ptr < buf.endptr)
+    {
+      if (btree_or_get_object (&buf, btid_int, BTREE_LEAF_NODE, offset_after_key, &inst_oid, &class_oid, &mvcc_info)
+	  != NO_ERROR)
+	{
+	  return false;
+	}
+      if (OID_EQ (&inst_oid, BTREE_INSERT_OID (insert_helper)) && BTREE_MVCC_INFO_IS_DELID_VALID (&mvcc_info)
+	  && logtb_is_active_other_mvccid (thread_p, mvcc_info.delete_mvccid))
+	{
+	  *owner_mvccid = mvcc_info.delete_mvccid;
+	  return true;
+	}
+      if (is_first)
+	{
+	  or_seek (&buf, offset_after_key);
+	  is_first = false;
+	}
+    }
+#endif /* SERVER_MODE */
+
+  return false;
+}
+
+/*
  * btree_key_find_and_insert_delete_mvccid () - BTREE_ADVANCE_WITH_KEY_FUNCTION used for MVCC logical delete.
  *						An object is found and an MVCCID is added to its MVCC info.
  *
@@ -32151,6 +32024,7 @@ btree_key_find_and_insert_delete_mvccid (THREAD_ENTRY * thread_p, BTID_INT * bti
 
   int num_visible = 0;
   MVCC_SNAPSHOT snapshot_dirty;
+  MVCCID settle_owner_mvccid = MVCCID_NULL;
 
   /* Assert expected arguments. */
   assert (btid_int != NULL);
@@ -32230,6 +32104,28 @@ btree_key_find_and_insert_delete_mvccid (THREAD_ENTRY * thread_p, BTID_INT * bti
   if (offset_to_found_object == NOT_FOUND)
     {
       assert (found_page == NULL);
+
+      /* NOT_FOUND can also mean the object is here with a delete MVCCID already set: this purpose matches
+       * only an object without one.  A still-running owner means the entry was stamped by a writer that gave
+       * up the row lock before ending, and rollback restores the heap before the index -- so the record this
+       * key came from can already be back to the version it was stamped for.  The heap-side settle cannot
+       * see that, only the entry can.  Hand the owner to btree_key_wait_for_tran_end (), which drops the
+       * latch, waits under the transaction's lock timeout and asks for a restart -- the same primitive the
+       * unique-key probe waits on.  No private budget here, and the heap-side settle keeps no count either. */
+#if defined (SERVER_MODE)
+      if (insert_helper->purpose == BTREE_OP_INSERT_MVCC_DELID
+	  && btree_key_find_active_delete_owner (thread_p, btid_int, insert_helper, &record, offset_after_key,
+						 &settle_owner_mvccid))
+	{
+	  error_code = btree_key_wait_for_tran_end (thread_p, settle_owner_mvccid, NULL, leaf_page, NULL, restart);
+	  if (error_code != NO_ERROR)
+	    {
+	      ASSERT_ERROR ();
+	    }
+	  goto exit;
+	}
+#endif /* SERVER_MODE */
+
       assert (false);
       btree_set_unknown_key_error (thread_p, btid_int->sys_btid, key, "btree_key_find_and_insert_delete_mvccid");
       error_code = ER_BTREE_UNKNOWN_KEY;

--- a/src/storage/btree_object_lock.cpp
+++ b/src/storage/btree_object_lock.cpp
@@ -1,0 +1,146 @@
+/*
+ *
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+//
+// Object locking through a b-tree key - taking the lock, and waiting out a writer that holds it
+//
+
+#include "btree_object_lock.hpp"
+
+#include "error_manager.h"
+#include "lock_manager.h"
+#include "log_impl.h"
+#include "page_buffer.h"
+
+// XXX: SHOULD BE THE LAST INCLUDE HEADER
+#include "memory_wrapper.hpp"
+
+#if defined (SERVER_MODE)
+
+static void btree_key_release_locked_object_and_pages (THREAD_ENTRY *thread_p,
+    BTREE_FIND_UNIQUE_HELPER *find_unique_helper,
+    PAGE_PTR *leaf_page, PAGE_PTR *overflow_page);
+
+/*
+ * btree_key_wait_out_conflicting_writer () - Wait out the transaction inserting or deleting the key's
+ *					      first object, if one is still live.
+ *
+ * return	       : Error code.  On NO_ERROR, *restart says what the caller must do next.
+ * thread_p (in)       : Thread entry.
+ * satisfies_delete (in) : DELETE_RECORD_INSERT_IN_PROGRESS or DELETE_RECORD_DELETE_IN_PROGRESS.
+ * mvcc_header (in)    : MVCC header of the first object, carrying the writer's MVCCID.
+ * find_unique_helper (in/out) : Find-unique state.
+ * leaf_page (in/out)  : Leaf node page latch.
+ * overflow_page (in/out) : Optional overflow node page latch; NULL when there is none.
+ * restart (out)       : Outputs true when the key must be re-read from root; otherwise untouched.
+ *
+ * Note: neither writer holds a row lock the caller's object lock could suspend on, so that lock would be
+ *	 granted at once and the re-check would spin.  Serialize on the writer's transaction end instead.
+ */
+int
+btree_key_wait_out_conflicting_writer (THREAD_ENTRY *thread_p, MVCC_SATISFIES_DELETE_RESULT satisfies_delete,
+				       MVCC_REC_HEADER *mvcc_header, BTREE_FIND_UNIQUE_HELPER *find_unique_helper,
+				       PAGE_PTR *leaf_page, PAGE_PTR *overflow_page, bool *restart)
+{
+  MVCCID writer_mvccid;
+
+  assert (satisfies_delete == DELETE_RECORD_INSERT_IN_PROGRESS || satisfies_delete == DELETE_RECORD_DELETE_IN_PROGRESS);
+
+  writer_mvccid = (satisfies_delete == DELETE_RECORD_INSERT_IN_PROGRESS)
+		  ? MVCC_GET_INSID (mvcc_header) : MVCC_GET_DELID (mvcc_header);
+
+  if (logtb_is_active_other_mvccid (thread_p, writer_mvccid))
+    {
+      return btree_key_wait_for_tran_end (thread_p, writer_mvccid, find_unique_helper, leaf_page, overflow_page,
+					  restart);
+    }
+
+  if (satisfies_delete == DELETE_RECORD_DELETE_IN_PROGRESS)
+    {
+      /* Verdict is stale: the deleter ended in the race and may have freed an object this scan locked. */
+      btree_key_release_locked_object_and_pages (thread_p, find_unique_helper, leaf_page, overflow_page);
+      *restart = true;
+    }
+
+  return NO_ERROR;
+}
+
+/*
+ * btree_key_wait_for_tran_end () - Wait for the writer working under the given MVCCID to end,
+ *				    then signal a restart from root.
+ *
+ * return	       : Error code (NO_ERROR on success, with *restart set to true).
+ * thread_p (in)       : Thread entry.
+ * writer_mvccid (in)  : MVCCID of the in-progress inserter or deleter to wait on.
+ * find_unique_helper (in/out) : Find-unique state; any object it has locked is released first.  NULL
+ *			       when the caller holds no object lock -- the stamp path comes in that way.
+ * leaf_page (in/out)  : Leaf node page latch; unfixed before suspending and left NULL.
+ * overflow_page (in/out) : Optional overflow node page latch (..._of_non_unique () scans overflow pages);
+ *			    unfixed before suspending and left NULL. NULL when there is no overflow page.
+ * restart (out)       : Set to true so the caller re-reads the key from root.
+ *
+ * Note: all page latches must be released before blocking on the lock (never wait while holding a latch).
+ */
+int
+btree_key_wait_for_tran_end (THREAD_ENTRY *thread_p, MVCCID writer_mvccid,
+			     BTREE_FIND_UNIQUE_HELPER *find_unique_helper, PAGE_PTR *leaf_page,
+			     PAGE_PTR *overflow_page, bool *restart)
+{
+  int error_code = NO_ERROR;
+
+  /* Release the locked object and the page latches before blocking on the lock. */
+  btree_key_release_locked_object_and_pages (thread_p, find_unique_helper, leaf_page, overflow_page);
+
+  error_code = logtb_wait_for_tran_end (thread_p, writer_mvccid);
+  if (error_code != NO_ERROR)
+    {
+      return error_code;
+    }
+
+  /* The page may have changed during the wait, so re-read the key from root. */
+  *restart = true;
+  return NO_ERROR;
+}
+
+/*
+ * btree_key_release_locked_object_and_pages () - Drop what this scan holds on the key: the object it
+ *						  locked and the page latches. The caller re-reads from root.
+ *
+ * thread_p (in)       : Thread entry.
+ * find_unique_helper (in/out) : Find-unique state; any object it has locked is released and forgotten.
+ *			       NULL when the caller holds no object lock, only page latches.
+ * leaf_page (in/out)  : Leaf node page latch; unfixed and left NULL.
+ * overflow_page (in/out) : Optional overflow node page latch; unfixed and left NULL, NULL when there is none.
+ */
+static void
+btree_key_release_locked_object_and_pages (THREAD_ENTRY *thread_p, BTREE_FIND_UNIQUE_HELPER *find_unique_helper,
+    PAGE_PTR *leaf_page, PAGE_PTR *overflow_page)
+{
+  if (find_unique_helper != NULL && !OID_ISNULL (&find_unique_helper->locked_oid))
+    {
+      lock_unlock_object_donot_move_to_non2pl (thread_p, &find_unique_helper->locked_oid,
+	  &find_unique_helper->locked_class_oid, find_unique_helper->lock_mode);
+      OID_SET_NULL (&find_unique_helper->locked_oid);
+    }
+  if (overflow_page != NULL && *overflow_page != NULL)
+    {
+      pgbuf_unfix_and_init (thread_p, *overflow_page);
+    }
+  pgbuf_unfix_and_init (thread_p, *leaf_page);
+}
+#endif /* SERVER_MODE */

--- a/src/storage/btree_object_lock.hpp
+++ b/src/storage/btree_object_lock.hpp
@@ -1,0 +1,93 @@
+/*
+ *
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+//
+// Object locking through a b-tree key - taking the lock, and waiting out a writer that holds it
+//
+
+#ifndef _BTREE_OBJECT_LOCK_HPP_
+#define _BTREE_OBJECT_LOCK_HPP_
+
+#if !defined (SERVER_MODE) && !defined (SA_MODE)
+#error Belongs to server module
+#endif /* !defined (SERVER_MODE) && !defined (SA_MODE) */
+
+#include "lock_manager.h"
+#include "mvcc.h"
+#include "oid.h"
+#include "perf_monitor.h"
+#include "storage_common.h"
+#include "thread_compat.hpp"
+
+/* BTREE_FIND_UNIQUE_HELPER - State carried through a unique-key probe: what to match, what was found,
+ *			      and what this scan has locked and must release if it restarts.
+ */
+typedef struct btree_find_unique_helper BTREE_FIND_UNIQUE_HELPER;
+struct btree_find_unique_helper
+{
+  OID oid;			/* OID of found object (if found). */
+  OID match_class_oid;		/* Object is only considered if its class OID matches this class OID. */
+  LOCK lock_mode;		/* Lock mode for found unique object. */
+  MVCC_SNAPSHOT *snapshot;	/* Snapshot used to filter objects not visible. If NULL, objects are not filtered. */
+  bool found_object;		/* Set to true if object was found. */
+
+  PERF_UTIME_TRACKER time_track;
+
+#if defined (SERVER_MODE)
+  OID locked_oid;		/* Locked object. */
+  OID locked_class_oid;		/* Locked object class OID. */
+#endif				/* SERVER_MODE */
+};
+/* BTREE_FIND_UNIQUE_HELPER static initializer. */
+#if defined (SERVER_MODE)
+#define BTREE_FIND_UNIQUE_HELPER_INITIALIZER \
+  { OID_INITIALIZER, /* oid */ \
+    OID_INITIALIZER, /* match_class_oid */ \
+    NULL_LOCK, /* lock_mode */ \
+    NULL, /* snapshot */ \
+    false, /* found_object */ \
+    PERF_UTIME_TRACKER_INITIALIZER, /* time_track */ \
+    OID_INITIALIZER, /* locked_oid */ \
+    OID_INITIALIZER /* locked_class_oid */ \
+  }
+#else	/* !SERVER_MODE */		   /* SA_MODE */
+#define BTREE_FIND_UNIQUE_HELPER_INITIALIZER \
+  { OID_INITIALIZER, /* oid */ \
+    OID_INITIALIZER, /* match_class_oid */ \
+    NULL_LOCK, /* lock_mode */ \
+    NULL, /* snapshot */ \
+    false, /* found_object */ \
+    PERF_UTIME_TRACKER_INITIALIZER /* time_track */ \
+  }
+#endif /* !SA_MODE */
+
+#if defined (SERVER_MODE)
+extern int btree_key_wait_out_conflicting_writer (THREAD_ENTRY *thread_p,
+    MVCC_SATISFIES_DELETE_RESULT satisfies_delete,
+    MVCC_REC_HEADER *mvcc_header,
+    BTREE_FIND_UNIQUE_HELPER *find_unique_helper,
+    PAGE_PTR *leaf_page, PAGE_PTR *overflow_page, bool *restart);
+/* The other half of this mechanism -- finding, in a leaf record, the active writer MVCCID to wait for -- is
+ * btree_key_find_active_delete_owner () in btree.c.  It stays there because it walks the leaf record layout
+ * (btree_or_get_object () and the record macros are private to btree.c); only the waiting is here. */
+extern int btree_key_wait_for_tran_end (THREAD_ENTRY *thread_p, MVCCID writer_mvccid,
+					BTREE_FIND_UNIQUE_HELPER *find_unique_helper, PAGE_PTR *leaf_page,
+					PAGE_PTR *overflow_page, bool *restart);
+#endif /* SERVER_MODE */
+
+#endif /* _BTREE_OBJECT_LOCK_HPP_ */

--- a/src/storage/compactdb_sr.c
+++ b/src/storage/compactdb_sr.c
@@ -211,7 +211,7 @@ process_object (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * upd_scancache, HEAP_CA
 
   /* get object with X_LOCK */
   scan_code = locator_lock_and_get_object (thread_p, oid, &upd_scancache->node.class_oid, &copy_recdes, upd_scancache,
-					   X_LOCK, COPY, NULL_CHN, LOG_WARNING_IF_DELETED);
+					   X_LOCK, COPY, NULL_CHN, LOG_WARNING_IF_DELETED, false, false);
   if (scan_code != S_SUCCESS)
     {
       if (er_errid () == ER_HEAP_UNKNOWN_OBJECT)
@@ -259,7 +259,7 @@ process_object (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * upd_scancache, HEAP_CA
 	locator_attribute_info_force (thread_p, &upd_scancache->node.hfid, oid, attr_info, atts_id, updated_n_attrs_id,
 				      LC_FLUSH_UPDATE, SINGLE_ROW_UPDATE, upd_scancache, &force_count, false,
 				      REPL_INFO_TYPE_RBR_NORMAL, DB_NOT_PARTITIONED_CLASS, NULL, NULL, NULL,
-				      UPDATE_INPLACE_NONE, &copy_recdes, false);
+				      UPDATE_INPLACE_NONE, &copy_recdes, LOCATOR_LOCK_AT_SELECT);
       if (error_code != NO_ERROR)
 	{
 	  if (error_code == ER_MVCC_NOT_SATISFIED_REEVALUATION)

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -18039,7 +18039,7 @@ heap_object_upgrade_domain (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * upd_scanca
     locator_attribute_info_force (thread_p, &upd_scancache->node.hfid, oid, attr_info, atts_id, updated_n_attrs_id,
 				  LC_FLUSH_UPDATE, SINGLE_ROW_UPDATE, upd_scancache, &force_count, false,
 				  REPL_INFO_TYPE_RBR_NORMAL, DB_NOT_PARTITIONED_CLASS, NULL, NULL, NULL,
-				  UPDATE_INPLACE_OLD_MVCCID, NULL, false);
+				  UPDATE_INPLACE_OLD_MVCCID, NULL, LOCATOR_LOCK_AT_SELECT);
   if (error != NO_ERROR)
     {
       if (error == ER_MVCC_NOT_SATISFIED_REEVALUATION)
@@ -23626,6 +23626,17 @@ heap_delete_logical (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context)
   else
     {
       is_mvcc_op = true;
+    }
+
+  /* late arrivals settle a DELETE_IN_PROGRESS row against the deleter's MVCCID self-lock, so it must be
+   * held before the DELID stamp becomes observable */
+  if (is_mvcc_op)
+    {
+      rc = logtb_ensure_mvccid_self_lock (thread_p);
+      if (rc != NO_ERROR)
+	{
+	  return rc;
+	}
     }
 #else /* SERVER_MODE */
   is_mvcc_op = false;

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -151,19 +151,20 @@ static int locator_update_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * cla
 				 HEAP_SCANCACHE * scan_cache, int *force_count, bool not_check_fk,
 				 REPL_INFO_TYPE repl_info_type, int pruning_type, PRUNING_CONTEXT * pcontext,
 				 MVCC_REEV_DATA * mvcc_reev_data, UPDATE_INPLACE_STYLE force_in_place,
-				 bool need_locking);
+				 LOCATOR_LOCK_POLICY lock_policy);
 static int locator_move_record (THREAD_ENTRY * thread_p, HFID * old_hfid, OID * old_class_oid, OID * obj_oid,
 				OID * new_class_oid, HFID * new_class_hfid, RECDES * recdes,
 				HEAP_SCANCACHE * scan_cache, int op_type, int has_index, int *force_count,
-				PRUNING_CONTEXT * context, MVCC_REEV_DATA * mvcc_reev_data, bool need_locking);
+				PRUNING_CONTEXT * context, MVCC_REEV_DATA * mvcc_reev_data,
+				LOCATOR_LOCK_POLICY lock_policy);
 static int locator_delete_force_for_moving (THREAD_ENTRY * thread_p, HFID * hfid, OID * oid, int has_index, int op_type,
 					    HEAP_SCANCACHE * scan_cache, int *force_count,
 					    MVCC_REEV_DATA * mvcc_reev_data, OID * new_obj_oid, OID * partition_oid,
-					    bool need_locking);
+					    LOCATOR_LOCK_POLICY lock_policy);
 static int locator_delete_force_internal (THREAD_ENTRY * thread_p, HFID * hfid, OID * oid, int has_index, int op_type,
 					  HEAP_SCANCACHE * scan_cache, int *force_count,
 					  MVCC_REEV_DATA * mvcc_reev_data, LOCATOR_INDEX_ACTION_FLAG idx_action_flag,
-					  OID * new_obj_oid, OID * partition_oid, bool need_locking);
+					  OID * new_obj_oid, OID * partition_oid, LOCATOR_LOCK_POLICY lock_policy);
 static int locator_force_for_multi_update (THREAD_ENTRY * thread_p, LC_COPYAREA * force_area);
 
 #if defined(ENABLE_UNUSED_FUNCTION)
@@ -217,7 +218,8 @@ static void locator_generate_class_pseudo_oid (THREAD_ENTRY * thread_p, OID * cl
 
 static int redistribute_partition_data (THREAD_ENTRY * thread_p, OID * class_oid, int no_oids, OID * oid_list);
 static SCAN_CODE locator_lock_and_get_object_internal (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * context,
-						       LOCK lock_mode);
+						       LOCK lock_mode, bool transient, bool owner_bypass_ok,
+						       bool * lock_acquired_p);
 static DB_LOGICAL locator_mvcc_reev_cond_assigns (THREAD_ENTRY * thread_p, OID * class_oid, const OID * oid,
 						  HEAP_SCANCACHE * scan_cache, RECDES * recdes,
 						  MVCC_UPDDEL_REEV_DATA * mvcc_reev_data);
@@ -4431,8 +4433,9 @@ locator_check_primary_key_delete (THREAD_ENTRY * thread_p, OR_INDEX * index, DB_
 		  recdes.data = NULL;
 		  /* TO DO - handle reevaluation */
 
+		  /* kept to commit, but a child row this transaction itself stamped is touched again without its lock */
 		  scan_code = locator_lock_and_get_object (thread_p, oid_ptr, &fkref->self_oid, &recdes, &scan_cache,
-							   X_LOCK, COPY, NULL_CHN, LOG_ERROR_IF_DELETED);
+							   X_LOCK, COPY, NULL_CHN, LOG_ERROR_IF_DELETED, false, true);
 		  if (scan_code != S_SUCCESS)
 		    {
 		      if (scan_code == S_DOESNT_EXIST && er_errid () != ER_HEAP_UNKNOWN_OBJECT)
@@ -4467,7 +4470,7 @@ locator_check_primary_key_delete (THREAD_ENTRY * thread_p, OR_INDEX * index, DB_
 		      /* oid already locked at locator_lock_and_get_object */
 		      error_code =
 			locator_delete_force (thread_p, &hfid, oid_ptr, true, SINGLE_ROW_DELETE, &scan_cache,
-					      &force_count, NULL, false);
+					      &force_count, NULL, LOCATOR_LOCK_AT_SELECT);
 		      if (error_code == ER_MVCC_NOT_SATISFIED_REEVALUATION)
 			{
 			  /* skip foreign keys that were already deleted. For example the "cross type" reference */
@@ -4499,7 +4502,7 @@ locator_check_primary_key_delete (THREAD_ENTRY * thread_p, OR_INDEX * index, DB_
 			locator_attribute_info_force (thread_p, &hfid, oid_ptr, &attr_info, attr_ids, index->n_atts,
 						      LC_FLUSH_UPDATE, SINGLE_ROW_UPDATE, &scan_cache, &force_count,
 						      false, REPL_INFO_TYPE_RBR_NORMAL, DB_NOT_PARTITIONED_CLASS, NULL,
-						      NULL, NULL, UPDATE_INPLACE_NONE, &recdes, false);
+						      NULL, NULL, UPDATE_INPLACE_NONE, &recdes, LOCATOR_LOCK_AT_SELECT);
 		      if (error_code != NO_ERROR)
 			{
 			  if (error_code == ER_MVCC_NOT_SATISFIED_REEVALUATION)
@@ -4786,8 +4789,9 @@ locator_check_primary_key_update (THREAD_ENTRY * thread_p, OR_INDEX * index, DB_
 		  recdes.data = NULL;
 		  /* TO DO - handle reevaluation */
 
+		  /* kept to commit, but a child row this transaction itself stamped is touched again without its lock */
 		  scan_code = locator_lock_and_get_object (thread_p, oid_ptr, &fkref->self_oid, &recdes, &scan_cache,
-							   X_LOCK, COPY, NULL_CHN, LOG_ERROR_IF_DELETED);
+							   X_LOCK, COPY, NULL_CHN, LOG_ERROR_IF_DELETED, false, true);
 		  if (scan_code != S_SUCCESS)
 		    {
 		      if (scan_code == S_DOESNT_EXIST && er_errid () != ER_HEAP_UNKNOWN_OBJECT)
@@ -4840,7 +4844,7 @@ locator_check_primary_key_update (THREAD_ENTRY * thread_p, OR_INDEX * index, DB_
 		    locator_attribute_info_force (thread_p, &hfid, oid_ptr, &attr_info, attr_ids, index->n_atts,
 						  LC_FLUSH_UPDATE, SINGLE_ROW_UPDATE, &scan_cache, &force_count, false,
 						  REPL_INFO_TYPE_RBR_NORMAL, DB_NOT_PARTITIONED_CLASS, NULL, NULL, NULL,
-						  UPDATE_INPLACE_NONE, &recdes, false);
+						  UPDATE_INPLACE_NONE, &recdes, LOCATOR_LOCK_AT_SELECT);
 		  if (error_code != NO_ERROR)
 		    {
 		      if (error_code == ER_MVCC_NOT_SATISFIED_REEVALUATION)
@@ -5285,7 +5289,7 @@ error2:
  * force_count (in/out)	:
  * context(in)	        : pruning context
  * mvcc_reev_data(in)	: MVCC reevaluation data
- * need_locking(in)	: true, if need locking
+ * lock_policy(in)	: where the row lock is taken and how long it is kept
  *
  * Note: this function calls locator_delete_force on the current object oid
  * and locator_insert_force for the RECDES it receives. The record has already
@@ -5295,7 +5299,8 @@ error2:
 static int
 locator_move_record (THREAD_ENTRY * thread_p, HFID * old_hfid, OID * old_class_oid, OID * obj_oid, OID * new_class_oid,
 		     HFID * new_class_hfid, RECDES * recdes, HEAP_SCANCACHE * scan_cache, int op_type, int has_index,
-		     int *force_count, PRUNING_CONTEXT * context, MVCC_REEV_DATA * mvcc_reev_data, bool need_locking)
+		     int *force_count, PRUNING_CONTEXT * context, MVCC_REEV_DATA * mvcc_reev_data,
+		     LOCATOR_LOCK_POLICY lock_policy)
 {
   int error = NO_ERROR;
   OID new_obj_oid;
@@ -5350,7 +5355,7 @@ locator_move_record (THREAD_ENTRY * thread_p, HFID * old_hfid, OID * old_class_o
   /* delete this record from the class it currently resides in */
   error =
     locator_delete_force_for_moving (thread_p, old_hfid, obj_oid, true, op_type, scan_cache, force_count,
-				     mvcc_reev_data, &new_obj_oid, new_class_oid, need_locking);
+				     mvcc_reev_data, &new_obj_oid, new_class_oid, lock_policy);
   if (error != NO_ERROR)
     {
       return error;
@@ -5397,7 +5402,7 @@ locator_update_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
 		      RECDES * recdes, int has_index, ATTR_ID * att_id, int n_att_id, int op_type,
 		      HEAP_SCANCACHE * scan_cache, int *force_count, bool not_check_fk, REPL_INFO_TYPE repl_info_type,
 		      int pruning_type, PRUNING_CONTEXT * pcontext, MVCC_REEV_DATA * mvcc_reev_data,
-		      UPDATE_INPLACE_STYLE force_in_place, bool need_locking)
+		      UPDATE_INPLACE_STYLE force_in_place, LOCATOR_LOCK_POLICY lock_policy)
 {
   OID rep_dir = { NULL_PAGEID, NULL_SLOTID, NULL_VOLID };
   char *rep_dir_offset;
@@ -5716,11 +5721,14 @@ locator_update_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
 		  mvcc_reev_data->upddel_reev_data->new_recdes = recdes;
 		}
 
-	      if (need_locking)
+	      if (!LOCATOR_LOCKED_AT_SELECT (lock_policy))
 		{
 		  scan = locator_lock_and_get_object_with_evaluation (thread_p, oid, class_oid, &copy_recdes,
 								      local_scan_cache, COPY, NULL_CHN, mvcc_reev_data,
-								      LOG_ERROR_IF_DELETED);
+								      LOG_ERROR_IF_DELETED,
+								      LOCATOR_LOCK_IS_TRANSIENT (lock_policy),
+								      LOCATOR_LOCKED_AT_SELECT (lock_policy)
+								      || LOCATOR_LOCK_IS_TRANSIENT (lock_policy));
 		}
 	      else
 		{
@@ -5951,7 +5959,7 @@ locator_update_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
 
 	      error_code =
 		locator_move_record (thread_p, hfid, class_oid, oid, &real_class_oid, &real_hfid, recdes, scan_cache,
-				     op_type, has_index, force_count, pcontext, mvcc_reev_data, need_locking);
+				     op_type, has_index, force_count, pcontext, mvcc_reev_data, lock_policy);
 	      if (error_code == NO_ERROR)
 		{
 		  COPY_OID (class_oid, &real_class_oid);
@@ -6097,6 +6105,53 @@ error:
 }
 
 /*
+ * locator_class_has_online_index () - is an index of this class being built online?
+ *   return: true when at least one index is in OR_ONLINE_INDEX_BUILDING_IN_PROGRESS
+ *   thread_p(in): thread entry
+ *   class_oid(in): the class
+ *
+ * Note: an online build keeps its own state on each index entry -- INSERT_FLAG, DELETE_FLAG, or
+ *	 neither -- and that state carries no MVCCID: it names neither the transaction that left it nor
+ *	 whether that transaction ended.  The row lock is what keeps two writers from reading the same
+ *	 entry under different assumptions, so a class under an online build keeps it to commit.
+ *
+ *	 One answer per class holds for the whole statement, and not because the build holds a strong
+ *	 lock throughout -- it demotes to IX for the load precisely so DML is not blocked.  It holds
+ *	 because the status is published by a schema change under SCH_M, and a DML statement holds IX on
+ *	 the class to commit: no statement spans that publication.  A caller that cannot read the class
+ *	 representation is told to keep the lock.
+ */
+bool
+locator_class_has_online_index (THREAD_ENTRY * thread_p, const OID * class_oid)
+{
+  OR_CLASSREP *classrep = NULL;
+  int idx_in_cache = -1;
+  bool found = false;
+  int i;
+
+  assert (class_oid != NULL && !OID_ISNULL (class_oid));
+
+  classrep = heap_classrepr_get (thread_p, (OID *) class_oid, NULL, NULL_REPRID, &idx_in_cache);
+  if (classrep == NULL)
+    {
+      return true;
+    }
+
+  for (i = 0; i < classrep->n_indexes; i++)
+    {
+      if (classrep->indexes[i].index_status == OR_ONLINE_INDEX_BUILDING_IN_PROGRESS)
+	{
+	  found = true;
+	  break;
+	}
+    }
+
+  heap_classrepr_free_and_init (classrep, &idx_in_cache);
+
+  return found;
+}
+
+/*
  * locator_delete_force () - Delete the given object
  *
  * return: NO_ERROR if all OK, ER_ status otherwise
@@ -6108,16 +6163,17 @@ error:
  *   scan_cache(in/out): Scan cache used to estimate the best space pages between heap changes.
  *   force_count(in):
  *   mvcc_reev_data(in): MVCC data
- *   need_locking(in): true, if need locking
+ *   lock_policy(in): where the row lock is taken and how long it is kept
  *
  * Note: The given object is deleted on this heap and all appropiate index entries are deleted.
  */
 int
 locator_delete_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * oid, int has_index, int op_type,
-		      HEAP_SCANCACHE * scan_cache, int *force_count, MVCC_REEV_DATA * mvcc_reev_data, bool need_locking)
+		      HEAP_SCANCACHE * scan_cache, int *force_count, MVCC_REEV_DATA * mvcc_reev_data,
+		      LOCATOR_LOCK_POLICY lock_policy)
 {
   return locator_delete_force_internal (thread_p, hfid, oid, has_index, op_type, scan_cache, force_count,
-					mvcc_reev_data, FOR_INSERT_OR_DELETE, NULL, NULL, need_locking);
+					mvcc_reev_data, FOR_INSERT_OR_DELETE, NULL, NULL, lock_policy);
 }
 
 /*
@@ -6136,17 +6192,17 @@ locator_delete_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * oid, int has_i
  *   mvcc_reev_data(in): MVCC data
  *   new_obj_oid(in): next version - only to be used with records relocated in other partitions, in MVCC.
  *   partition_oid(in): new partition class oid
- *   need_locking(in): true, if need locking
+ *   lock_policy(in): where the row lock is taken and how long it is kept
  *
  * Note: The given object is deleted on this heap and all appropriate index entries are deleted.
  */
 static int
 locator_delete_force_for_moving (THREAD_ENTRY * thread_p, HFID * hfid, OID * oid, int has_index, int op_type,
 				 HEAP_SCANCACHE * scan_cache, int *force_count, MVCC_REEV_DATA * mvcc_reev_data,
-				 OID * new_obj_oid, OID * partition_oid, bool need_locking)
+				 OID * new_obj_oid, OID * partition_oid, LOCATOR_LOCK_POLICY lock_policy)
 {
   return locator_delete_force_internal (thread_p, hfid, oid, has_index, op_type, scan_cache, force_count,
-					mvcc_reev_data, FOR_MOVE, new_obj_oid, partition_oid, need_locking);
+					mvcc_reev_data, FOR_MOVE, new_obj_oid, partition_oid, lock_policy);
 }
 
 /*
@@ -6164,7 +6220,7 @@ locator_delete_force_for_moving (THREAD_ENTRY * thread_p, HFID * hfid, OID * oid
  *			  'UPDATE ... SET ...', NOT 'DELETE FROM ...'
  *   new_obj_oid(in): next version - only to be used with records relocated in other partitions, in MVCC.
  *   partition_oid(in): new partition class oid
- *   need_locking(in): true, if need locking
+ *   lock_policy(in): where the row lock is taken and how long it is kept
  *
  * Note: The given object is deleted on this heap and all appropriate index entries are deleted.
  */
@@ -6172,7 +6228,7 @@ static int
 locator_delete_force_internal (THREAD_ENTRY * thread_p, HFID * hfid, OID * oid, int has_index, int op_type,
 			       HEAP_SCANCACHE * scan_cache, int *force_count, MVCC_REEV_DATA * mvcc_reev_data,
 			       LOCATOR_INDEX_ACTION_FLAG idx_action_flag, OID * new_obj_oid, OID * partition_oid,
-			       bool need_locking)
+			       LOCATOR_LOCK_POLICY lock_policy)
 {
   bool isold_object;		/* Make sure that this is an old object during the deletion */
   OID class_oid = { NULL_PAGEID, NULL_SLOTID, NULL_VOLID };
@@ -6198,17 +6254,20 @@ locator_delete_force_internal (THREAD_ENTRY * thread_p, HFID * hfid, OID * oid, 
 
   copy_recdes.data = NULL;
 
-  if (need_locking == false)
+  if (LOCATOR_LOCKED_AT_SELECT (lock_policy))
     {
       /* the reevaluation is not necessary if the object is already locked */
       mvcc_reev_data = NULL;
     }
 
-  /* IMPORTANT TODO: use a different get function when need_locking==false, but make sure it gets the last version,
+  /* IMPORTANT TODO: use a different get function when the select phase locked, but make sure it gets the last version,
      not the visible one; we need only the last version to use it to retrieve the last version of the btree key */
   scan_code =
     locator_lock_and_get_object_with_evaluation (thread_p, oid, &class_oid, &copy_recdes, scan_cache, COPY, NULL_CHN,
-						 mvcc_reev_data, LOG_WARNING_IF_DELETED);
+						 mvcc_reev_data, LOG_WARNING_IF_DELETED,
+						 LOCATOR_LOCK_IS_TRANSIENT (lock_policy),
+						 LOCATOR_LOCKED_AT_SELECT (lock_policy)
+						 || LOCATOR_LOCK_IS_TRANSIENT (lock_policy));
 
   if (scan_code == S_SUCCESS && mvcc_reev_data != NULL && mvcc_reev_data->filter_result == V_FALSE)
     {
@@ -6661,7 +6720,7 @@ locator_force_for_multi_update (THREAD_ENTRY * thread_p, LC_COPYAREA * force_are
 	  error_code =
 	    locator_update_force (thread_p, &obj->hfid, &obj->class_oid, &obj->oid, NULL, &recdes,
 				  has_index, NULL, 0, MULTI_ROW_UPDATE, &scan_cache, &force_count, false, repl_info,
-				  DB_NOT_PARTITIONED_CLASS, NULL, NULL, UPDATE_INPLACE_NONE, true);
+				  DB_NOT_PARTITIONED_CLASS, NULL, NULL, UPDATE_INPLACE_NONE, LOCATOR_LOCK_AT_FORCE);
 	  if (error_code != NO_ERROR)
 	    {
 	      /*
@@ -7032,7 +7091,8 @@ xlocator_repl_force (THREAD_ENTRY * thread_p, LC_COPYAREA * force_area, LC_COPYA
 	      error_code =
 		locator_update_force (thread_p, &obj->hfid, &obj->class_oid, &obj->oid, NULL, &recdes, has_index,
 				      NULL, 0, SINGLE_ROW_UPDATE, force_scancache, &force_count, false,
-				      REPL_INFO_TYPE_RBR_NORMAL, pruning_type, NULL, NULL, UPDATE_INPLACE_NONE, true);
+				      REPL_INFO_TYPE_RBR_NORMAL, pruning_type, NULL, NULL, UPDATE_INPLACE_NONE,
+				      LOCATOR_LOCK_AT_FORCE);
 
 	      if (error_code == NO_ERROR)
 		{
@@ -7044,7 +7104,7 @@ xlocator_repl_force (THREAD_ENTRY * thread_p, LC_COPYAREA * force_area, LC_COPYA
 	    case LC_FLUSH_DELETE:
 	      error_code =
 		locator_delete_force (thread_p, &obj->hfid, &obj->oid, has_index, SINGLE_ROW_DELETE, force_scancache,
-				      &force_count, NULL, true);
+				      &force_count, NULL, LOCATOR_LOCK_AT_FORCE);
 
 	      if (error_code == NO_ERROR)
 		{
@@ -7227,7 +7287,8 @@ xlocator_force (THREAD_ENTRY * thread_p, LC_COPYAREA * force_area, int num_ignor
 	  error_code =
 	    locator_update_force (thread_p, &obj->hfid, &obj->class_oid, &obj->oid, NULL, &recdes,
 				  has_index, NULL, 0, SINGLE_ROW_UPDATE, force_scancache, &force_count, false,
-				  REPL_INFO_TYPE_RBR_NORMAL, pruning_type, NULL, NULL, UPDATE_INPLACE_NONE, true);
+				  REPL_INFO_TYPE_RBR_NORMAL, pruning_type, NULL, NULL, UPDATE_INPLACE_NONE,
+				  LOCATOR_LOCK_AT_FORCE);
 
 	  if (error_code == NO_ERROR)
 	    {
@@ -7239,7 +7300,7 @@ xlocator_force (THREAD_ENTRY * thread_p, LC_COPYAREA * force_area, int num_ignor
 	case LC_FLUSH_DELETE:
 	  error_code =
 	    locator_delete_force (thread_p, &obj->hfid, &obj->oid, has_index, SINGLE_ROW_DELETE, force_scancache,
-				  &force_count, NULL, true);
+				  &force_count, NULL, LOCATOR_LOCK_AT_FORCE);
 
 	  if (error_code == NO_ERROR)
 	    {
@@ -7451,7 +7512,7 @@ locator_allocate_copy_area_by_attr_info (THREAD_ENTRY * thread_p, HEAP_CACHE_ATT
  *			 forced and the update style will be decided in this
  *			 function. Otherwise the update of the instance will be
  *			 made in place and according to provided style.
- *  need_locking(in): true, if need locking
+ *  lock_policy(in): where the row lock is taken and how long it is kept
  *
  * Note: Force an object represented by an attribute information structure.
  *       For insert the oid is set as a side effect.
@@ -7463,7 +7524,8 @@ locator_attribute_info_force (THREAD_ENTRY * thread_p, const HFID * hfid, OID * 
 			      HEAP_SCANCACHE * scan_cache, int *force_count, bool not_check_fk,
 			      REPL_INFO_TYPE repl_info, int pruning_type, PRUNING_CONTEXT * pcontext,
 			      FUNC_PRED_UNPACK_INFO * func_preds, MVCC_REEV_DATA * mvcc_reev_data,
-			      UPDATE_INPLACE_STYLE force_update_inplace, RECDES * rec_descriptor, bool need_locking)
+			      UPDATE_INPLACE_STYLE force_update_inplace, RECDES * rec_descriptor,
+			      LOCATOR_LOCK_POLICY lock_policy)
 {
   LC_COPYAREA *copyarea = NULL;
   RECDES new_recdes;
@@ -7498,7 +7560,7 @@ locator_attribute_info_force (THREAD_ENTRY * thread_p, const HFID * hfid, OID * 
 	{
 	  copy_recdes = *rec_descriptor;
 	}
-      else if (HEAP_IS_UPDATE_INPLACE (force_update_inplace) || need_locking == false)
+      else if (HEAP_IS_UPDATE_INPLACE (force_update_inplace) || LOCATOR_LOCKED_AT_SELECT (lock_policy))
 	{
 	  HEAP_GET_CONTEXT context;
 
@@ -7522,8 +7584,11 @@ locator_attribute_info_force (THREAD_ENTRY * thread_p, const HFID * hfid, OID * 
 	      scan_cache->mvcc_snapshot = NULL;
 	    }
 
+	  /* the select phase did not lock this row, so this request is the statement's and follows its
+	   * policy -- locator_update_force () below sees oldrecdes filled and does not lock it again */
 	  scan = locator_lock_and_get_object (thread_p, oid, &class_oid, &copy_recdes, scan_cache, X_LOCK, COPY,
-					      NULL_CHN, LOG_ERROR_IF_DELETED);
+					      NULL_CHN, LOG_ERROR_IF_DELETED, LOCATOR_LOCK_IS_TRANSIENT (lock_policy),
+					      LOCATOR_LOCK_IS_TRANSIENT (lock_policy));
 	  if (saved_mvcc_snapshot != NULL)
 	    {
 	      scan_cache->mvcc_snapshot = saved_mvcc_snapshot;
@@ -7602,7 +7667,7 @@ locator_attribute_info_force (THREAD_ENTRY * thread_p, const HFID * hfid, OID * 
 	  error_code =
 	    locator_update_force (thread_p, &class_hfid, &class_oid, oid, old_recdes, &new_recdes, has_index,
 				  att_id, n_att_id, op_type, scan_cache, force_count, not_check_fk, repl_info,
-				  pruning_type, pcontext, mvcc_reev_data, force_update_inplace, need_locking);
+				  pruning_type, pcontext, mvcc_reev_data, force_update_inplace, lock_policy);
 	  if (error_code != NO_ERROR)
 	    {
 	      ASSERT_ERROR ();
@@ -7621,7 +7686,7 @@ locator_attribute_info_force (THREAD_ENTRY * thread_p, const HFID * hfid, OID * 
     case LC_FLUSH_DELETE:
       error_code =
 	locator_delete_force (thread_p, &class_hfid, oid, true, op_type, scan_cache, force_count, mvcc_reev_data,
-			      need_locking);
+			      lock_policy);
       break;
 
     default:
@@ -12942,20 +13007,234 @@ xlocator_redistribute_partition_data (THREAD_ENTRY * thread_p, OID * class_oid, 
 }
 
 /*
+ * locator_get_settled_last_version () - Read the locked object's last version and its MVCC header
+ *
+ * return	       : S_SUCCESS or S_SUCCESS_CHN_UPTODATE on success.
+ * thread_p (in)       :
+ * context (in/out)    : Heap get context.
+ * is_mvcc_class (in)  : False when MVCC does not apply, and then no header is read.
+ * recdes_header (out) : MVCC header of the version read.
+ *
+ * Note: settled means no delete is left undecided. A deleter holds no row lock and may still roll back,
+ *	 so it is waited out and the version read again; our row lock bounds that to one wait.
+ */
+static SCAN_CODE
+locator_get_settled_last_version (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * context, bool is_mvcc_class,
+				  MVCC_REC_HEADER * recdes_header)
+{
+  SCAN_CODE scan = S_SUCCESS;
+#if defined (SERVER_MODE)
+  MVCCID owner_mvccid;		/* the transaction still deciding the last version, if there is one */
+#endif /* SERVER_MODE */
+
+  while (true)
+    {
+      if (context->recdes_p != NULL)
+	{
+	  scan = heap_get_last_version (thread_p, context);
+	  if (scan != S_SUCCESS && scan != S_SUCCESS_CHN_UPTODATE)
+	    {
+	      return scan;
+	    }
+	}
+
+      if (!is_mvcc_class)
+	{
+	  return scan;
+	}
+
+      if (context->recdes_p == NULL || scan == S_SUCCESS_CHN_UPTODATE)
+	{
+	  if (heap_prepare_get_context (thread_p, context, false, LOG_WARNING_IF_DELETED) != S_SUCCESS)
+	    {
+	      return S_ERROR;
+	    }
+	  if (heap_get_mvcc_header (thread_p, context, recdes_header) != S_SUCCESS)
+	    {
+	      return S_ERROR;
+	    }
+	}
+      else if (or_mvcc_get_header (context->recdes_p, recdes_header) != NO_ERROR)
+	{
+	  return S_ERROR;
+	}
+
+#if defined (SERVER_MODE)
+      /* The last version may be one an active transaction is still deciding: a deleter stamps the delete id,
+       * an updater leaves its version with an insert id and no delete id, so both stamps must be settled.
+       * Either owner holds the self-lock on its MVCCID before that stamp is observable, which makes the wait
+       * below a real wait, not a no-op grant. */
+      owner_mvccid = MVCCID_NULL;
+      if (MVCC_IS_HEADER_DELID_VALID (recdes_header)
+	  && logtb_is_active_other_mvccid (thread_p, MVCC_GET_DELID (recdes_header)))
+	{
+	  owner_mvccid = MVCC_GET_DELID (recdes_header);
+	}
+      else if (MVCC_IS_HEADER_INSID_NOT_ALL_VISIBLE (recdes_header)
+	       && logtb_is_active_other_mvccid (thread_p, MVCC_GET_INSID (recdes_header)))
+	{
+	  owner_mvccid = MVCC_GET_INSID (recdes_header);
+	}
+
+      if (owner_mvccid != MVCCID_NULL)
+	{
+	  if (context->scan_cache != NULL && context->scan_cache->cache_last_fix_page
+	      && context->home_page_watcher.pgptr != NULL)
+	    {
+	      /* Prevent caching home page watcher in scan_cache: the wait below must not hold a page fixed. */
+	      pgbuf_ordered_unfix (thread_p, &context->home_page_watcher);
+	    }
+	  heap_clean_get_context (thread_p, context);
+	  if (logtb_wait_for_tran_end (thread_p, owner_mvccid) != NO_ERROR)
+	    {
+	      return S_ERROR;
+	    }
+
+	  /* whichever way it went -- committed, or rolled back to the version before it -- the header has to
+	   * be read again, and it may name yet another owner */
+	  scan = heap_prepare_get_context (thread_p, context, false, LOG_WARNING_IF_DELETED);
+	  if (scan != S_SUCCESS)
+	    {
+	      return scan;
+	    }
+	  continue;
+	}
+#endif /* SERVER_MODE */
+
+      return scan;
+    }
+}
+
+/*
+ * locator_has_isolation_conflict () - Is modifying the locked object an isolation conflict?
+ *
+ * return	       : True on conflict, false otherwise.
+ * thread_p (in)       :
+ * context (in)	       : Heap get context.
+ * recdes_header (in)  : MVCC header of the version to be modified.
+ * conflict_scan (out) : The code to fail with -- S_DOESNT_EXIST for a version that is gone, S_ERROR for
+ *			 a conflict, whose error is set. Written only on conflict, so a false return leaves
+ *			 the caller's own scan code intact.
+ */
+static bool
+locator_has_isolation_conflict (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * context, MVCC_REC_HEADER * recdes_header,
+				SCAN_CODE * conflict_scan)
+{
+  /* Check REPEATABLE READ/SERIALIZABLE isolation restrictions. */
+  if (logtb_find_current_isolation (thread_p) > TRAN_READ_COMMITTED
+      && logtb_check_class_for_rr_isolation_err (context->class_oid_p))
+    {
+      /* In these isolation levels, the transaction is not allowed to modify an object that was already
+       * modified by other transactions. This would be true if last version matched the visible version.
+       *
+       * TODO: We already know here that this last row version is not deleted. It would be enough to just
+       * check whether the insert MVCCID is considered active relatively to transaction's snapshot.
+       */
+      MVCC_SNAPSHOT *tran_snapshot = logtb_get_mvcc_snapshot (thread_p);
+      MVCC_SATISFIES_SNAPSHOT_RESULT snapshot_res;
+
+      assert (tran_snapshot != NULL && tran_snapshot->snapshot_fnc != NULL);
+      snapshot_res = tran_snapshot->snapshot_fnc (thread_p, recdes_header, tran_snapshot);
+      if (snapshot_res == TOO_OLD_FOR_SNAPSHOT)
+	{
+	  /* Not visible. */
+	  er_set (ER_WARNING_SEVERITY, ARG_FILE_LINE, ER_HEAP_UNKNOWN_OBJECT, 3, context->oid_p->volid,
+		  context->oid_p->pageid, context->oid_p->slotid);
+	  *conflict_scan = S_DOESNT_EXIST;
+	  return true;
+	}
+      else if (snapshot_res == TOO_NEW_FOR_SNAPSHOT)
+	{
+	  /* Trying to modify a version already modified by concurrent transaction, which is an isolation conflict.
+	   */
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_MVCC_SERIALIZABLE_CONFLICT, 0);
+	  *conflict_scan = S_ERROR;
+	  return true;
+	}
+      else if (MVCC_IS_HEADER_DELID_VALID (recdes_header))
+	{
+	  /* Trying to modify version deleted by concurrent transaction, which is an isolation conflict. */
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_MVCC_SERIALIZABLE_CONFLICT, 0);
+	  *conflict_scan = S_ERROR;
+	  return true;
+	}
+      /* Last version is also visible version and it is not deleted. Fall through. */
+    }
+
+  if (MVCC_IS_HEADER_DELID_VALID (recdes_header))
+    {
+      *conflict_scan = S_DOESNT_EXIST;
+      return true;
+    }
+
+  return false;
+}
+
+/*
+ * locator_last_version_is_ours () - Whether the object's last version carries this transaction's own, still
+ *				     active insert id
+ *   return: true when the last version was inserted by this transaction and is not yet visible to all
+ *   thread_p(in): thread entry
+ *   context(in/out): heap get context; given back unfixed, as it was on entry
+ *
+ * Note: a row whose last version we stamped needs no row lock to be touched again.  Any other writer meets that
+ *	stamp and settles on our MVCCID self-lock first, so while that lock stands we are the row's only writer,
+ *	and the settle below never waits for us either.  Taking the row lock anyway would queue us behind a
+ *	waiter that already holds it while it waits on us -- a cycle the deadlock detector then has to break.
+ *	This is the same ground on which locator_update_force () asks for the lock only of a version it did not
+ *	insert.  Read the header, decide, and give the page back so the caller starts from one state either way.
+ */
+static bool
+locator_last_version_is_ours (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * context)
+{
+  MVCC_REC_HEADER header;
+  bool ours = false;
+
+  if (heap_prepare_get_context (thread_p, context, false, LOG_WARNING_IF_DELETED) == S_SUCCESS
+      && heap_get_mvcc_header (thread_p, context, &header) == S_SUCCESS)
+    {
+      ours = MVCC_IS_HEADER_INSID_NOT_ALL_VISIBLE (&header)
+	&& logtb_is_current_mvccid (thread_p, MVCC_GET_INSID (&header));
+    }
+
+  if (context->scan_cache != NULL && context->scan_cache->cache_last_fix_page
+      && context->home_page_watcher.pgptr != NULL)
+    {
+      /* do not leave the home page cached in scan_cache: the caller may block on the lock next */
+      pgbuf_ordered_unfix (thread_p, &context->home_page_watcher);
+    }
+  heap_clean_get_context (thread_p, context);
+
+  return ours;
+}
+
+/*
  * locator_lock_and_get_object_internal () - Internal function: aquire lock and return object
  *
- * return : scan code
+ * return : Scan code; S_SUCCESS_CHN_UPTODATE from heap_get_last_version () is preserved to the caller.
  * thread_p (in)   :
  * context (in/out): Heap get context .
  * lock_mode (in)  : Type of lock.
+ * transient (in)  : Whether the request ends with the statement rather than the transaction.
+ * owner_bypass_ok (in) : Whether a row this transaction itself stamped may be touched again without the row
+ *			  lock -- a statement's own DML and a foreign-key cascade may, a client fetch that caches
+ *			  the lock it asked for may not.
+ * lock_acquired_p (out) : Whether this call took the lock and still holds it on return; NULL when the caller
+ *			   does not care.
  *
  * NOTE: Caller must handle the cleanup of context
  */
 static SCAN_CODE
-locator_lock_and_get_object_internal (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * context, LOCK lock_mode)
+locator_lock_and_get_object_internal (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * context, LOCK lock_mode,
+				      bool transient, bool owner_bypass_ok, bool * lock_acquired_p)
 {
   SCAN_CODE scan = S_SUCCESS;
   bool lock_acquired = false;
+  MVCC_REC_HEADER recdes_header;
+  bool is_mvcc_class;
+  /* whether the request this call makes ends with the statement or with the transaction */
+  int (*lock_fn) (THREAD_ENTRY *, const OID *, const OID *, LOCK, int) =
+    (transient ? lock_object_transient : lock_object);
 
   assert (context != NULL);
   assert (context->oid_p != NULL && !OID_ISNULL (context->oid_p));
@@ -12963,9 +13242,27 @@ locator_lock_and_get_object_internal (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT 
   assert (lock_mode > NULL_LOCK);	/* this is not the appropriate function for NULL_LOCK */
   assert (context->scan_cache != NULL);
 
-  /* try to lock the object conditionally, if it fails unfix page watchers and try unconditionally */
+  if (lock_acquired_p != NULL)
+    {
+      *lock_acquired_p = false;
+    }
 
-  if (lock_object (thread_p, context->oid_p, context->class_oid_p, lock_mode, LK_COND_LOCK) != LK_GRANTED)
+  is_mvcc_class = !mvcc_is_mvcc_disabled_class (context->class_oid_p);
+
+  /* try to lock the object conditionally, if it fails unfix page watchers and try unconditionally.  Between the
+   * two, when the caller allows it, a last version this transaction stamped itself is touched again without the
+   * row lock -- see locator_last_version_is_ours ().  Asked only once the conditional try has failed: an
+   * uncontended row is simply taken, as it always was. */
+
+  if (lock_fn (thread_p, context->oid_p, context->class_oid_p, lock_mode, LK_COND_LOCK) == LK_GRANTED)
+    {
+      lock_acquired = true;
+    }
+  else if (owner_bypass_ok && is_mvcc_class && locator_last_version_is_ours (thread_p, context))
+    {
+      /* lock_acquired stays false: there is nothing to give back */
+    }
+  else
     {
       if (context->scan_cache && context->scan_cache->cache_last_fix_page && context->home_page_watcher.pgptr != NULL)
 	{
@@ -12973,7 +13270,7 @@ locator_lock_and_get_object_internal (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT 
 	  pgbuf_ordered_unfix (thread_p, &context->home_page_watcher);
 	}
       heap_clean_get_context (thread_p, context);
-      if (lock_object (thread_p, context->oid_p, context->class_oid_p, lock_mode, LK_UNCOND_LOCK) != LK_GRANTED)
+      if (lock_fn (thread_p, context->oid_p, context->class_oid_p, lock_mode, LK_UNCOND_LOCK) != LK_GRANTED)
 	{
 	  goto error;
 	}
@@ -12987,98 +13284,24 @@ locator_lock_and_get_object_internal (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT 
 	  goto error;
 	}
     }
-  else
-    {
-      lock_acquired = true;
-    }
 
   assert (OID_IS_ROOTOID (context->class_oid_p) || lock_mode == S_LOCK || lock_mode == X_LOCK);
 
-  /* Lock should be aquired now -> get recdes */
-  if (context->recdes_p != NULL)
+  scan = locator_get_settled_last_version (thread_p, context, is_mvcc_class, &recdes_header);
+  if (scan != S_SUCCESS && scan != S_SUCCESS_CHN_UPTODATE)
     {
-      scan = heap_get_last_version (thread_p, context);
-      /* this scan_code must be preserved until the end of this function to be returned; - unless an error occur */
-      if (scan != S_SUCCESS && scan != S_SUCCESS_CHN_UPTODATE)
-	{
-	  goto error;
-	}
+      goto error;
     }
 
-  /* Check isolation restrictions and the visibility of the object if it belongs to a mvcc class */
-  if (!mvcc_is_mvcc_disabled_class (context->class_oid_p))
+  if (is_mvcc_class && locator_has_isolation_conflict (thread_p, context, &recdes_header, &scan))
     {
-      MVCC_REC_HEADER recdes_header;
-
-      /* get header: directly from recdes if it has been obtained, otherwise from heap */
-      if (context->recdes_p == NULL || scan == S_SUCCESS_CHN_UPTODATE)
-	{
-	  /* ensure context is prepared to get header of the record */
-	  if (heap_prepare_get_context (thread_p, context, false, LOG_WARNING_IF_DELETED) != S_SUCCESS)
-	    {
-	      scan = S_ERROR;
-	      goto error;
-	    }
-	  if (heap_get_mvcc_header (thread_p, context, &recdes_header) != S_SUCCESS)
-	    {
-	      scan = S_ERROR;
-	      goto error;
-	    }
-	}
-      else if (or_mvcc_get_header (context->recdes_p, &recdes_header) != NO_ERROR)
-	{
-	  goto error;
-	}
-
-      /* Check REPEATABLE READ/SERIALIZABLE isolation restrictions. */
-      if (logtb_find_current_isolation (thread_p) > TRAN_READ_COMMITTED
-	  && logtb_check_class_for_rr_isolation_err (context->class_oid_p))
-	{
-	  /* In these isolation levels, the transaction is not allowed to modify an object that was already
-	   * modified by other transactions. This would be true if last version matched the visible version.
-	   *
-	   * TODO: We already know here that this last row version is not deleted. It would be enough to just
-	   * check whether the insert MVCCID is considered active relatively to transaction's snapshot.
-	   */
-	  MVCC_SNAPSHOT *tran_snapshot = logtb_get_mvcc_snapshot (thread_p);
-	  MVCC_SATISFIES_SNAPSHOT_RESULT snapshot_res;
-
-	  assert (tran_snapshot != NULL && tran_snapshot->snapshot_fnc != NULL);
-	  snapshot_res = tran_snapshot->snapshot_fnc (thread_p, &recdes_header, tran_snapshot);
-	  if (snapshot_res == TOO_OLD_FOR_SNAPSHOT)
-	    {
-	      /* Not visible. */
-	      er_set (ER_WARNING_SEVERITY, ARG_FILE_LINE, ER_HEAP_UNKNOWN_OBJECT, 3, context->oid_p->volid,
-		      context->oid_p->pageid, context->oid_p->slotid);
-	      scan = S_DOESNT_EXIST;
-	      goto error;
-	    }
-	  else if (snapshot_res == TOO_NEW_FOR_SNAPSHOT)
-	    {
-	      /* Trying to modify a version already modified by concurrent transaction, which is an isolation conflict.
-	       */
-	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_MVCC_SERIALIZABLE_CONFLICT, 0);
-	      goto error;
-	    }
-	  else if (MVCC_IS_HEADER_DELID_VALID (&recdes_header))
-	    {
-	      /* Trying to modify version deleted by concurrent transaction, which is an isolation conflict. */
-	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_MVCC_SERIALIZABLE_CONFLICT, 0);
-	      goto error;
-	    }
-	  else
-	    {
-	      /* Last version is also visible version and it is not deleted. Fall through. */
-	    }
-	}
-
-      if (MVCC_IS_HEADER_DELID_VALID (&recdes_header))
-	{
-	  scan = S_DOESNT_EXIST;
-	  goto error;
-	}
+      goto error;
     }
 
+  if (lock_acquired_p != NULL)
+    {
+      *lock_acquired_p = lock_acquired;
+    }
   return scan;
 
 error:
@@ -13091,7 +13314,15 @@ error:
 
   if (lock_acquired)
     {
-      lock_unlock_object_donot_move_to_non2pl (thread_p, context->oid_p, context->class_oid_p, lock_mode);
+      /* undo the request we just made -- including the count it added, if it was a transient one */
+      if (transient)
+	{
+	  lock_unlock_object_transient (thread_p, context->oid_p, context->class_oid_p, lock_mode);
+	}
+      else
+	{
+	  lock_unlock_object_donot_move_to_non2pl (thread_p, context->oid_p, context->class_oid_p, lock_mode);
+	}
     }
 
   return (scan != S_SUCCESS && scan != S_SUCCESS_CHN_UPTODATE) ? scan : S_ERROR;
@@ -13112,6 +13343,8 @@ error:
  * (obsolete) non_ex_handling_type (in): - LOG_ERROR_IF_DELETED: write the
  *				ER_HEAP_UNKNOWN_OBJECT error to log
  *                            - LOG_WARNING_IF_DELETED: set only warning
+ * owner_bypass_ok (in) : Whether a row this transaction itself stamped may be touched again without the row
+ *			  lock; passed on to locator_lock_and_get_object_internal ().
  *
  * Note: This function will lock the object with X_LOCK. This lock type should correspond to delete/update operations.
  */
@@ -13119,7 +13352,8 @@ SCAN_CODE
 locator_lock_and_get_object_with_evaluation (THREAD_ENTRY * thread_p, OID * oid, OID * class_oid, RECDES * recdes,
 					     HEAP_SCANCACHE * scan_cache, int ispeeking, int old_chn,
 					     MVCC_REEV_DATA * mvcc_reev_data,
-					     NON_EXISTENT_HANDLING non_ex_handling_type)
+					     NON_EXISTENT_HANDLING non_ex_handling_type, bool transient,
+					     bool owner_bypass_ok)
 {
   HEAP_GET_CONTEXT context;
   SCAN_CODE scan = S_SUCCESS;
@@ -13128,6 +13362,7 @@ locator_lock_and_get_object_with_evaluation (THREAD_ENTRY * thread_p, OID * oid,
   DB_LOGICAL ev_res = V_UNKNOWN;	/* Re-evaluation result. */
   OID class_oid_local = OID_INITIALIZER;
   LOCK lock_mode = X_LOCK;
+  bool lock_acquired = false;	/* whether the internal call took the row lock */
   int err = NO_ERROR;
 
   if (recdes == NULL && mvcc_reev_data != NULL)
@@ -13172,7 +13407,8 @@ locator_lock_and_get_object_with_evaluation (THREAD_ENTRY * thread_p, OID * oid,
 	}
     }
 
-  scan = locator_lock_and_get_object_internal (thread_p, &context, lock_mode);
+  scan =
+    locator_lock_and_get_object_internal (thread_p, &context, lock_mode, transient, owner_bypass_ok, &lock_acquired);
 
   /* perform reevaluation */
   if (mvcc_reev_data != NULL && (scan == S_SUCCESS || scan == S_SUCCESS_CHN_UPTODATE))
@@ -13205,8 +13441,16 @@ locator_lock_and_get_object_with_evaluation (THREAD_ENTRY * thread_p, OID * oid,
       ev_res = locator_mvcc_reev_cond_and_assignment (thread_p, scan_cache, mvcc_reev_data, &mvcc_header, oid, recdes);
       if (ev_res != V_TRUE)
 	{
-	  /* did not pass the evaluation or error occurred - unlock object */
-	  lock_unlock_object_donot_move_to_non2pl (thread_p, oid, class_oid, lock_mode);
+	  /* did not pass the evaluation or error occurred - unlock object, if this call took it (an owner
+	   * touching its own stamped row again went without the lock) */
+	  if (lock_acquired && transient)
+	    {
+	      lock_unlock_object_transient (thread_p, oid, class_oid, lock_mode);
+	    }
+	  else if (lock_acquired)
+	    {
+	      lock_unlock_object_donot_move_to_non2pl (thread_p, oid, class_oid, lock_mode);
+	    }
 	}
       switch (ev_res)
 	{
@@ -13342,7 +13586,7 @@ locator_get_object (THREAD_ENTRY * thread_p, const OID * oid, OID * class_oid, R
   else
     {
       /* Locking */
-      scan_code = locator_lock_and_get_object_internal (thread_p, &context, lock_mode);
+      scan_code = locator_lock_and_get_object_internal (thread_p, &context, lock_mode, false, false, NULL);
     }
 
   heap_clean_get_context (thread_p, &context);
@@ -13366,11 +13610,12 @@ locator_get_object (THREAD_ENTRY * thread_p, const OID * oid, OID * class_oid, R
  * (obsolete) non_ex_handling_type (in): - LOG_ERROR_IF_DELETED: write the
  *				ER_HEAP_UNKNOWN_OBJECT error to log
  *                            - LOG_WARNING_IF_DELETED: set only warning
+ * transient (in)      : whether this request is one the statement gives back when it ends
  */
 SCAN_CODE
 locator_lock_and_get_object (THREAD_ENTRY * thread_p, const OID * oid, OID * class_oid, RECDES * recdes,
 			     HEAP_SCANCACHE * scan_cache, LOCK lock, int ispeeking, int old_chn,
-			     NON_EXISTENT_HANDLING non_ex_handling_type)
+			     NON_EXISTENT_HANDLING non_ex_handling_type, bool transient, bool owner_bypass_ok)
 {
   HEAP_GET_CONTEXT context;
   SCAN_CODE scan_code;
@@ -13385,7 +13630,7 @@ locator_lock_and_get_object (THREAD_ENTRY * thread_p, const OID * oid, OID * cla
     }
 
   heap_init_get_context (thread_p, &context, oid, class_oid, recdes, scan_cache, ispeeking, old_chn);
-  scan_code = locator_lock_and_get_object_internal (thread_p, &context, lock);
+  scan_code = locator_lock_and_get_object_internal (thread_p, &context, lock, transient, owner_bypass_ok, NULL);
   heap_clean_get_context (thread_p, &context);
   return scan_code;
 }

--- a/src/transaction/locator_sr.h
+++ b/src/transaction/locator_sr.h
@@ -61,6 +61,29 @@ enum
 
 extern bool locator_Dont_check_foreign_key;
 
+/* Where a statement takes the row lock for a modified object, and how long it keeps it.
+ * The select phase may have taken it already; otherwise the force phase does, and then either holds it
+ * to commit or -- once the change is published and a late arrival can settle on the MVCCID self-lock --
+ * gives it up when the statement ends. */
+typedef enum
+{
+  LOCATOR_LOCK_AT_SELECT,	/* the select phase locked the object; the force phase must not lock again */
+  LOCATOR_LOCK_AT_SELECT_TRANSIENT,	/* the same, and both phases' requests end with the statement */
+  LOCATOR_LOCK_AT_FORCE,	/* the force phase locks the object and holds the lock to commit */
+  LOCATOR_LOCK_AT_FORCE_TRANSIENT	/* the force phase locks the object and gives it up at statement end */
+} LOCATOR_LOCK_POLICY;
+
+/* the select phase already holds a row lock, so the force phase reevaluation is not needed */
+#define LOCATOR_LOCKED_AT_SELECT(policy) \
+  ((policy) == LOCATOR_LOCK_AT_SELECT || (policy) == LOCATOR_LOCK_AT_SELECT_TRANSIENT)
+
+/* the request the force phase makes ends with the statement rather than with the transaction */
+#define LOCATOR_LOCK_IS_TRANSIENT(policy) \
+  ((policy) == LOCATOR_LOCK_AT_SELECT_TRANSIENT || (policy) == LOCATOR_LOCK_AT_FORCE_TRANSIENT)
+
+extern bool locator_class_has_online_index (THREAD_ENTRY * thread_p, const OID * class_oid);
+
+
 extern int locator_initialize (THREAD_ENTRY * thread_p);
 extern void locator_finalize (THREAD_ENTRY * thread_p);
 extern int locator_drop_transient_class_name_entries (THREAD_ENTRY * thread_p, LOG_LSA * savep_lsa);
@@ -80,7 +103,7 @@ extern int locator_attribute_info_force (THREAD_ENTRY * thread_p, const HFID * h
 					 int pruning_type, PRUNING_CONTEXT * pcontext,
 					 FUNC_PRED_UNPACK_INFO * func_preds, MVCC_REEV_DATA * mvcc_reev_data,
 					 UPDATE_INPLACE_STYLE force_update_inplace, RECDES * rec_descriptor,
-					 bool need_locking);
+					 LOCATOR_LOCK_POLICY lock_policy);
 extern LC_COPYAREA *locator_allocate_copy_area_by_attr_info (THREAD_ENTRY * thread_p, HEAP_CACHE_ATTRINFO * attr_info,
 							     RECDES * old_recdes, RECDES * new_recdes,
 							     const int copyarea_length_hint, int lob_create_flag);
@@ -98,7 +121,7 @@ extern DISK_ISVALID locator_check_btree_entries (THREAD_ENTRY * thread_p, BTID *
 						 const char *btname, bool repair);
 extern int locator_delete_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * oid, int has_index, int op_type,
 				 HEAP_SCANCACHE * scan_cache, int *force_count, MVCC_REEV_DATA * mvcc_reev_data,
-				 bool need_locking);
+				 LOCATOR_LOCK_POLICY lock_policy);
 extern int locator_add_or_remove_index (THREAD_ENTRY * thread_p, RECDES * recdes, OID * inst_oid, OID * class_oid,
 					int is_insert, int op_type, HEAP_SCANCACHE * scan_cache, bool datayn,
 					bool replyn, HFID * hfid, FUNC_PRED_UNPACK_INFO * func_preds, bool has_BU_lock,
@@ -115,12 +138,14 @@ extern int locator_rv_redo_rename (THREAD_ENTRY * thread_p, LOG_RCV * rcv);
 
 extern SCAN_CODE locator_lock_and_get_object (THREAD_ENTRY * thread_p, const OID * oid, OID * class_oid,
 					      RECDES * recdes, HEAP_SCANCACHE * scan_cache, LOCK lock, int ispeeking,
-					      int old_chn, NON_EXISTENT_HANDLING non_ex_handling_type);
+					      int old_chn, NON_EXISTENT_HANDLING non_ex_handling_type, bool transient,
+					      bool owner_bypass_ok);
 extern SCAN_CODE locator_lock_and_get_object_with_evaluation (THREAD_ENTRY * thread_p, OID * oid, OID * class_oid,
 							      RECDES * recdes, HEAP_SCANCACHE * scan_cache,
 							      int ispeeking, int old_chn,
 							      MVCC_REEV_DATA * mvcc_reev_data,
-							      NON_EXISTENT_HANDLING non_ex_handling_type);
+							      NON_EXISTENT_HANDLING non_ex_handling_type,
+							      bool transient, bool owner_bypass_ok);
 extern SCAN_CODE locator_get_object (THREAD_ENTRY * thread_p, const OID * oid, OID * class_oid, RECDES * recdes,
 				     HEAP_SCANCACHE * scan_cache, SCAN_OPERATION_TYPE op_type, LOCK lock_mode,
 				     int ispeeking, int chn);

--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -377,6 +377,8 @@ struct lk_tran_lock
   LK_ENTRY *lk_entry_pool;	/* local pool of lock entries which can be used with no synchronization. */
   int lk_entry_pool_count;	/* Current count of lock entries in local pool. */
   int inst_hold_count;		/* # of entries in inst_hold_list */
+  int transient_scope;		/* statements now taking transient row locks, so nesting is visible */
+  int transient_total;		/* counted requests outstanding, so an empty walk can be skipped */
   int class_hold_count;		/* # of entries in class_hold_list */
 
   LK_ENTRY *waiting;		/* waiting lock entry */
@@ -557,7 +559,10 @@ static bool lock_wakeup_deadlock_victim_aborted (int tran_index);
 static void lock_grant_blocked_holder (THREAD_ENTRY * thread_p, LK_RES * res_ptr);
 static int lock_grant_blocked_waiter (THREAD_ENTRY * thread_p, LK_RES * res_ptr);
 static void lock_grant_blocked_waiter_partial (THREAD_ENTRY * thread_p, LK_RES * res_ptr, LK_ENTRY * from_whom);
+static int lock_object_with_flag (THREAD_ENTRY * thread_p, const OID * oid, const OID * class_oid, LOCK lock,
+				  int cond_flag, bool mark_transient);
 static bool lock_check_escalate (THREAD_ENTRY * thread_p, LK_ENTRY * class_entry, LK_TRAN_LOCK * tran_lock);
+static void lock_reset_transient_state (LK_TRAN_LOCK * tran_lock);
 static int lock_escalate_if_needed (THREAD_ENTRY * thread_p, LK_ENTRY * class_entry, int tran_index);
 static int lock_internal_hold_lock_object_instant (THREAD_ENTRY * thread_p, int tran_index, const OID * oid,
 						   const OID * class_oid, LOCK lock);
@@ -789,6 +794,7 @@ lock_uninit_entry (void *entry)
 
   entry_ptr->tran_index = -1;
   entry_ptr->thrd_entry = NULL;
+  entry_ptr->transient_count = 0;
 
   return NO_ERROR;
 }
@@ -984,6 +990,7 @@ lock_initialize_entry (LK_ENTRY * entry_ptr)
   entry_ptr->class_entry = NULL;
   entry_ptr->ngranules = 0;
   entry_ptr->instant_lock_count = 0;
+  entry_ptr->transient_count = 0;
   entry_ptr->bind_index_in_tran = -1;
   XASL_ID_SET_NULL (&entry_ptr->xasl_id);
 }
@@ -1004,6 +1011,7 @@ lock_initialize_entry_as_granted (LK_ENTRY * entry_ptr, int tran_index, LK_RES *
   entry_ptr->class_entry = NULL;
   entry_ptr->ngranules = 0;
   entry_ptr->instant_lock_count = 0;
+  entry_ptr->transient_count = 0;
 
   lock_event_set_xasl_id_to_entry (tran_index, entry_ptr);
 }
@@ -1025,6 +1033,7 @@ lock_initialize_entry_as_blocked (LK_ENTRY * entry_ptr, THREAD_ENTRY * thread_p,
   entry_ptr->class_entry = NULL;
   entry_ptr->ngranules = 0;
   entry_ptr->instant_lock_count = 0;
+  entry_ptr->transient_count = 0;
 
   lock_event_set_xasl_id_to_entry (tran_index, entry_ptr);
 }
@@ -1045,6 +1054,7 @@ lock_initialize_entry_as_non2pl (LK_ENTRY * entry_ptr, int tran_index, LK_RES * 
   entry_ptr->class_entry = NULL;
   entry_ptr->ngranules = 0;
   entry_ptr->instant_lock_count = 0;
+  entry_ptr->transient_count = 0;
 }
 
 /* initialize lock resource as allocated state */
@@ -1106,6 +1116,22 @@ lock_get_hash_value (const OID * oid, int htsize)
 
 #if defined(SERVER_MODE)
 /*
+ * lock_reset_transient_state () - Put a transaction's statement-scoped bookkeeping back to its start state
+ *   return: void
+ *   tran_lock(in/out): the transaction's lock list
+ *
+ * Note: a zeroed LK_TRAN_LOCK is not this state -- NA_LOCK is 0 and NULL_LOCK is 2, and a zeroed OID is
+ *	not a null one -- so the table's initial memset does not produce it and this has to run there too,
+ *	not only when a transaction ends.
+ */
+static void
+lock_reset_transient_state (LK_TRAN_LOCK * tran_lock)
+{
+  tran_lock->transient_scope = 0;
+  tran_lock->transient_total = 0;
+}
+
+/*
  * lock_initialize_tran_lock_table - Initialize the transaction lock hold table.
  *
  * return: error code
@@ -1135,6 +1161,7 @@ lock_initialize_tran_lock_table (void)
   for (i = 0; i < lk_Gl.config.num_trans; i++)
     {
       tran_lock = &lk_Gl.tran_lock_table[i];
+      lock_reset_transient_state (tran_lock);
       pthread_mutex_init (&tran_lock->hold_mutex, NULL);
       pthread_mutex_init (&tran_lock->non2pl_mutex, NULL);
       lk_Gl.init_state.tran_lock_table_initialized_count++;
@@ -6247,10 +6274,12 @@ lock_hold_object_instant (THREAD_ENTRY * thread_p, const OID * oid, const OID * 
  *   class_oid(in): Identifier of the class instance of the given object
  *   lock(in): Requested lock mode
  *   cond_flag(in):
+ *   mark_transient(in): count this request among the ones the statement gives up when it ends
  *
  */
-int
-lock_object (THREAD_ENTRY * thread_p, const OID * oid, const OID * class_oid, LOCK lock, int cond_flag)
+static int
+lock_object_with_flag (THREAD_ENTRY * thread_p, const OID * oid, const OID * class_oid, LOCK lock, int cond_flag,
+		       bool mark_transient)
 {
 #if !defined (SERVER_MODE)
   LK_SET_STANDALONE_XLOCK (lock);
@@ -6427,6 +6456,16 @@ lock_object (THREAD_ENTRY * thread_p, const OID * oid, const OID * class_oid, LO
       granted =
 	lock_internal_perform_lock_object (thread_p, tran_index, lock_create_search_key (oid, class_oid), lock,
 					   wait_msecs, &inst_entry, class_entry);
+      if (mark_transient && granted == LK_GRANTED && inst_entry != NULL
+	  && inst_entry->transient_count < inst_entry->count)
+	{
+	  /* the caller gives this request up when its statement ends.  Counted rather than flagged: a second
+	   * request on the same entry only raises count, and the release has to give back exactly what was
+	   * taken -- see lock_release_transient_object_locks.  Never count past what the entry holds: a request
+	   * an earlier statement took is not this statement's to give back. */
+	  inst_entry->transient_count++;
+	  lk_Gl.tran_lock_table[tran_index].transient_total++;
+	}
       goto end;
     }
 
@@ -6447,6 +6486,256 @@ end:
   return granted;
 #endif /* !SERVER_MODE */
 }
+
+/*
+ * lock_object () - Lock an object
+ *   return: one of following values
+ *   thread_p(in): thread entry
+ *   oid(in): identifier of the object
+ *   class_oid(in): identifier of the class of the object
+ *   lock(in): requested lock mode
+ *   cond_flag(in): conditional or unconditional
+ */
+int
+lock_object (THREAD_ENTRY * thread_p, const OID * oid, const OID * class_oid, LOCK lock, int cond_flag)
+{
+  return lock_object_with_flag (thread_p, oid, class_oid, lock, cond_flag, false);
+}
+
+/*
+ * lock_object_transient () - Lock an object the caller gives up when its statement ends
+ *   return: one of following values
+ *   thread_p(in): thread entry
+ *   oid(in): identifier of the object
+ *   class_oid(in): identifier of the class of the object
+ *   lock(in): requested lock mode
+ *   cond_flag(in): conditional or unconditional
+ *
+ * Note: the entry is marked so lock_release_transient_object_locks () can find it by walking the
+ *	transaction's hold list, which costs no hash lookup.  Only the instance entry is marked -- a class
+ *	lock taken on the way is not -- and releasing it decrements the count this request added, so a lock
+ *	the transaction already held survives.
+ */
+int
+lock_object_transient (THREAD_ENTRY * thread_p, const OID * oid, const OID * class_oid, LOCK lock, int cond_flag)
+{
+  return lock_object_with_flag (thread_p, oid, class_oid, lock, cond_flag, true);
+}
+
+/*
+ * lock_transient_scope_start () - Enter a statement that may take transient row locks
+ *   return: true when this is the outermost such statement
+ *   thread_p(in): thread entry
+ *
+ * Note: the counts live on the transaction, not on the statement that made them, so a statement running
+ *	inside another one would give back the outer statement's locks when it ended -- opening exactly the
+ *	window a statement-scoped release exists to close.  Only the outermost statement takes transient
+ *	locks; one nested in it keeps its own to commit, the way every statement did before.
+ */
+bool
+lock_transient_scope_start (THREAD_ENTRY * thread_p)
+{
+#if !defined (SERVER_MODE)
+  return true;
+#else /* !SERVER_MODE */
+  LK_TRAN_LOCK *tran_lock = &lk_Gl.tran_lock_table[LOG_FIND_THREAD_TRAN_INDEX (thread_p)];
+
+  return (++tran_lock->transient_scope) == 1;
+#endif /* !SERVER_MODE */
+}
+
+/*
+ * lock_transient_scope_is_outermost () - Whether the statement now opening is the outermost one
+ *   return: true when no other statement of this transaction is inside a transient scope
+ *   thread_p(in): thread entry
+ *
+ * Note: asked once per scan open, so that the scan can be told whether the row locks it is about to take
+ *	are its statement's to give back.  A statement nested in another one -- a row trigger's inner
+ *	statement -- must not be told yes: the counts live on the transaction, and it would be giving back
+ *	the outer statement's requests when it ended.
+ */
+bool
+lock_transient_scope_is_outermost (THREAD_ENTRY * thread_p)
+{
+#if !defined (SERVER_MODE)
+  return true;
+#else /* !SERVER_MODE */
+  LK_TRAN_LOCK *tran_lock = &lk_Gl.tran_lock_table[LOG_FIND_THREAD_TRAN_INDEX (thread_p)];
+
+  return tran_lock->transient_scope == 1;
+#endif /* !SERVER_MODE */
+}
+
+/*
+ * lock_transient_scope_end () - Leave such a statement, giving its locks back if it was the outermost
+ *   return: void
+ *   thread_p(in): thread entry
+ *   release(in): give the counted requests back, rather than only forgetting the counts
+ */
+void
+lock_transient_scope_end (THREAD_ENTRY * thread_p, bool release)
+{
+#if !defined (SERVER_MODE)
+  return;
+#else /* !SERVER_MODE */
+  LK_TRAN_LOCK *tran_lock = &lk_Gl.tran_lock_table[LOG_FIND_THREAD_TRAN_INDEX (thread_p)];
+
+  assert (tran_lock->transient_scope > 0);
+  if (tran_lock->transient_scope > 0 && --tran_lock->transient_scope > 0)
+    {
+      /* an outer statement is still running and the counts are its to give back */
+      return;
+    }
+
+  if (release)
+    {
+      lock_release_transient_object_locks (thread_p);
+    }
+  else
+    {
+      lock_forget_transient_object_locks (thread_p);
+    }
+#endif /* !SERVER_MODE */
+}
+
+/*
+ * lock_unlock_object_transient () - Give back one request that was counted transient
+ *   return: void
+ *   thread_p(in): thread entry
+ *   oid(in): the object
+ *   class_oid(in): its class
+ *   lock(in): the mode that was granted
+ *
+ * Note: used where the caller undoes an acquisition it just made, so the count it added has to go with
+ *	it -- otherwise the statement's release would give back a request nobody is holding.
+ */
+void
+lock_unlock_object_transient (THREAD_ENTRY * thread_p, const OID * oid, const OID * class_oid, LOCK lock)
+{
+#if !defined (SERVER_MODE)
+  return;
+#else /* !SERVER_MODE */
+  LK_ENTRY *entry_ptr;
+  int tran_index;
+
+  tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
+  entry_ptr = lock_find_tran_hold_entry (thread_p, tran_index, oid, false);
+  if (entry_ptr == NULL)
+    {
+      return;
+    }
+
+  assert (!OID_IS_ROOTOID (oid) && (class_oid == NULL || !OID_IS_ROOTOID (class_oid)));
+  assert (entry_ptr->transient_count > 0);
+  if (entry_ptr->transient_count > 0)
+    {
+      entry_ptr->transient_count--;
+      if (lk_Gl.tran_lock_table[tran_index].transient_total > 0)
+	{
+	  lk_Gl.tran_lock_table[tran_index].transient_total--;
+	}
+    }
+  lock_internal_perform_unlock_object (thread_p, entry_ptr, false, false);
+#endif /* !SERVER_MODE */
+}
+
+/*
+ * lock_release_transient_object_locks () - Give up the instance lock requests counted transient
+ *   return: void
+ *   thread_p(in): thread entry
+ *
+ * Note: the hold list is walked rather than each object looked up, so what a lock costs to give back
+ *	is what commit pays for it and does not grow with the size of the lock table.  The walk is over
+ *	everything the transaction holds rather than over what this statement took, so a statement that
+ *	took nothing would still pay for the locks the transaction holds for other reasons -- the running
+ *	total is there to answer that case without walking at all.  An entry the escalation reclaimed is
+ *	already off this list, so nothing has to be said about it here.
+ *
+ *	The walk takes no hold_mutex, on the same ground the other walks of this list state: a transaction
+ *	runs one thread at a time, so no one else is changing the list while we are on it.
+ */
+void
+lock_release_transient_object_locks (THREAD_ENTRY * thread_p)
+{
+#if !defined (SERVER_MODE)
+  return;
+#else /* !SERVER_MODE */
+  LK_TRAN_LOCK *tran_lock;
+  LK_ENTRY *entry_ptr, *next_ptr;
+  int tran_index, i, n;
+
+  tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
+  tran_lock = &lk_Gl.tran_lock_table[tran_index];
+
+  if (tran_lock->transient_total == 0)
+    {
+      /* nothing was counted, so the list has nothing for us -- a statement that took no transient lock
+       * does not pay for the locks the transaction holds for other reasons */
+      return;
+    }
+
+  for (entry_ptr = tran_lock->inst_hold_list; entry_ptr != NULL; entry_ptr = next_ptr)
+    {
+      /* the entry may be gone once its last request is given back, so take the link first */
+      next_ptr = entry_ptr->tran_next;
+
+      n = entry_ptr->transient_count;
+      if (n > 0)
+	{
+	  /* every counted request also raised count, so this cannot outrun what the entry holds; were it
+	   * to, the release that empties the entry would free it under the ones still to come */
+	  assert (n <= entry_ptr->count);
+	  n = MIN (n, entry_ptr->count);
+	  entry_ptr->transient_count = 0;
+	  for (i = 0; i < n; i++)
+	    {
+	      /* give back exactly what this statement took; a request it did not take stays */
+	      lock_internal_perform_unlock_object (thread_p, entry_ptr, false, false);
+	    }
+	}
+    }
+
+  /* an entry the escalation reclaimed took its count with it, so the total can only have run high;
+   * clearing it here keeps that from costing a walk later */
+  tran_lock->transient_total = 0;
+#endif /* !SERVER_MODE */
+}
+
+/*
+ * lock_forget_transient_object_locks () - Drop the transient counts without releasing anything
+ *   return: void
+ *   thread_p(in): thread entry
+ *
+ * Note: a statement that failed leaves its locks to commit, the way it did before any of them were
+ *	counted.  The counts have to go, though: they name no statement, so the next statement to release
+ *	would give back requests it never took.
+ */
+void
+lock_forget_transient_object_locks (THREAD_ENTRY * thread_p)
+{
+#if !defined (SERVER_MODE)
+  return;
+#else /* !SERVER_MODE */
+  LK_TRAN_LOCK *tran_lock;
+  LK_ENTRY *entry_ptr;
+  int tran_index;
+
+  tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
+  tran_lock = &lk_Gl.tran_lock_table[tran_index];
+
+  if (tran_lock->transient_total == 0)
+    {
+      return;
+    }
+
+  for (entry_ptr = tran_lock->inst_hold_list; entry_ptr != NULL; entry_ptr = entry_ptr->tran_next)
+    {
+      entry_ptr->transient_count = 0;
+    }
+  tran_lock->transient_total = 0;
+#endif /* !SERVER_MODE */
+}
+
 
 /*
  * lock_transaction_mvccid - Acquire a transaction self-lock keyed by an MVCCID
@@ -6475,7 +6764,7 @@ lock_transaction_mvccid (THREAD_ENTRY * thread_p, MVCCID mvccid, LOCK lock, int 
   int granted;
   LK_ENTRY *tran_entry = NULL;
 
-  /* callers pre-filter via logtb_get_current_mvccid / btree_is_active_other_inserter, so a non-normal
+  /* callers pre-filter via logtb_get_current_mvccid / logtb_is_active_other_mvccid, so a non-normal
    * MVCCID is not an expected input; the early return below is a safe no-op fallback. */
   assert (MVCCID_IS_NORMAL (mvccid));
   if (!MVCCID_IS_NORMAL (mvccid))
@@ -7388,6 +7677,9 @@ lock_unlock_all (THREAD_ENTRY * thread_p)
 
   tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
   tran_lock = &lk_Gl.tran_lock_table[tran_index];
+
+  /* the transaction is over, so no statement of it is inside a transient scope any more */
+  lock_reset_transient_state (tran_lock);
 
   /* remove all instance locks */
   entry_ptr = tran_lock->inst_hold_list;

--- a/src/transaction/lock_manager.h
+++ b/src/transaction/lock_manager.h
@@ -95,6 +95,7 @@ struct lk_entry
   int instant_lock_count;	/* number of instant lock requests */
   int bind_index_in_tran;
   XASL_ID xasl_id;
+  int transient_count;		/* requests on this entry that the statement gives up before commit */
 #else				/* not SERVER_MODE */
   int dummy;
 #endif				/* not SERVER_MODE */
@@ -223,6 +224,14 @@ extern int lock_hold_object_instant (THREAD_ENTRY * thread_p, const OID * oid, c
 extern int lock_object_wait_msecs (THREAD_ENTRY * thread_p, const OID * oid, const OID * class_oid, LOCK lock,
 				   int cond_flag, int wait_msecs);
 extern int lock_object (THREAD_ENTRY * thread_p, const OID * oid, const OID * class_oid, LOCK lock, int cond_flag);
+extern int lock_object_transient (THREAD_ENTRY * thread_p, const OID * oid, const OID * class_oid, LOCK lock,
+				  int cond_flag);
+extern void lock_unlock_object_transient (THREAD_ENTRY * thread_p, const OID * oid, const OID * class_oid, LOCK lock);
+extern bool lock_transient_scope_is_outermost (THREAD_ENTRY * thread_p);
+extern bool lock_transient_scope_start (THREAD_ENTRY * thread_p);
+extern void lock_transient_scope_end (THREAD_ENTRY * thread_p, bool release);
+extern void lock_release_transient_object_locks (THREAD_ENTRY * thread_p);
+extern void lock_forget_transient_object_locks (THREAD_ENTRY * thread_p);
 extern int lock_transaction_mvccid (THREAD_ENTRY * thread_p, MVCCID mvccid, LOCK lock, int cond_flag);
 extern void lock_unlock_transaction_mvccid (THREAD_ENTRY * thread_p, MVCCID mvccid, LOCK lock);
 extern int lock_has_lock_on_transaction_mvccid (THREAD_ENTRY * thread_p, MVCCID mvccid, LOCK lock);

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -1195,6 +1195,9 @@ extern int logtb_invalidate_snapshot_data (THREAD_ENTRY * thread_p);
 extern int xlogtb_get_mvcc_snapshot (THREAD_ENTRY * thread_p);
 
 extern bool logtb_is_current_mvccid (THREAD_ENTRY * thread_p, MVCCID mvccid);
+extern bool logtb_is_active_other_mvccid (THREAD_ENTRY * thread_p, MVCCID mvccid);
+extern bool logtb_has_active_savepoint (THREAD_ENTRY * thread_p);
+extern int logtb_wait_for_tran_end (THREAD_ENTRY * thread_p, MVCCID mvccid);
 extern bool logtb_is_mvccid_committed (THREAD_ENTRY * thread_p, MVCCID mvccid);
 extern MVCC_SNAPSHOT *logtb_get_mvcc_snapshot (THREAD_ENTRY * thread_p);
 extern void logtb_complete_mvcc (THREAD_ENTRY * thread_p, LOG_TDES * tdes, bool committed);

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -4220,6 +4220,75 @@ logtb_is_current_mvccid (THREAD_ENTRY * thread_p, MVCCID mvccid)
 }
 
 /*
+ * logtb_is_active_other_mvccid () - Is mvccid an in-progress write by another transaction?
+ *
+ * return: true if some other transaction is still active under mvccid
+ *
+ *   thread_p(in): thread entry
+ *   mvccid(in): MVCC id
+ */
+bool
+logtb_is_active_other_mvccid (THREAD_ENTRY * thread_p, MVCCID mvccid)
+{
+  return MVCCID_IS_NORMAL (mvccid) && !logtb_is_current_mvccid (thread_p, mvccid)
+    && log_Gl.mvcc_table.is_active (mvccid);
+}
+
+/*
+ * logtb_has_active_savepoint () - Is a savepoint declared, so a partial rollback can reach back to here?
+ *
+ * return: true if this transaction has declared a savepoint
+ *
+ *   thread_p(in): thread entry
+ */
+bool
+logtb_has_active_savepoint (THREAD_ENTRY * thread_p)
+{
+  LOG_TDES *tdes = LOG_FIND_TDES (LOG_FIND_THREAD_TRAN_INDEX (thread_p));
+
+  return tdes != NULL && !LSA_ISNULL (&tdes->savept_lsa);
+}
+
+/*
+ * logtb_wait_for_tran_end () - Block until the transaction working under mvccid ends: S_LOCK on its
+ *				MVCCID self-lock, then release.
+ *
+ * return	 : NO_ERROR once that transaction has ended. An error if the lock failed, or if the
+ *		   self-lock invariant is breached (grant while the transaction is still active) --
+ *		   waiting again cannot recover it, so fail the statement rather than spin.
+ * thread_p (in) : Thread entry.
+ * mvccid (in)	 : MVCCID of the in-progress transaction to wait out.
+ *
+ * Note: call with no page latch held.
+ */
+int
+logtb_wait_for_tran_end (THREAD_ENTRY * thread_p, MVCCID mvccid)
+{
+  int error_code;
+
+  if (lock_transaction_mvccid (thread_p, mvccid, S_LOCK, LK_UNCOND_LOCK) != LK_GRANTED)
+    {
+      error_code = er_errid ();
+      if (error_code == NO_ERROR)
+	{
+	  error_code = ER_CANNOT_GET_LOCK;
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_code, 0);
+	}
+      return error_code;
+    }
+  lock_unlock_transaction_mvccid (thread_p, mvccid, S_LOCK);
+
+  if (log_Gl.mvcc_table.is_active (mvccid))
+    {
+      /* Invariant breach: no-op grant while that transaction is still active. */
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CANNOT_GET_LOCK, 0);
+      assert (false);
+      return ER_CANNOT_GET_LOCK;
+    }
+  return NO_ERROR;
+}
+
+/*
  * logtb_get_mvcc_snapshot  - get MVCC snapshot
  *
  * return: MVCC snapshot


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27034

### Purpose

DELETE·UPDATE 는 select 단계에서 대상 행마다 X 락을 잡아 커밋까지 쥔다. 20만 행을 지우는 트랜잭션은 20만 개의 락 엔트리를 커밋까지 들고 있고, lock escalation 이 일어나면 건드린 적 없는 행까지 막는다. 그런데 엔트리가 적는 사실 — 지금 이 행을 누가 쓰고 있는가 — 은 MVCC 레코드 헤더에 이미 있다. 엔트리는 그 사본이다.

이 PR 은 뒤에 온 트랜잭션이 기다릴 자리를 행 락에서 그 행을 고친 트랜잭션의 락으로 옮기고, 행 락 자체는 문장이 끝날 때 반납한다. 삭제자·갱신자는 MVCC 스탬프(DELID·INSID)가 남에게 보이기 전에 자기 MVCCID 에 X 를 잡고, 그 스탬프를 만난 트랜잭션은 행 락이 아니라 그 락을 기다린다. 같은 행에 두 writer 가 올라가지 못하는 것도, 대기가 커밋까지 이어지는 것도 그대로다 — 달라지는 것은 무엇이 그것을 지키느냐다. 미커밋 상태에서 300행 중 150행을 건드린 트랜잭션의 인스턴스 락 엔트리가 150 개에서 1 개(트랜잭션 락)로 준다.

### Implementation

**1. 대기 자리 — 뒤에 온 트랜잭션은 어디서 기다리는가**

목표: 스탬프를 만난 트랜잭션이 행 락이 아니라 그 스탬프를 남긴 트랜잭션의 락에서 기다린다. 그 락은 스탬프가 남에게 보이기 전에 서 있어야 한다.

- `heap_file.c`: `heap_delete_logical ()` 이 스탬프 전에 `logtb_ensure_mvccid_self_lock ()` 로 트랜잭션 락을 확보한다. 삽입·갱신 쪽은 CBRD-26942 가 이미 같은 순서를 지킨다.
- `log_tran_table.c`, `log_impl.h`: `logtb_wait_for_tran_end ()` 가 그 MVCCID 에 S_LOCK 을 요청해 소유자가 쥔 X 가 풀릴 때까지 기다리고, `logtb_is_active_other_mvccid ()` 가 아직 살아 있는 writer 인지 가른다. 순서가 뒤집혀 아무도 기다리지 않고 승인되면 `assert` 가 잡는다.
- `locator_sr.{c,h}`: `locator_get_settled_last_version ()` 이 DELID·INSID 두 스탬프 모두에 정착한다 — 힙의 최신 버전을 얻는 자리가 정착 지점이다.
- `btree_lock.{cpp,hpp}` (`btree.c` 에서 분리): 키를 통해 락을 잡는 일과 그 키를 쥔 writer 를 기다리는 일. 힙 쪽 정착과 같은 프리미티브(`logtb_*`)를 쓴다. 외래 키 검사가 `DELETE_RECORD_DELETE_IN_PROGRESS` 를 만나면 객체 락이 아니라 그 트랜잭션의 끝을 기다린다.
- `btree.c`: 삭제 스탬프의 소유자는 검색이 out-param 으로 알려 준다. `btree_find_oid_from_leaf ()` 외 넷이 OID 가 맞고 delete MVCCID 가 있고 그 소유자가 아직 살아 있는 첫 객체를 `btree_note_active_delete_owner ()` 로 기록하고, 오버플로의 두 형식(unique 의 선형 체인, non-unique 의 OID 디렉터리)도 그 검색이 이미 안다. 다른 호출자 일곱은 `NULL` 을 넘긴다.

**2. 문장 끝 반납 — 어느 락이 이 문장의 것인가**

목표: 문장이 잡은 행 락은 그 문장이 끝날 때 돌려준다. 어느 요청이 이 문장의 것인지, 그리고 지금이 반납해도 되는 문장인지를 실행기가 답한다.

- `lock_manager.{c,h}`: `LK_ENTRY.transient_count` 가 그 엔트리에 얹힌 이 문장의 요청 수를 센다 — 한 문장이 한 행에 요청을 둘 이상 쌓을 수 있고, 반납은 그만큼만 되돌린다. `lock_transient_scope_start/end ()` 가 문장 경계와 중첩을 맡아 가장 바깥 scope 가 닫힐 때만 반납한다.
- `query_executor.c`: DELETE·UPDATE 실행기가 자기 구간을 그 scope 로 감싸고, `qexec_open_scan ()` 은 `upd_del_class_cnt` 로 DML 을 구동하는 select 를 가려 select 단계의 락도 문장의 것으로 센다. 반납 여부는 문장마다 한 번 계산해 select·force 두 단계가 같은 값을 읽는다(`statement_ends_locks`). 격리 게이트도 두 단계가 같다 — 반납은 READ COMMITTED 에서만 한다.
- `scan_manager.{c,h}`: 스캔이 `lock_ends_with_statement` 를 들고 다닌다. 파티션 프루닝 뒤에는 프루닝된 파티션 기준으로 다시 계산하고, 온라인 인덱스 빌드 중인 클래스와 비-MVCC 클래스는 뺀다.
- `locator_sr.{c,h}`: `LOCATOR_LOCK_*_TRANSIENT` 정책으로 force 단계가 같은 답을 받는다.

**3. 소유자 재접촉 — 자기 스탬프 행을 다시 건드릴 때**

목표: 행 락을 잡지 않는다. 이 트랜잭션의 락이 잡혀 있는 동안 그 MVCCID 가 찍힌 행의 유일한 writer 는 이 트랜잭션이므로(소유자 유일) 행 락이 더 해 줄 일이 없고, 반대로 락을 요청하면 그 행의 X 를 쥔 채 이 트랜잭션을 기다리는 대기자 뒤에 서서 사이클이 닫힌다.

- `locator_sr.{c,h}`: `locator_last_version_is_ours ()` 가 힙 헤더의 삽입 MVCCID 로 판정한다. 조건부 락이 실패한 뒤에만 물으므로 비경합 비용은 0 이다. 허용은 호출자가 정한다 — 문장의 DML 과 외래 키 cascade 는 락의 수명과 무관하게 허용하고, 클라이언트 fetch-with-lock 은 불허한다(클라이언트에 락 캐시가 있어 락이 실제로 있어야 한다).

**4. ODKU 의 충돌 행 — 진행 중인 삭제를 덮지 않는다**

목표: 삭제가 진행 중인 중복 행은 그 삭제자가 끝난 뒤의 상태를 보고 판단한다. 삭제자가 게시한 뒤로 그 행에는 행 락이 없고 보이는 버전이 그 삭제를 가리므로, 그대로 갱신하면 아직 되돌려야 할 레코드를 덮는다.

- `query_executor.c`: 충돌 행 fetch 가 `heap_get_visible_version ()` 대신 락 경로(`locator_lock_and_get_object ()`)로 읽어 삭제자를 기다렸다 다시 읽는다. 사용자가 보는 차이가 둘 생긴다 — 충돌 행에 커밋까지 유지되는 X 락이 생기고, 삭제가 확정된 경우 중복이 아니게 되어 삽입으로 넘어간다.

### Remarks

- **문장 끝 반납의 조건.** 세이브포인트가 선언된 적이 없는 트랜잭션에서만 반납한다 — `logtb_has_active_savepoint ()` 가 보는 `savept_lsa` 는 tdes 정리 때만 지워지므로, 사용자 `SAVEPOINT` 뿐 아니라 트리거가 걸린 테이블의 INSERT·MERGE·DDL 이 잡는 시스템 세이브포인트 하나를 지난 트랜잭션도 그 뒤 모든 DELETE·UPDATE 에서 행 락을 커밋까지 쥔다. 안전한 쪽으로 넓은 판정이고, 좁히는 변경(클라이언트가 질의마다 되돌아갈 수 있는 세이브포인트가 없다고 단언한다)은 클라이언트 라이브러리를 고치는 별개 층이라 이 PR 뒤에 따로 온다.
- `SELECT … FOR UPDATE`, REPEATABLE READ, MERGE 는 문장 끝 반납 대상이 아니다(의도). 앞의 둘은 락이 트랜잭션의 것이고, MERGE 는 `qexec_execute_merge ()` 가 자기 transient scope 를 열어 두 절을 중첩 문장으로 만든다. 그 scope 는 서버가 실행하는 MERGE 만 덮는다 — 대상에 트리거가 있거나 뷰이면 `do_merge ()` 가 클라이언트에서 실행하고 서버로는 절마다 SELECT 하나가 내려와, 그 락은 평범한 락으로 커밋까지 남는다.
- 트리거가 붙은 테이블의 DELETE·UPDATE 와 뷰를 통한 DELETE·UPDATE 는 클라이언트 경로로 가므로 이 개선을 받지 않는다. 회귀는 아니고 이득이 닿지 않는 것이며, 그 경계가 `CREATE TRIGGER` 한 줄로 뒤집힌다. 트리거 *동작* 문장은 서버 경로를 타므로 이 개선을 받는다.
- **남은 데드락 하나.** 자기가 갱신한 행을 `INSERT … ON DUPLICATE KEY UPDATE` 로 다시 치는 트랜잭션은, 그 사이 그 행을 기다리는 다른 트랜잭션이 있으면 데드락에 걸린다(AS-IS 에는 없다). 그 X 는 fetch 가 아니라 앞의 유일 키 조회(`xbtree_find_unique (S_UPDATE)` → `btree_key_lock_object ()`)에서 나오는데, 인덱스 항목이 아는 것은 키를 넣은 트랜잭션이고 비키 컬럼만 고친 소유자의 스탬프는 힙 헤더에만 있어 그 자리에는 소유자 판정이 없다. 그 조회가 객체 락을 잡지 않게 하고 판정을 뒤의 fetch 로 옮기는 별도 변경으로 닫았고, 이 PR 뒤에 온다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
