### PR TITLE
[CBRD-27392] Fix mishandled error paths in parallel hash join workers

### DIFF
--- a/src/query/parallel/px_hash_join/px_hash_join_task_manager.cpp
+++ b/src/query/parallel/px_hash_join/px_hash_join_task_manager.cpp
@@ -355,16 +355,23 @@ namespace parallel_query
 
 		  if (qfile_reopen_list_as_append_mode (&thread_ref, part_list_id[part_id]) != NO_ERROR)
 		    {
+		      assert_release_error (er_errid () != NO_ERROR);
+		      m_task_manager.handle_error (thread_ref);
+		      has_error = true;
 		      break;		/* error_exit */
 		    }
 
 		  error = qfile_add_tuple_to_list (&thread_ref, part_list_id[part_id], tuple_record.tpl);
-		  if (error != NO_ERROR)
-		    {
-		      break;		/* error_exit */
-		    }
 
 		  qfile_close_list (&thread_ref, part_list_id[part_id]);
+
+		  if (error != NO_ERROR)
+		    {
+		      assert_release_error (er_errid () != NO_ERROR);
+		      m_task_manager.handle_error (thread_ref);
+		      has_error = true;
+		      break;		/* error_exit */
+		    }
 
 		  /* next page */
 		  break;
@@ -1138,6 +1145,11 @@ cleanup:
 		}
 	      while (true);
 
+	      if (has_error)
+		{
+		  break;
+		}
+
 	      if (error != NO_ERROR)
 		{
 		  assert_release_error (er_errid () != NO_ERROR);
@@ -1513,6 +1525,11 @@ cleanup:
 		    }
 		}
 	      while (true);
+
+	      if (has_error)
+		{
+		  break;
+		}
 
 	      if (error != NO_ERROR)
 		{

--- a/src/query/parallel/px_hash_join/px_hash_join_task_manager.cpp
+++ b/src/query/parallel/px_hash_join/px_hash_join_task_manager.cpp
@@ -367,9 +367,7 @@ namespace parallel_query
 		      assert_release_error (er_errid () != NO_ERROR);
 		      m_task_manager.handle_error (thread_ref);
 		      has_error = true;
-
 		      qfile_close_list (&thread_ref, part_list_id[part_id]);
-
 		      break;		/* error_exit */
 		    }
 

--- a/src/query/parallel/px_hash_join/px_hash_join_task_manager.cpp
+++ b/src/query/parallel/px_hash_join/px_hash_join_task_manager.cpp
@@ -362,16 +362,18 @@ namespace parallel_query
 		    }
 
 		  error = qfile_add_tuple_to_list (&thread_ref, part_list_id[part_id], tuple_record.tpl);
-
-		  qfile_close_list (&thread_ref, part_list_id[part_id]);
-
 		  if (error != NO_ERROR)
 		    {
 		      assert_release_error (er_errid () != NO_ERROR);
 		      m_task_manager.handle_error (thread_ref);
 		      has_error = true;
+
+		      qfile_close_list (&thread_ref, part_list_id[part_id]);
+
 		      break;		/* error_exit */
 		    }
+
+		  qfile_close_list (&thread_ref, part_list_id[part_id]);
 
 		  /* next page */
 		  break;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27392

### Purpose

분할 태스크의 오버플로 append 실패와 프로브 워커 매치 루프의 술어 에러가 태스크를 즉시 중단시키지 못해, 행 누락이나 디버그 빌드 크래시로 이어진다. 두 경로 모두 에러 발생 즉시 중단하도록 고친다.

### Implementation

- 분할 태스크의 오버플로 append 실패(재오픈/튜플 추가) 경로에 `handle_error` + `has_error` 적용 -- 추가 실패 시에는 append 모드를 `qfile_close_list` 로 닫은 뒤 중단
- 프로브 워커 매치 루프 직후 `if (has_error) break;` 추가 (execute_inner, execute_outer 각 1곳)

### Remarks

- 오버플로 append 실패 경로(결함 1)는 자연 재현이 안 돼 코드 읽기 근거로 고쳤다 -- 이 부분은 회귀 테스트가 없다. 매치 루프 쪽(결함 2)은 optdebug before/after 로 재현·검증됨.
