### PR TITLE
[CUBRIDQA-1501] Show the log of each failed case in the run summary

### DIFF
--- a/.github/workflows/gha-ci.yml
+++ b/.github/workflows/gha-ci.yml
@@ -1529,10 +1529,28 @@ jobs:
         run: |
           set -eo pipefail
           : > /tmp/failed.list
+          rm -rf /tmp/failed-logs
+          mkdir -p /tmp/failed-logs
           for x in "$RUNDIR"/results/*/test-shell.xml; do
             [ -f "$x" ] || continue
             i=$(basename "$(dirname "$x")")
-            awk -v shard="$i" '
+            # Line k of failed.list is /tmp/failed-logs/k.log. The offset carries
+            # that numbering across the shards.
+            off=$(wc -l < /tmp/failed.list)
+            awk -v shard="$i" -v off="$off" '
+              # First, so that a case log carrying the literal <testcase or
+              # <failure does not restart the scan while the body is being read.
+              body != "" {
+                if (/\]\]><\/failure>/) {
+                  sub(/\]\]><\/failure>.*$/, "")
+                  print > body
+                  close(body)
+                  body = ""
+                  next
+                }
+                print > body
+                next
+              }
               /<testcase/ {
                 cur = ""
                 # The leading space is required: CTP writes classname before name,
@@ -1542,7 +1560,22 @@ jobs:
                 }
                 next
               }
-              /<failure/ && cur != "" { printf "%s\t%s\n", shard, cur; cur = "" }
+              /<failure/ && cur != "" {
+                printf "%s\t%s\n", shard, cur
+                body = "/tmp/failed-logs/" (off + ++k) ".log"
+                rest = $0
+                sub(/^.*<!\[CDATA\[/, "", rest)
+                if (rest ~ /\]\]><\/failure>/) {
+                  sub(/\]\]><\/failure>.*$/, "", rest)
+                  print rest > body
+                  close(body)
+                  body = ""
+                } else if (rest != "") {
+                  print rest > body
+                }
+                cur = ""
+                next
+              }
               /<\/testcase>/ { cur = "" }
             ' "$x" >> /tmp/failed.list
           done
@@ -1860,6 +1893,88 @@ jobs:
           fi
           [ "$rc" -eq 0 ] && echo "completed with no failures."
           exit $rc
+
+      # Its own step, so it gets its own 1 MiB summary budget: when the logs are
+      # too big, the upload GitHub drops is this one and the verdict above stays.
+      - name: The log of each failed case
+        if: always()
+        env:
+          FAILED_N: ${{ steps.failures.outputs.n }}
+        run: |
+          set -eo pipefail
+          [ "${FAILED_N:-0}" -gt 0 ] || exit 0
+
+          # Same 50 the table above lists. Sharing the budget out over them lets a
+          # run with one failure show that log whole, which is the common case.
+          shown=$FAILED_N
+          [ "$shown" -gt 50 ] && shown=50
+          budget=900000
+          case_max=$((budget / shown))
+          [ "$case_max" -gt 131072 ] && case_max=131072
+          head_b=$((case_max / 2))
+          tail_b=$((case_max - head_b))
+          echo "cases $FAILED_N / shown $shown / per case $case_max bytes"
+
+          # The 1 MiB is counted after escaping, so escape before measuring.
+          esc() { sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' "$1"; }
+
+          base="$ARTIFACT_URL_BASE/${RUNDIR#$CI_ROOT/}"
+          {
+            echo "### The log of each failed case"
+            echo
+            echo "What CTP wrote in the case's \`<failure>\`, trimmed to fit. Untrimmed, it is in the shard's \`test-shell.xml\`."
+            echo
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          used=0
+          i=0
+          left=0
+          while IFS=$'\t' read -r shard name; do
+            i=$((i + 1))
+            [ "$i" -le "$shown" ] || { left=$((left + 1)); continue; }
+            log="/tmp/failed-logs/$i.log"
+            {
+              echo "<details>"
+              echo "<summary>shard $shard &middot; <code>$name</code> &middot; <a href=\"$base/results/$shard/test-shell.xml\">full log</a></summary>"
+              echo
+              # <pre> opens its own line: a blank line inside the log would end the
+              # HTML block that <details> opened, and the rest would render as text.
+              echo "<pre>"
+            } > /tmp/block
+            if [ ! -f "$log" ]; then
+              echo "(this case left no log in the XML)" >> /tmp/block
+            else
+              raw=$(wc -c < "$log")
+              if [ "$raw" -le "$case_max" ]; then
+                esc "$log" >> /tmp/block
+              else
+                # sed drops the line the byte cut split, so <pre> holds whole lines.
+                head -c "$head_b" "$log" | sed '$d' > /tmp/piece
+                esc /tmp/piece >> /tmp/block
+                printf '\n... %d KB of the middle is not here ...\n\n' $(((raw - head_b - tail_b) / 1024)) >> /tmp/block
+                tail -c "$tail_b" "$log" | sed '1d' > /tmp/piece
+                esc /tmp/piece >> /tmp/block
+              fi
+            fi
+            {
+              echo "</pre>"
+              echo
+              echo "</details>"
+              echo
+            } >> /tmp/block
+            size=$(wc -c < /tmp/block)
+            if [ $((used + size)) -gt "$budget" ]; then
+              left=$((left + 1))
+              continue
+            fi
+            cat /tmp/block >> "$GITHUB_STEP_SUMMARY"
+            used=$((used + size))
+          done < /tmp/failed.list
+
+          if [ "$left" -gt 0 ]; then
+            echo "_$left more cases failed. Their logs are in each shard's \`test-shell.xml\`, under [Artifacts]($base/)._" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo "wrote $((i - left)) of $i case logs, $used bytes"
 
       # 59MB per run, nothing worth keeping, and the cleanup CronJob does not see it.
       #

--- a/.github/workflows/gha-ci.yml
+++ b/.github/workflows/gha-ci.yml
@@ -1909,13 +1909,14 @@ jobs:
           shown=$FAILED_N
           [ "$shown" -gt 50 ] && shown=50
           budget=900000
-          case_max=$((budget / shown))
+          # 512 for the <details> wrapper of each case, so that the cases which
+          # all reach their share still add up to less than the budget.
+          case_max=$((budget / shown - 512))
           [ "$case_max" -gt 131072 ] && case_max=131072
           head_b=$((case_max / 2))
           tail_b=$((case_max - head_b))
           echo "cases $FAILED_N / shown $shown / per case $case_max bytes"
 
-          # The 1 MiB is counted after escaping, so escape before measuring.
           esc() { sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' "$1"; }
 
           base="$ARTIFACT_URL_BASE/${RUNDIR#$CI_ROOT/}"
@@ -1944,16 +1945,18 @@ jobs:
             if [ ! -f "$log" ]; then
               echo "(this case left no log in the XML)" >> /tmp/block
             else
-              raw=$(wc -c < "$log")
-              if [ "$raw" -le "$case_max" ]; then
-                esc "$log" >> /tmp/block
+              # The 1 MiB is counted after escaping, so cut the escaped log, not
+              # the log: a share measured before escaping is not the share spent.
+              esc "$log" > /tmp/esc
+              sz=$(wc -c < /tmp/esc)
+              if [ "$sz" -le "$case_max" ]; then
+                cat /tmp/esc >> /tmp/block
               else
-                # sed drops the line the byte cut split, so <pre> holds whole lines.
-                head -c "$head_b" "$log" | sed '$d' > /tmp/piece
-                esc /tmp/piece >> /tmp/block
-                printf '\n... %d KB of the middle is not here ...\n\n' $(((raw - head_b - tail_b) / 1024)) >> /tmp/block
-                tail -c "$tail_b" "$log" | sed '1d' > /tmp/piece
-                esc /tmp/piece >> /tmp/block
+                # sed drops the line the byte cut split, so <pre> holds whole
+                # lines and no entity is left half written.
+                head -c "$head_b" /tmp/esc | sed '$d' >> /tmp/block
+                printf '\n... %d KB of the middle is not here ...\n\n' $(((sz - head_b - tail_b) / 1024)) >> /tmp/block
+                tail -c "$tail_b" /tmp/esc | sed '1d' >> /tmp/block
               fi
             fi
             {


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBRIDQA-1501>

### Purpose

gha-ci의 run summary는 실패한 케이스의 **이름만** 보여준다. 그 케이스가 왜 깨졌는지는 summary에 없다. 원인을 보려면 shard의 `test-shell.xml`을 따로 열어야 한다.

CircleCI의 job 화면은 다르다. `Tests` 탭이 실패한 테스트의 수행 로그를 같이 보여준다. 이관 뒤에도 같은 것을 보게 만든다.

CTP는 실패 케이스마다 `<failure>` 하나를 남긴다. 그 본문(CDATA)이 그 케이스의 수행 로그 전문이다 — `EnvIdentify`, 하위 케이스별 `OK`/`NOK`, `diff ... failed`와 그 diff, 그 뒤 셸 추적 전문. CircleCI `Tests` 탭이 보여주는 것도 이것이다.

### Implementation

`collect` job에 실패 케이스의 수행 로그를 summary로 내는 경로를 더했다.

**1. 실패 목록 step이 로그 본문도 뽑는다.** `Failure list, from CTP JUnit XML`의 awk가 `<failure>` 본문을 케이스별 파일로 저장한다. `failed.list`의 k번째 줄이 `/tmp/failed-logs/k.log`다. `failed.list` 자체의 형식은 그대로다 — `rerun_from`이 이 파일을 읽는다.

같은 awk에서 본문을 읽는 규칙을 맨 앞으로 옮겼다. CTP 로그에는 `<testcase`나 `<failure` 같은 문자열이 들어올 수 있다. 셸 추적이 그 문자열을 출력하는 케이스가 있다. 본문을 읽는 중에 다른 규칙이 걸리면 케이스 이름 추출이 어긋난다.

**2. 로그를 별도 step으로 summary에 쓴다.** step 이름은 `The log of each failed case`다. 케이스마다 접힌 `<details>` 하나를 쓴다. 요약 줄은 shard 번호·케이스 경로·그 shard의 `test-shell.xml` 링크다. 펼치면 수행 로그가 나온다.

`$GITHUB_STEP_SUMMARY`는 **step당 1 MiB**다. 넘으면 잘리는 것이 아니라 그 step의 summary 업로드가 통째로 실패한다. 그래서 둘을 뒀다.

- **별도 step이다.** 로그가 넘쳐 이 step의 업로드가 실패해도 위쪽 Verdict step의 summary는 남는다 — Coverage·provenance·벽시계·실패 케이스 표.
- **예산을 나눈다.** 표와 같은 50건까지 쓴다. 900 KB를 그 건수로 나눠 케이스당 상한을 잡고, 케이스당 최대는 128 KB다. 상한을 넘는 로그는 앞 절반과 뒤 절반만 쓰고 가운데를 `... N KB of the middle is not here ...`로 접는다. 실패가 1건이면 그 로그는 통째로 보인다.
- 넘어간 케이스는 마지막 한 줄로 알린다. 전문은 shard의 `test-shell.xml`에 있고 링크는 Artifacts다.

**바뀐 동작**: 실패가 있는 run의 summary 맨 아래에 `The log of each failed case`가 붙는다. 실패가 없으면 아무것도 붙지 않는다. 기존 `Failed cases` 표와 Verdict summary는 손대지 않았다. `plan`의 summary도 손대지 않았다.

### Remarks

- 실물 run의 산출물을 받아 로컬에서 두 step을 그대로 돌려 확인했다.
  - 실패 64건 run [33828030783](https://github.com/CUBRID/cubrid/actions/runs/33828030783): 50건 게시, summary 873 KB = 1 MiB의 83%. 남은 14건은 링크 한 줄.
  - 실패 1건 run [33834718548](https://github.com/CUBRID/cubrid/actions/runs/33834718548): 로그 15 KB 전문 게시, summary 16 KB.
  - 표본 64건의 로그는 건당 8 KB ~ 750 KB이고 합이 5.1 MB다. 상한 없이 넣으면 1 MiB를 넘긴다.
- 로그의 `&`·`<`·`>`는 HTML 엔티티로 바꾼다. 1 MiB 예산은 이스케이프 뒤 크기로 센다. 실측 팽창률은 0.4%, 최악 2.3%였다.
- `<pre>`는 `<details>`와 **다른 줄**에서 연다. 같은 줄이면 로그 안 빈 줄에서 HTML 블록이 끊겨 뒤가 본문 텍스트로 렌더된다. 산출 Markdown을 GitHub Markdown API로 렌더해 확인했다 — 로그가 `<pre>` 안에 그대로 남고 빈 줄도 유지된다.
- 산출물 링크는 사내망 전용이다. #7872가 띄운 서버와 같다.
- run 디렉토리 안 배치를 바꾸는 후속 작업이 이 step의 `results/<shard>/` 경로를 옮긴다. 그 작업이 이 PR 뒤에 rebase한다.
