### PR TITLE
[CBRD-27385] Reject a view as a heap dump target in cubrid diagdb instead of aborting

### DIFF
--- a/msg/en_US.utf8/utils.msg
+++ b/msg/en_US.utf8/utils.msg
@@ -284,6 +284,7 @@ Available command:\n\
     acl         <status|reload> [gateway-name]\n
 46 The length of owner_name is required to be less than %1$d and the length of class_name is required to be less than %2$d bytes.\n
 47 Invalid format for owner_name.class_name ('%1$s').\n
+51 "%1$s" is a view; this operation requires a table.\n
 
 $set 2 MSGCAT_UTIL_SET_BACKUPDB
 30 WARNING: -t option is ignored in stand-alone mode execution.\n

--- a/msg/ko_KR.utf8/utils.msg
+++ b/msg/ko_KR.utf8/utils.msg
@@ -284,6 +284,7 @@ cubrid 관리자 유틸리티, 버전 %1$s\n\
     acl         <status|reload> [게이트웨이 이름]\n
 46 owner_name의 길이는 %1$d 미만이어야 하고 class_name의 길이는 %2$d 바이트 미만이어야 합니다.\n
 47 테이블 이름('%1$s')을 owner_name.class_name 형식으로 입력하십시오.\n
+51 "%1$s"은(는) 뷰입니다. 이 작업은 테이블을 대상으로 합니다.\n
 
 $set 2 MSGCAT_UTIL_SET_BACKUPDB
 30 경고: -t 옵션은 독립 실행 모드에서는 무시 됩니다.\n

--- a/src/executables/util_common.c
+++ b/src/executables/util_common.c
@@ -45,6 +45,10 @@
 #else
 #include "tcp.h"
 #endif
+#include "error_manager.h"
+#if !defined (SERVER_MODE)
+#include "db.h"
+#endif /* !SERVER_MODE */
 // XXX: SHOULD BE THE LAST INCLUDE HEADER
 #include "memory_wrapper.hpp"
 
@@ -406,6 +410,50 @@ utility_check_class_name (const char *class_name)
 
   return NO_ERROR;
 }
+
+#if !defined (SERVER_MODE)
+/*
+ * utility_check_class_is_vclass() - Check that a class given to a utility is not a view.
+ *   return: ER_FAILED if the class exists and is a view (reported and logged here, like
+ *           utility_check_class_name ()); NO_ERROR otherwise. An unknown class is not an error here - it is left
+ *           to the caller so that its existing unknown-class report is unchanged.
+ *   class_name(in): class name given to the utility
+ *
+ * Note: a view is a class without a heap, so a utility that operates on a class's heap (e.g. diagdb heap dump)
+ *       must reject it up front, the same way it rejects an unknown class.
+ */
+int
+utility_check_class_is_vclass (const char *class_name)
+{
+  DB_OBJECT *class_mop;
+  int is_vclass;
+
+  class_mop = db_find_class (class_name);
+  if (class_mop == NULL)
+    {
+      er_clear ();
+      return NO_ERROR;
+    }
+
+  is_vclass = db_is_vclass (class_mop);
+  if (is_vclass < 0)
+    {
+      er_clear ();
+      return NO_ERROR;
+    }
+
+  if (is_vclass > 0)
+    {
+      PRINT_AND_LOG_ERR_MSG (msgcat_message
+			     (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_GENERIC, MSGCAT_UTIL_GENERIC_CLASS_IS_VCLASS),
+			     class_name);
+      util_log_write_errid (MSGCAT_UTIL_GENERIC_CLASS_IS_VCLASS, class_name);
+      return ER_FAILED;
+    }
+
+  return NO_ERROR;
+}
+#endif /* !SERVER_MODE */
 
 /*
  * fopen_ex - open a file for variable architecture

--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -1738,6 +1738,10 @@ diagdb (UTIL_FUNCTION_ARG * arg)
 		  goto error_exit;
 		}
 	    }
+	  if (utility_check_class_is_vclass (class_name) != NO_ERROR)
+	    {
+	      goto error_exit;
+	    }
 	  error_code = heap_dump_heap_file (thread_p, outfp, dump_records, class_name);
 	  if (error_code != NO_ERROR)
 	    {
@@ -1777,6 +1781,10 @@ diagdb (UTIL_FUNCTION_ARG * arg)
 		    {
 		      goto error_exit;
 		    }
+		}
+	      if (utility_check_class_is_vclass (input_class) != NO_ERROR)
+		{
+		  goto error_exit;
 		}
 
 	      error_code = heap_dump_heap_file (thread_p, outfp, dump_records, input_class);

--- a/src/executables/utility.h
+++ b/src/executables/utility.h
@@ -133,7 +133,8 @@ typedef enum
   MSGCAT_UTIL_GENERIC_CLASSNAME_INVALID_FORMAT = 47,
   MSGCAT_UTIL_GENERIC_INVALID_HOSTNAME = 48,
   MSGCAT_UTIL_GENERIC_EMPTY_HOSTS_CONF = 49,
-  MSGCAT_UTIL_GENERIC_FILE_NOT_FOUND = 50
+  MSGCAT_UTIL_GENERIC_FILE_NOT_FOUND = 50,
+  MSGCAT_UTIL_GENERIC_CLASS_IS_VCLASS = 51
 } MSGCAT_UTIL_GENERIC_MSG;
 
 /* Message id in the set MSGCAT_UTIL_SET_DELETEDB */
@@ -1833,6 +1834,7 @@ extern "C"
   extern INT64 utility_get_option_bigint_value (UTIL_ARG_MAP * arg_map, int arg_ch);
   extern int utility_get_option_string_table_size (UTIL_ARG_MAP * arg_map);
   extern int utility_check_class_name (const char *class_name);
+  extern int utility_check_class_is_vclass (const char *class_name);
 
   extern FILE *fopen_ex (const char *filename, const char *type);
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27385>

> 이 PR은 CBRD-27384 위에 스택되어 있습니다. diff에 CBRD-27384의 커밋 2개가 함께 보이지만, **본 PR의 리뷰 대상은 마지막 커밋 하나**(`[CBRD-27385] Report a class with no heap ...`)입니다. CBRD-27384가 먼저 머지되면 diff가 자동으로 정리됩니다.

### Purpose

debug 빌드에서 view를 대상으로 heap 덤프(cubrid diagdb -d 9 -n <뷰 이름> <db 이름>)를 실행하면 유틸리티가 assert로 종료됩니다.

heap 덤프는 클래스 이름으로 클래스를 찾은 뒤 그 클래스의 HFID(heap 파일 위치)를 조회하는데, "이름으로 찾은 클래스라면 HFID 조회는 반드시 성공한다"고 가정합니다. 그러나 view는 카탈로그에 존재하는 클래스라서 이름 조회는 성공하지만, 행을 저장하지 않으므로 heap이 없습니다(HFID = NULL). 따라서 HFID 조회가 "heap 없음"으로 실패하고, 그 결과가 assert에 걸려 종료됩니다. view에 대해 항상 재현됩니다.

view는 heap이 없으므로 heap 덤프의 대상 자체가 성립하지 않습니다. 존재하지 않는 테이블 이름을 넣었을 때와 같은 성격의 잘못된 입력이므로, 같은 방식으로 명시적인 오류로 처리해야 합니다.

### Implementation

diagdb()의 입력 검증 단계에서 대상 클래스가 view인지 확인하고, view이면 기존의 "알 수 없는 클래스" 처리와 동일하게 오류로 종료합니다.

### Remarks

- 검증(debug 빌드, SA 모드):
  - 사용자 view / 시스템 view(db_class): `"<이름>" is a view; this operation requires a table.` 이 stderr로 출력되고 exit 1, cubrid_utility.log에 FAILURE 기록
  - `-o` 파일 지정 시: 파일 0바이트, 이유는 stderr
  - 알 수 없는 클래스: 기존 `Unknown class "<이름>"` 처리 그대로 (회귀 없음)
  - 정상 테이블: 덤프 출력, exit 0
  - 클래스 목록 [테이블, view, 테이블]: 첫 테이블만 덤프된 뒤 view에서 중단, exit 1 (알 수 없는 클래스와 동일한 동작)
- 이 수정은 CBRD-27384가 도입한 found 반환 계약에 의존하므로 그 위에 스택되어 있습니다.