### PR TITLE
[CBRD-27325] Rediscover free heap pages so bulk-deleted space is reused by bestspace

### DIFF
--- a/src/storage/bestspace.cpp
+++ b/src/storage/bestspace.cpp
@@ -430,6 +430,25 @@ namespace cubstorage
       }
   }
 
+  // rediscover skips a page already advertised by an L1 slot: requeueing it would route concurrent
+  // inserters through the blocking candidate verify path against a page its L1 owner is filling.
+  bool
+  bestspace::shard::holds (const VPID &vpid)
+  {
+    std::size_t i;
+    L1 l1;
+
+    for (i = 0; i < ENTRIES_PER_SHARD; i++)
+      {
+	l1 = m_L1[i].load ();
+	if (l1.get_vpid ().pageid == vpid.pageid && l1.get_vpid ().volid == vpid.volid)
+	  {
+	    return true;
+	  }
+      }
+    return false;
+  }
+
   bestspace::status
   bestspace::shard::L3_find (OID *class_oid, tier minimum, std::uint16_t needed_size, std::uint16_t consume_size,
 			     std::size_t bias, PGBUF_WATCHER &page_watcher)
@@ -1069,6 +1088,19 @@ namespace cubstorage
 	return result;
       }
 
+    // pop returns a full batch only when the queue can cover needed_size; fewer means it cannot
+    // serve this request, so rediscover before extending the file.
+    if (num_candidates < ALLOC_BATCH_SIZE && m_parent.rediscover (hfid) > 0)
+      {
+	result = allocate_get_candidates_or_update_residents (class_oid, needed_size, consume_size, residents, victims,
+		 candidates, num_candidates, page_watcher);
+	if (result == status::FOUND || result == status::FAILURE)
+	  {
+	    allocate_unmark ();
+	    return result;
+	  }
+      }
+
     // verify the page has enough freespace and allocate new pages if not
     result = allocate_verify_or_allocate (class_oid, hfid, needed_size, candidates, num_candidates, page_watcher);
     if (result == status::FAILURE)
@@ -1285,8 +1317,13 @@ namespace cubstorage
     , m_num_pages (num_pages)
     , m_recs_num (recs_num)
     , m_recs_sumlen (recs_sumlen)
+    , m_scanning (false)
+    , m_scan_enabled (true)
+    , m_scan_fruitless (0)
   {
     assert (shard_count > 0);
+
+    VPID_SET_NULL (&m_scan_cursor);
 
     // last updated time
     m_last_updated.store (monotonic_seconds ());
@@ -1340,6 +1377,13 @@ namespace cubstorage
       {
 	m_candidates.try_push (candidates[i]);
       }
+
+    // CBRD-27325: fresh candidates mean free space exists again - re-arm the rediscovery scan
+    if (num_candidates > 0 && !m_scan_enabled.load ())
+      {
+	m_scan_fruitless.store (0);
+	m_scan_enabled.store (true);
+      }
   }
 
   void
@@ -1350,6 +1394,13 @@ namespace cubstorage
     for (i = 0; i < num_candidates; i++)
       {
 	m_candidates.push (candidates[i]);
+      }
+
+    // CBRD-27325: fresh candidates mean free space exists again - re-arm the rediscovery scan
+    if (num_candidates > 0 && !m_scan_enabled.load ())
+      {
+	m_scan_fruitless.store (0);
+	m_scan_enabled.store (true);
       }
   }
 
@@ -1545,6 +1596,125 @@ namespace cubstorage
   bestspace::get_num_shards ()
   {
     return m_shards.size ();
+  }
+
+  // Scan up to REDISCOVER_BATCH_SIZE pages of the heap chain from a persistent cursor and return
+  // free ones to the candidate queue. A hint only: consumers re-validate under latch.
+  std::size_t
+  bestspace::rediscover (HFID *hfid)
+  {
+    cubthread::entry *thread_p = thread_get_thread_entry_info ();
+    bestspace_entry found[REDISCOVER_BATCH_SIZE];
+    PGBUF_WATCHER watcher;
+    std::size_t num_found = 0;
+    std::size_t visited;
+    VPID vpid, next_vpid;
+    std::uint32_t fruitless;
+    int freespace;
+    int wait_msecs;
+    int error;
+    bool is_header;
+    bool expected = false;
+
+    if (!m_scan_enabled.load ())
+      {
+	return 0;
+      }
+    if (!m_scanning.compare_exchange_strong (expected, true))
+      {
+	// another thread is already scanning this heap
+	return 0;
+      }
+
+    vpid = m_scan_cursor;
+
+    for (visited = 0; visited < REDISCOVER_BATCH_SIZE; visited++)
+      {
+	if (VPID_ISNULL (&vpid))
+	  {
+	    // wrap around: restart from the heap header page
+	    vpid.volid = hfid->vfid.volid;
+	    vpid.pageid = hfid->hpgid;
+	  }
+	is_header = (vpid.pageid == hfid->hpgid && vpid.volid == hfid->vfid.volid);
+
+	PGBUF_INIT_WATCHER (&watcher, is_header ? PGBUF_ORDERED_HEAP_HDR : PGBUF_ORDERED_HEAP_NORMAL, hfid);
+
+	wait_msecs = xlogtb_reset_wait_msecs (thread_p, LK_FORCE_ZERO_WAIT);
+	error = pgbuf_ordered_fix (thread_p, &vpid, OLD_PAGE_MAYBE_DEALLOCATED, PGBUF_LATCH_READ, &watcher);
+	(void) xlogtb_reset_wait_msecs (thread_p, wait_msecs);
+	if (error != NO_ERROR)
+	  {
+	    if (error != ER_LK_PAGE_TIMEOUT)
+	      {
+		// deallocated or otherwise stale cursor: restart from the header next time
+		VPID_SET_NULL (&vpid);
+	      }
+	    // a busy page keeps the cursor so the next scan resumes here
+	    er_clear ();
+	    break;
+	  }
+
+	if (!is_header
+	    && !heap_page_is_bestspace (thread_p, watcher.pgptr)
+	    && !heap_page_is_not_in_heap (thread_p, watcher.pgptr))
+	  {
+	    freespace = spage_max_space_for_new_record (thread_p, watcher.pgptr);
+	    if (freespace > 0 && size_to_tier ((std::uint16_t) freespace) >= tier::FS3)
+	      {
+		bool resident = false;
+		for (std::size_t s = 0; s < m_shards.size (); s++)
+		  {
+		    if (m_shards[s].holds (vpid))
+		      {
+			resident = true;
+			break;
+		      }
+		  }
+		if (!resident)
+		  {
+		    found[num_found].freespace = (std::uint16_t) freespace;
+		    found[num_found].volid = vpid.volid;
+		    found[num_found].pageid = vpid.pageid;
+		    num_found++;
+		  }
+	      }
+	  }
+
+	error = heap_vpid_next (thread_p, hfid, watcher.pgptr, &next_vpid);
+	pgbuf_ordered_unfix (thread_p, &watcher);
+	if (error != NO_ERROR)
+	  {
+	    er_clear ();
+	    VPID_SET_NULL (&vpid);
+	    break;
+	  }
+	vpid = next_vpid;
+      }
+
+    m_scan_cursor = vpid;
+
+    if (num_found > 0)
+      {
+	push_candidates (found, num_found);
+	m_scan_fruitless.store (0);
+      }
+    else
+      {
+	// threshold must be the live per-shard total; the global m_num_pages only refreshes at
+	// stats-sync and would disable the scan before a full chain sweep.
+	int live_pages;
+	std::uint64_t rn, rs;
+	get_estimates (live_pages, rn, rs);
+	fruitless = m_scan_fruitless.fetch_add ((std::uint32_t) visited) + (std::uint32_t) visited;
+	if (live_pages > 0 && fruitless >= (std::uint32_t) live_pages)
+	  {
+	    m_scan_enabled.store (false);
+	  }
+      }
+
+    m_scanning.store (false);
+    return num_found;
   }
 
   void

--- a/src/storage/bestspace.hpp
+++ b/src/storage/bestspace.hpp
@@ -75,6 +75,8 @@ namespace cubstorage
       static constexpr std::size_t MAX_CANDIDATES_QUEUE_SIZE = 128;
       static constexpr std::size_t MAX_SHARD_PAGE_COUNT = 4;
       static constexpr std::size_t ALLOC_BATCH_SIZE = 4;
+      // CBRD-27325: pages visited by one bounded rediscovery scan of the heap chain
+      static constexpr std::size_t REDISCOVER_BATCH_SIZE = 64;
       static constexpr std::size_t L3_FANOUT = 8;
       static constexpr std::size_t L2_FANOUT = 8;
       static constexpr std::size_t ENTRIES_PER_SHARD = L3_FANOUT * L2_FANOUT;
@@ -255,6 +257,8 @@ namespace cubstorage
 
 	  void to_entries (bestspace_entry *entries);
 
+	  bool holds (const VPID &vpid);
+
 	private:
 	  // core
 	  atomic_wrapper<bool> m_allocating;
@@ -381,6 +385,11 @@ namespace cubstorage
 
       std::size_t get_num_shards ();
 
+      // CBRD-27325: scan a bounded slice of the heap chain and push free pages into the
+      // candidate queue. Returns the number of pages pushed. At most one scan runs at a time;
+      // a fruitless full sweep disables scanning until the queue sees a push again.
+      std::size_t rediscover (HFID *hfid);
+
       void to_entries (bestspace_entry *entries, bestspace_entry *candidates, std::size_t &num_candidates);
 
     private:
@@ -397,6 +406,12 @@ namespace cubstorage
       std::atomic<std::uint64_t> m_recs_sumlen;
 
       std::atomic<std::uint64_t> m_last_updated;
+
+      // CBRD-27325: rediscovery state. m_scan_cursor is only accessed while m_scanning is held.
+      std::atomic<bool> m_scanning;
+      std::atomic<bool> m_scan_enabled;
+      std::atomic<std::uint32_t> m_scan_fruitless;
+      VPID m_scan_cursor;
 
       int find_from_shards (cubthread::entry &thread_ref, OID *class_oid, HFID *hfid, std::size_t shard,
 			    std::uint16_t needed_size, std::uint16_t consume_size, std::size_t bias, bool is_newrec, PGBUF_WATCHER &page_watcher);


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27325>

### Purpose

REUSE_OID 힙에 대량 INSERT 후 대량 DELETE 를 반복하면, vacuum 이 비운 페이지가 다음 INSERT 에 재사용되지 않고 힙 파일이 라운드마다 단조 증가합니다(300K delete/insert 1라운드당 약 +2,830 페이지). 11.4 에서는 발생하지 않는 CBRD-26176(bestspace 재설계) 이후의 regression 입니다.


재설계 이전 bestspace 는 힌트가 바닥나면 `heap_stats_sync_bestspace()` 로 힙 체인을 다시 훑어 여유 페이지를 재발견했고, vacuum 이 페이지를 비우면 다음 INSERT 가 그 페이지들을 다시 썼습니다. 재설계는 이 재발견 경로를 제거하고 고정 크기 캐시로 대체했습니다 — 샤드 상주 64개(L1) + 후보 큐 128개(`MAX_CANDIDATES_QUEUE_SIZE`).

vacuum 은 비운 페이지를 `heap_add_bestpage()` 로 후보 큐에만 넣습니다. 큐가 128개를 넘으면 초과분은 어디에도 기록되지 않고, 그 128개를 소진한 뒤의 INSERT 는 매번 `allocate_new_pages()` 로 파일을 확장합니다. 힙 체인을 다시 훑는 경로가 없으므로, 대량 DELETE 로 수천 페이지가 비어도 비워진 페이지는 영영 재발견되지 않습니다.

### Implementation

`bestspace` 에 bounded rediscovery fallback 을 추가했습니다. 

`shard::allocate()` 가 후보 큐로부터 요청을 충족할 페이지를 얻지 못하면(`pop_candidates` 가 `ALLOC_BATCH_SIZE` 미만 반환), 파일을 확장하기 전에 `bestspace::rediscover()` 를 1회 호출하고 큐를 다시 조회합니다.

- **Bounded scan** — 인메모리 커서에서 이어서 힙 체인을 최대 `REDISCOVER_BATCH_SIZE`(64)페이지만 순회합니다. `spage_max_space_for_new_record()` 로 실측해 FS3(≥25% 여유) 이상인 페이지만 후보 큐에 push 합니다. 힙 헤더·bestspace 메타페이지·미공개(`HEAP_PAGE_FLAG_NOT_IN_HEAP`) 페이지는 건너뜁니다.
- **Zero-wait** — 모든 fix 는 `LK_FORCE_ZERO_WAIT` READ 이며 `OLD_PAGE_MAYBE_DEALLOCATED` 모드입니다. busy 페이지를 만나면 커서를 유지한 채 중단하고, 해제된 커서 페이지는 오류 없이 감지되어 커서를 헤더로 리셋합니다. hint 경로에 어떤 wait 도 더하지 않습니다.
- **Single scanner** — `m_scanning` try-flag 로 힙당 동시 scanner 를 하나로 제한합니다. 경쟁에서 진 스레드는 기다리지 않고 기존 경로(신규 할당)로 진행합니다.
- **Resident-page skip** — 이미 L1 슬롯에 등록된 페이지는 큐에 넣지 않습니다. growth burst 중 갓 할당된 페이지를 후보 큐로 복제하면 동시 세션이 blocking verify 경로로 수렴해 throughput 이 저하되므로, 이를 막습니다.
- **Backoff** — 스캔이 아무것도 찾지 못한 채 힙 체인 한 바퀴만큼 누적되면 스캔을 비활성화하고, 큐에 push 가 들어오면(=vacuum/delete 활동 재개) 재활성화합니다. 순수 append 워크로드에서 무의미한 스캔 오버헤드를 방지합니다. 

정확성은 스캔에 의존하지 않습니다. 스캔이 넣은 후보도 소비 시점에 latch 후 class_oid·실측 공간을 재검증하는 기존 validation 단계를 그대로 통과해야 하므로, 낡거나 재사용된 페이지가 섞여도 안전합니다.

### Remarks

- **검증(이슈 재현)**: seed 524,288행, 300K INSERT→DELETE ×5, 단일 서버, 기본 설정에서 `SHOW HEAP CAPACITY` 의 Num_pages.

  | 라운드 | 수정 전 | 수정 후 | 11.4 |
  |---|---|---|---|
  | 1 | 2,973 | 2,973 | 2,971 |
  | 2 | 5,813 | 3,012 | 2,983 |
  | 3 | 8,657 | 3,030 | 2,983 |
  | 4 | 11,501 | 3,052 | 2,983 |
  | 5 | 14,341 (계속 증가) | 3,056 (수렴) | 2,983 |

  수정 후 증가폭이 +39→+18→+22→+4 로 둔화해 ~3,056 에서 수렴합니다. 완전 평탄한 11.4 대비 resident-page skip (L1 슬롯에 등록된 페이지는 큐에 넣지 않는 규칙) 이 일부 재사용을 지연시켜 소폭 높은 지점에서 안정되지만, 파일 무한 증가는 제거됩니다. 행 유실 0, 서버 abort·assert 0.
- **회귀 방지**: 동시 INSERT 6세션×2,000행 무결성(12,000/12,000, 세션별 균등), rollback race 3라운드(commit 9,000/9,000·rollback 잔여 0), append/concurrent/cyclic 마이크로벤치 모두 수정 전 대비 동등 이상.