### PR TITLE
[CUBRIDQA-1501] Read the CI storage off the gha-ci volume, and keep the build log next to the build

### DIFF
--- a/.github/workflows/gha-ci.yml
+++ b/.github/workflows/gha-ci.yml
@@ -116,11 +116,10 @@ concurrency:
   cancel-in-progress: ${{ github.event_name != 'push' }}
 
 env:
-  # Not the operational builds/ path -- the CircleCI test_shell still reads that.
-  CI_ROOT: /home/build-cache/gha-ci
-  CI_BUILD_ROOT: /home/build-cache/gha-ci/builds
-  TIMINGS: /home/build-cache/gha-ci/timings/shell.tsv
-  STAMPS: /home/build-cache/gha-ci/runs/${{ github.run_id }}/stamps
+  CI_ROOT: /home/gha-ci
+  CI_BUILD_ROOT: /home/gha-ci/builds
+  TIMINGS: /home/gha-ci/timings/shell.tsv
+  STAMPS: /home/gha-ci/runs/${{ github.run_id }}/stamps
   BUILD_SENTINEL: .complete
   BUILD_META: .gha-ci-build.meta
   # Paired with arc_artifact_server_node_port in circleci-k8s-ansible.
@@ -352,11 +351,10 @@ jobs:
         shell: bash
 
     env:
-      # Same values as the CircleCI executor cubrid-build.
-      BUILD_MIRROR: /home/build-cache/cubrid-mirror
+      BUILD_MIRROR: /home/gha-ci/repos
       # Per mode: one path for two matrix legs is the later leg overwriting
       # the earlier one.
-      BUILD_LOG_DIR: /home/build-cache/gha-ci/runs/${{ github.run_id }}/build/${{ matrix.mode }}
+      BUILD_LOG_DIR: /home/gha-ci/runs/${{ github.run_id }}/build/${{ matrix.mode }}
       MODE: ${{ matrix.mode }}
       BUILD_ARGS: ${{ matrix.args }}
       # develop | pr. Keeps the preserved develop artifacts out of reach of PR builds.
@@ -364,7 +362,7 @@ jobs:
 
       # One cache per mode, mounted straight off GlusterFS -- there is no restore/save
       # step to gate, so "write on develop only" is enforced by ccache itself below.
-      CCACHE_DIR: /home/build-cache/ccache-develop-${{ matrix.mode }}
+      CCACHE_DIR: /home/gha-ci/cache/ccache/develop-${{ matrix.mode }}
       # The default is mtime, which a fresh clone always misses.
       CCACHE_COMPILERCHECK: content
       # `ccache --max-size` writes into the cache directory; the variable does not.
@@ -394,7 +392,7 @@ jobs:
           echo "SHA=$INPUT_SHA" >> "$GITHUB_ENV"
 
           echo "=== mounts ==="
-          ls -ld /home/build-cache "$BUILD_MIRROR/cubrid.git" "$CCACHE_DIR" || true
+          ls -ld /home/gha-ci "$BUILD_MIRROR/cubrid.git" "$CCACHE_DIR" || true
           if [ ! -d "$BUILD_MIRROR/cubrid.git" ]; then
             echo "::error::the mirror is not visible. The pod template did not reach the job pod."
             exit 1
@@ -534,6 +532,12 @@ jobs:
             mkdir -p "$tmp"
             cp -a /home/CUBRID "$tmp/CUBRID"
 
+            # The summary links this copy, not the one under the run directory: a
+            # reused build outlives the run that made it.
+            if [ -f "$GITHUB_WORKSPACE/build.log" ]; then
+              cp "$GITHUB_WORKSPACE/build.log" "$tmp/build.log"
+            fi
+
             # Inside the CUBRID tree on purpose: shard mounts it as the overlay lowerdir,
             # so reading this file proves the mount the tests actually use.
             meta=$(printf 'sha=%s\nmode=%s\nns=%s\nrun_id=%s\nrun_attempt=%s\nbuilt_at=%s\nworkflow=gha-ci\n' \
@@ -593,7 +597,7 @@ jobs:
           echo "built by : $by (this run: $GITHUB_RUN_ID)"
           cat "$dir/build.meta"
           du -sh "$dir"
-          df -h /home/build-cache | tail -1
+          df -h /home/gha-ci | tail -1
 
           printf 'end\t%s\n' "$(date -u +%s)" >> "$STAMPS/build.tsv"
 
@@ -1794,13 +1798,11 @@ jobs:
             fi
             echo
             echo "---"
-            # BRID: a reused build left no log under this run. debug: that is
-            # what the suite mounted. A build published before this layout has
-            # no log here, and the flat file it left names no mode -- linking
-            # it would open the release log next to a debug failure half the
-            # time, so that run gets no build-log link at all.
+            # Next to the published build, not under the run directory: a reused
+            # build outlives the run that made it. debug is what the suite mounted.
+            # A build published before this layout carries no log, so no link.
             line="[Artifacts]($ARTIFACT_URL_BASE/${RUNDIR#$CI_ROOT/}/)"
-            blog="runs/$BRID/build/debug/build.log"
+            blog="builds/$BUILD_NS/$SHA/debug/build.log"
             [ -f "$CI_ROOT/$blog" ] && line="$line · [build log]($ARTIFACT_URL_BASE/$blog)"
             echo "$line"
             echo


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBRIDQA-1501>

### Purpose

gha-ci 가 지금 CircleCI 와 **같은 GlusterFS 볼륨**(`build-cache`, `/home/build-cache`)을 쓴다. 그 안에 CircleCI 의 `builds/` 와 gha-ci 의 `gha-ci/`, 양쪽이 쓰는 `cubrid-mirror`, 소유가 불분명한 디렉토리가 섞여 있다. 이름만 보고 무엇이 무엇인지 알 수 없고, 볼륨 이름의 `cache` 는 그 안의 대부분과 뜻이 맞지 않는다.

그래서 gha-ci 전용 볼륨 `gha-ci`(`/home/gha-ci`)를 새로 만들고, 부류를 이름으로 갈랐다 — `runs/`(실행 기록) · `builds/`(발행물) · `cache/`(ccache) · `repos/`(repo 사본) · `timings/`(운영 데이터). 볼륨과 마운트는 [ansible#21](https://github.com/tw-kang/circleci-k8s-ansible/pull/21)·[#22](https://github.com/tw-kang/circleci-k8s-ansible/pull/22) 가 이미 세웠고, job pod 은 지금 볼륨 둘을 같이 마운트한다. **이 PR 이 워크플로를 새 볼륨으로 옮긴다.**

같이 고치는 것이 하나 더 있다. **summary 의 `build log` 링크가 빌드보다 먼저 죽는다.** 발행된 빌드는 남아 있는데 그 빌드를 만든 run 디렉토리는 7 일 뒤 지워지므로, 그 빌드를 재사용하는 run 의 링크가 404 가 된다.

### Implementation

**1. 읽고 쓰는 자리가 새 볼륨으로 바뀐다.** 워크플로 안의 경로 9 곳이다.

| 무엇 | 전 | 후 |
|---|---|---|
| `CI_ROOT` | `/home/build-cache/gha-ci` | `/home/gha-ci` |
| `CI_BUILD_ROOT` | `…/gha-ci/builds` | `/home/gha-ci/builds` |
| `TIMINGS` | `…/gha-ci/timings/shell.tsv` | `/home/gha-ci/timings/shell.tsv` |
| `STAMPS` | `…/gha-ci/runs/<id>/stamps` | `/home/gha-ci/runs/<id>/stamps` |
| `BUILD_MIRROR` | `/home/build-cache/cubrid-mirror` | `/home/gha-ci/repos` |
| `BUILD_LOG_DIR` | `…/gha-ci/runs/<id>/build/<mode>` | `/home/gha-ci/runs/<id>/build/<mode>` |
| `CCACHE_DIR` | `/home/build-cache/ccache-develop-<mode>` | `/home/gha-ci/cache/ccache/develop-<mode>` |
| 점검 출력 2곳 | `ls -ld`·`df -h /home/build-cache` | `/home/gha-ci` |

URL 은 안 바뀐다. `ARTIFACT_URL_BASE` 도 그대로다 — summary 의 링크는 `CI_ROOT` 상대 경로이고, 산출물 서버의 서빙 루트가 같은 창에서 새 볼륨으로 옮겨간다.

**2. 발행된 빌드가 자기 빌드 로그를 같이 갖는다.** 발행 step 이 staging 안에 `build.log` 를 넣으므로, 빌드 디렉토리와 그 로그의 수명이 같아진다. summary 는 `builds/<ns>/<sha>/debug/build.log` 를 링크한다.

바뀐 화면은 summary 마지막 줄의 링크 주소 하나다. 보이는 글자는 같다.

```
[Artifacts](…/runs/<run_id>/) · [build log](…/builds/develop/<sha>/debug/build.log)
```

빌드를 재사용한 run 도 링크가 붙는다. 전에는 그 run 이 자기 run 디렉토리에 로그를 남기지 않아 링크가 없었고, 있어도 7 일 뒤 죽었다. run 디렉토리 안의 `build/<mode>/build.log` 는 그대로 둔다 — 실패한 빌드는 발행되지 않으므로 그쪽이 유일한 증거다.

### Remarks

- ⚠ **머지 창이 정해져 있다.** 이 PR 과 [ansible#23](https://github.com/tw-kang/circleci-k8s-ansible/pull/23)(산출물 서버 루트) 은 **같은 창에서** 나가야 한다. summary 의 링크가 `ARTIFACT_URL_BASE` + `CI_ROOT` 상대 경로라, 한쪽만 옮기면 쓰는 곳과 읽는 곳이 갈려 그 사이 run 의 링크가 전부 404 다. 창에서 하는 일 = 러너 pod 0 확인 → 증분 rsync → ansible 적용 → 이 PR 머지 → green run 1 건 확인.
- **이 PR 이 확인되면 옛 마운트를 지운다** — [ansible#24](https://github.com/tw-kang/circleci-k8s-ansible/pull/24). 그 순서를 거꾸로 하면 옛 경로를 읽는 job 이 마운트를 못 찾아 죽는다.
- **옛 볼륨은 그대로 둔다.** CircleCI 가 9/30 까지 `builds/`·`cubrid-mirror/`·`ccache-shell-debug` 를 읽는다. `.circleci/config.yml` 은 이 PR 이 건드리지 않는다. 호환 심링크도 두지 않는다 — 새 볼륨이라 필요가 없다.
- **ccache 는 경로가 바뀌어도 hit 한다.** `CCACHE_BASEDIR` 를 쓰지 않고 키가 절대경로 기반이라 캐시 디렉토리 위치는 키에 들어가지 않는다. 창에서 증분 rsync 로 옮긴다.
- **옛 run 의 `/run rerun <id>` 도 산다.** 새 볼륨의 `runs/` 는 옛 볼륨에서 rsync 로 이미 채웠다(2026-09-07, 108,577 파일). 창의 증분 rsync 가 그 뒤에 난 run 을 따라잡는다.
- ⚠ **머지 직전에 시작한 run 은 옛 경로로 끝난다.** 그 run 이 쓴 timings 행은 옛 볼륨에 남는다. 증분 rsync 와 머지 사이를 짧게 잡는다.
- ⚠ **이 파일을 고치는 티켓 셋이 뒤에 있다** — 실패 케이스 로그(37) · attempt 별 stamps(39) · run 디렉토리 재배치(44). **이 PR 이 먼저다.** 나머지는 이 위에 rebase 한다.
- 검증: YAML 파싱(job 7개 그대로) · run step 34 개 전부 `bash -n` 통과 · step 본문에 `${{ }}` 보간 0 · 워크플로에 `/home/build-cache` 0 곳. 실 run 은 이 PR 이 열릴 때 도는 `pull_request` 빌드가 새 경로로 처음 도는 것이다(build 만, 테스트 없음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EApyK91WVUGxuvv9f9xTqH
