### PR TITLE
[CBRD-27334] rev: Semantic error occurs when executing SP containing a WITH clause

### DIFF
--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -14936,7 +14936,9 @@ pt_print_select (PARSER_CONTEXT * parser, PT_NODE * p)
 
   if (p->info.query.is_subquery == PT_IS_SUBQUERY
       || (p->info.query.is_subquery == PT_IS_UNION_SUBQUERY && p->info.query.order_by)
-      || (p->info.query.is_subquery == PT_IS_UNION_QUERY && p->info.query.order_by))
+      || (p->info.query.is_subquery == PT_IS_UNION_QUERY && p->info.query.order_by)
+      || (p->info.query.is_subquery == PT_IS_CTE_NON_REC_SUBQUERY && p->info.query.order_by)
+      || (p->info.query.is_subquery == PT_IS_CTE_REC_SUBQUERY && p->info.query.order_by))
     {
       if (!p->info.query.flag.subquery_cached)
 	{


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27334>

### Purpose

CTE WITH쿼리 가 포함된 PL/CSQL에서 에러 발생

### Implementation

CBRD-27334 이슈에서, WITH 쿼리에 UNION ... ORDER BY가 포함된 경우 괄호를 넣어주어야 함.

### Remarks

11.4에 백포트 필요
