### PR TITLE
[CBRD-26354] Bound the LIMIT NL join card by the LIMIT and apply filters to the hit_prob NDV

### DIFF
--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -3516,9 +3516,10 @@ qo_nljoin_cost (QO_PLAN * planp)
 	{
 	  guessed_result_cardinality = outer->limit_nljoin_guessed_card;
 	  outer_card = ((outer->info)->cardinality == 0) ? 1 : (outer->info)->cardinality;
-	  /* result = outer_guessed * (inner_card * selectivity) = outer_guessed * (plan_card/outer_card). */
+	  /* result = outer_guessed * (inner_card * selectivity) = outer_guessed * (plan_card/outer_card),
+	   * and never more than the LIMIT since the query stops there. */
 	  planp->limit_nljoin_guessed_card =
-	    MAX (1.0, guessed_result_cardinality * ((planp->info)->cardinality / outer_card));
+	    MAX (1.0, MIN (limit_val, guessed_result_cardinality * ((planp->info)->cardinality / outer_card)));
 	}
       else
 	{

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -3462,7 +3462,7 @@ qo_nljoin_cost (QO_PLAN * planp)
 {
   QO_PLAN *inner, *outer;
   double inner_io_cost, inner_cpu_cost, outer_io_cost, outer_cpu_cost;
-  double guessed_result_cardinality, limit_val, outer_card;
+  double guessed_result_cardinality, limit_val, outer_card, required_card;
 
   inner = planp->plan_un.join.inner;
 
@@ -3502,8 +3502,15 @@ qo_nljoin_cost (QO_PLAN * planp)
 
       if (outer->plan_type == QO_PLANTYPE_SCAN)
 	{
-	  planp->limit_nljoin_guessed_card = MAX (limit_val / (outer->info)->hit_prob, 1.0);
-	  guessed_result_cardinality = MIN (planp->limit_nljoin_guessed_card, (outer->info)->cardinality);
+	  /* outer rows required to satisfy the LIMIT; the outer scan cannot read more rows than it has */
+	  required_card = MAX (limit_val / (outer->info)->hit_prob, 1.0);
+	  guessed_result_cardinality = MIN (required_card, (outer->info)->cardinality);
+	  /* rows this join emits (shown as card, handed to the next join level): the query stops at the
+	   * LIMIT, and when the outer is exhausted first it is what the rows read actually produce
+	   * (rows read * plan_card/outer_card). */
+	  outer_card = ((outer->info)->cardinality == 0) ? 1 : (outer->info)->cardinality;
+	  planp->limit_nljoin_guessed_card =
+	    MAX (1.0, MIN (limit_val, guessed_result_cardinality * ((planp->info)->cardinality / outer_card)));
 	}
       else if (outer->plan_type == QO_PLANTYPE_JOIN)
 	{

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -221,6 +221,8 @@ static void qo_dump_planvec (QO_PLANVEC *, FILE *, int);
 static void qo_dump_info (QO_INFO *, FILE *);
 static void qo_dump_planner_info (QO_PLANNER *, QO_PARTITION *, FILE *);
 
+static void qo_get_term_hit_prob (QO_TERM * term, QO_INFO * head_info, QO_INFO * tail_info, QO_ENV * env,
+				  double *out_head_factor, double *out_tail_factor);
 static void planner_visit_node (QO_PLANNER *, QO_PARTITION *, PT_HINT_ENUM, QO_NODE *, QO_NODE *, BITSET *, BITSET *,
 				BITSET *, BITSET *, BITSET *, BITSET *, BITSET *, int);
 static double planner_nodeset_join_cost (QO_PLANNER *, BITSET *);
@@ -1464,9 +1466,9 @@ qo_plan_print_costs (QO_PLAN * plan, FILE * f, int howfar)
   fprintf (f, "\n" INDENTED_TITLE_FMT "%.0f card %.0f", (int) howfar, ' ', "cost:", fixed + variable, card);
 
 #if TEST_DUMP_PLAN_SCAN_COST
-  fprintf (f, "\n" INDENTED_TITLE_FMT "%.0f expected %.0f scan %.0f total %.0f group %.0f", (int) howfar, ' ',
-	   "cost:", fixed + variable, (plan->info)->cardinality, (plan->info)->scan_rows, (plan->info)->total_rows,
-	   (plan->info)->group_rows);
+  fprintf (f, "\n" INDENTED_TITLE_FMT "%.0f expected %.0f scan %.0f total %.0f group %.0f hit_prob %.5f", (int) howfar,
+	   ' ', "cost:", fixed + variable, (plan->info)->cardinality, (plan->info)->scan_rows, (plan->info)->total_rows,
+	   (plan->info)->group_rows, (plan->info)->hit_prob);
 #endif /* TEST_DUMP_PLAN_SCAN_COST */
 }
 
@@ -3460,7 +3462,7 @@ qo_nljoin_cost (QO_PLAN * planp)
 {
   QO_PLAN *inner, *outer;
   double inner_io_cost, inner_cpu_cost, outer_io_cost, outer_cpu_cost;
-  double guessed_result_cardinality, limit_val, outer_card, required_card, fanout;
+  double guessed_result_cardinality, limit_val, outer_card, required_card;
 
   inner = planp->plan_un.join.inner;
 
@@ -3500,17 +3502,13 @@ qo_nljoin_cost (QO_PLAN * planp)
 
       if (outer->plan_type == QO_PLANTYPE_SCAN)
 	{
-	  /* rows this join emits per outer row (join selectivity and inner filters included). Capped at 1:
-	   * several matches per outer row never justify reading fewer than LIMIT outer rows, while fewer
-	   * matches per outer row mean more outer rows must be read. */
-	  outer_card = ((outer->info)->cardinality == 0) ? 1 : (outer->info)->cardinality;
-	  fanout = (planp->info)->cardinality / outer_card;
-	  fanout = (fanout > 0.0) ? MIN (1.0, fanout) : 1.0;
 	  /* outer rows required to satisfy the LIMIT; the outer scan cannot read more rows than it has */
-	  required_card = MAX (limit_val / fanout, 1.0);
+	  required_card = MAX (limit_val / (outer->info)->hit_prob, 1.0);
 	  guessed_result_cardinality = MIN (required_card, (outer->info)->cardinality);
 	  /* rows this join emits (shown as card, handed to the next join level): the query stops at the
-	   * LIMIT, and when the outer is exhausted first it is what the rows read actually produce. */
+	   * LIMIT, and when the outer is exhausted first it is what the rows read actually produce
+	   * (rows read * plan_card/outer_card). */
+	  outer_card = ((outer->info)->cardinality == 0) ? 1 : (outer->info)->cardinality;
 	  planp->limit_nljoin_guessed_card =
 	    MAX (1.0, MIN (limit_val, guessed_result_cardinality * ((planp->info)->cardinality / outer_card)));
 	}
@@ -5940,6 +5938,7 @@ qo_alloc_info (QO_PLANNER * planner, BITSET * nodes, BITSET * terms, BITSET * eq
   info->scan_rows = cardinality;	/* after iscan_cost, sscan_cost. it'll be replaced accurately */
   info->total_rows = total_rows;
   info->group_rows = cardinality;	/* it is recalculated in qo_sort_new() */
+  info->hit_prob = 1.0;
 
   qo_init_planvec (&info->best_no_order);
 
@@ -7414,6 +7413,90 @@ qo_dump_planner_info (QO_PLANNER * planner, QO_PARTITION * partition, FILE * f)
  *   remaining_subqueries(in):
  *   num_path_inner(in):
  */
+/*
+ * qo_get_term_hit_prob () -
+ *
+ * hit_prob = min(1, ndv(tail after its filters) / ndv(head))
+ *
+ * The NDV of a side's join key is reduced by that side's own
+ * search conditions with qo_estimate_ndv (), the same estimate
+ * GROUP BY uses for the number of groups after filtering.
+ */
+static void
+qo_get_term_hit_prob (QO_TERM * term, QO_INFO * head_info, QO_INFO * tail_info, QO_ENV * env,
+		      double *out_head_factor, double *out_tail_factor)
+{
+  const BITSET *term_segs = (const BITSET *) &(term->segments);
+  BITSET_ITERATOR seg_iter;
+  int seg_idx;
+  QO_SEGMENT *head_seg = NULL, *tail_seg = NULL;
+  INT64 head_ndv = 1, tail_ndv = 1;
+  double head_ndv_eff, tail_ndv_eff;
+
+  *out_head_factor = 1.0;
+  *out_tail_factor = 1.0;
+  if (bitset_cardinality (term_segs) != 2)
+    {
+      return;
+    }
+
+  for (seg_idx = bitset_iterate (term_segs, &seg_iter); seg_idx != -1; seg_idx = bitset_next_member (&seg_iter))
+    {
+      QO_SEGMENT *seg = QO_ENV_SEG (env, seg_idx);
+      QO_NODE *node = QO_SEG_HEAD (seg);
+      int node_idx = QO_NODE_IDX (node);
+
+      if (BITSET_MEMBER (head_info->nodes, node_idx))
+	{
+	  head_seg = seg;
+	}
+      else if (BITSET_MEMBER (tail_info->nodes, node_idx))
+	{
+	  tail_seg = seg;
+	}
+    }
+  if (head_seg == NULL || tail_seg == NULL)
+    {
+      return;
+    }
+
+  if (QO_SEG_INFO (head_seg) != NULL && QO_SEG_INFO (head_seg)->ndv > 0)
+    {
+      head_ndv = QO_SEG_INFO (head_seg)->ndv;
+    }
+  else
+    {
+      return;
+    }
+
+  if (QO_SEG_INFO (tail_seg) != NULL && QO_SEG_INFO (tail_seg)->ndv > 0)
+    {
+      tail_ndv = QO_SEG_INFO (tail_seg)->ndv;
+    }
+  else
+    {
+      return;
+    }
+
+  /* Distinct join-key values that survive each side's own search conditions: the NDV shrinks the way
+   * qo_estimate_ndv () models it for GROUP BY, and stays as is when there is no filter
+   * (cardinality == total_rows). The denominator keeps the full NDV: it is the domain the outer
+   * row's value is drawn from. */
+  head_ndv_eff = qo_estimate_ndv (head_info->total_rows, head_info->cardinality, (double) head_ndv);
+  tail_ndv_eff = qo_estimate_ndv (tail_info->total_rows, tail_info->cardinality, (double) tail_ndv);
+  if (head_ndv_eff <= 0.0)
+    {
+      head_ndv_eff = (double) head_ndv;
+    }
+  if (tail_ndv_eff <= 0.0)
+    {
+      tail_ndv_eff = (double) tail_ndv;
+    }
+
+  *out_head_factor = MIN (1.0, tail_ndv_eff / (double) head_ndv);
+  *out_tail_factor = MIN (1.0, head_ndv_eff / (double) tail_ndv);
+}
+
 static void
 planner_visit_node (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM hint, QO_NODE * head_node,
 		    QO_NODE * tail_node, BITSET * visited_nodes, BITSET * visited_rel_nodes, BITSET * visited_terms,
@@ -7948,7 +8031,7 @@ planner_visit_node (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM
   if (new_info == NULL)
     {
 
-      double selectivity, cardinality, total_rows;
+      double selectivity, cardinality, total_rows, head_hit_prob, tail_hit_prob;
       BITSET eqclasses;
 
       bitset_init (&eqclasses, planner->env);
@@ -7958,6 +8041,8 @@ planner_visit_node (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM
 
       cardinality = head_info->cardinality * tail_info->cardinality;
       total_rows = head_info->total_rows * tail_info->total_rows;
+      head_hit_prob = 1.0;
+      tail_hit_prob = 1.0;
       if (IS_OUTER_JOIN_TYPE (join_type))
 	{
 	  /* set lower bound of outer join result */
@@ -7994,8 +8079,14 @@ planner_visit_node (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM
 		   * conditional share qo_derived_term_compensate () left it with. */
 		  if (!QO_TERM_IS_FLAGED (term, QO_TERM_LIKE_DERIVED_RANGE | QO_TERM_OR_DERIVED))
 		    {
+		      double head_factor, tail_factor;
+
 		      selectivity *= QO_TERM_SELECTIVITY (term);
 		      selectivity = MAX (1.0 / MAX (cardinality, 1.0), selectivity);
+
+		      qo_get_term_hit_prob (term, head_info, tail_info, planner->env, &head_factor, &tail_factor);
+		      head_hit_prob *= head_factor;
+		      tail_hit_prob *= tail_factor;
 		    }
 		}
 	    }
@@ -8020,6 +8111,21 @@ planner_visit_node (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM
 
       bitset_assign (&eqclasses, &(head_info->eqclasses));
       bitset_union (&eqclasses, &(tail_info->eqclasses));
+
+      head_info->hit_prob = head_hit_prob;
+      tail_info->hit_prob = tail_hit_prob;
+      if (IS_OUTER_JOIN_TYPE (join_type))
+	{
+	  /* set lower bound of outer join result */
+	  if (join_type == JOIN_RIGHT)
+	    {
+	      tail_info->hit_prob = 1.0;
+	    }
+	  else
+	    {
+	      head_info->hit_prob = 1.0;
+	    }
+	}
 
       new_info = planner->join_info[QO_INFO_INDEX (QO_PARTITION_M_OFFSET (partition), *visited_rel_nodes)] =
 	qo_alloc_info (planner, visited_nodes, visited_terms, &eqclasses, cardinality, total_rows);

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -221,8 +221,6 @@ static void qo_dump_planvec (QO_PLANVEC *, FILE *, int);
 static void qo_dump_info (QO_INFO *, FILE *);
 static void qo_dump_planner_info (QO_PLANNER *, QO_PARTITION *, FILE *);
 
-static void qo_get_term_hit_prob (QO_TERM * term, QO_INFO * head_info, QO_INFO * tail_info, QO_ENV * env,
-				  double *out_head_factor, double *out_tail_factor);
 static void planner_visit_node (QO_PLANNER *, QO_PARTITION *, PT_HINT_ENUM, QO_NODE *, QO_NODE *, BITSET *, BITSET *,
 				BITSET *, BITSET *, BITSET *, BITSET *, BITSET *, int);
 static double planner_nodeset_join_cost (QO_PLANNER *, BITSET *);
@@ -1466,9 +1464,9 @@ qo_plan_print_costs (QO_PLAN * plan, FILE * f, int howfar)
   fprintf (f, "\n" INDENTED_TITLE_FMT "%.0f card %.0f", (int) howfar, ' ', "cost:", fixed + variable, card);
 
 #if TEST_DUMP_PLAN_SCAN_COST
-  fprintf (f, "\n" INDENTED_TITLE_FMT "%.0f expected %.0f scan %.0f total %.0f group %.0f hit_prob %.5f", (int) howfar,
-	   ' ', "cost:", fixed + variable, (plan->info)->cardinality, (plan->info)->scan_rows, (plan->info)->total_rows,
-	   (plan->info)->group_rows, (plan->info)->hit_prob);
+  fprintf (f, "\n" INDENTED_TITLE_FMT "%.0f expected %.0f scan %.0f total %.0f group %.0f", (int) howfar, ' ',
+	   "cost:", fixed + variable, (plan->info)->cardinality, (plan->info)->scan_rows, (plan->info)->total_rows,
+	   (plan->info)->group_rows);
 #endif /* TEST_DUMP_PLAN_SCAN_COST */
 }
 
@@ -3462,7 +3460,7 @@ qo_nljoin_cost (QO_PLAN * planp)
 {
   QO_PLAN *inner, *outer;
   double inner_io_cost, inner_cpu_cost, outer_io_cost, outer_cpu_cost;
-  double guessed_result_cardinality, limit_val, outer_card, required_card;
+  double guessed_result_cardinality, limit_val, outer_card, required_card, fanout;
 
   inner = planp->plan_un.join.inner;
 
@@ -3502,13 +3500,17 @@ qo_nljoin_cost (QO_PLAN * planp)
 
       if (outer->plan_type == QO_PLANTYPE_SCAN)
 	{
+	  /* rows this join emits per outer row (join selectivity and inner filters included). Capped at 1:
+	   * several matches per outer row never justify reading fewer than LIMIT outer rows, while fewer
+	   * matches per outer row mean more outer rows must be read. */
+	  outer_card = ((outer->info)->cardinality == 0) ? 1 : (outer->info)->cardinality;
+	  fanout = (planp->info)->cardinality / outer_card;
+	  fanout = (fanout > 0.0) ? MIN (1.0, fanout) : 1.0;
 	  /* outer rows required to satisfy the LIMIT; the outer scan cannot read more rows than it has */
-	  required_card = MAX (limit_val / (outer->info)->hit_prob, 1.0);
+	  required_card = MAX (limit_val / fanout, 1.0);
 	  guessed_result_cardinality = MIN (required_card, (outer->info)->cardinality);
 	  /* rows this join emits (shown as card, handed to the next join level): the query stops at the
-	   * LIMIT, and when the outer is exhausted first it is what the rows read actually produce
-	   * (rows read * plan_card/outer_card). */
-	  outer_card = ((outer->info)->cardinality == 0) ? 1 : (outer->info)->cardinality;
+	   * LIMIT, and when the outer is exhausted first it is what the rows read actually produce. */
 	  planp->limit_nljoin_guessed_card =
 	    MAX (1.0, MIN (limit_val, guessed_result_cardinality * ((planp->info)->cardinality / outer_card)));
 	}
@@ -5938,7 +5940,6 @@ qo_alloc_info (QO_PLANNER * planner, BITSET * nodes, BITSET * terms, BITSET * eq
   info->scan_rows = cardinality;	/* after iscan_cost, sscan_cost. it'll be replaced accurately */
   info->total_rows = total_rows;
   info->group_rows = cardinality;	/* it is recalculated in qo_sort_new() */
-  info->hit_prob = 1.0;
 
   qo_init_planvec (&info->best_no_order);
 
@@ -7413,74 +7414,6 @@ qo_dump_planner_info (QO_PLANNER * planner, QO_PARTITION * partition, FILE * f)
  *   remaining_subqueries(in):
  *   num_path_inner(in):
  */
-/*
- * qo_get_term_hit_prob () -
- *
- * hit_prob = min(1, ndv(tail) / ndv(head))
- *
- * Although filters may reduce data, NDV cannot be adjusted
- * accurately. To avoid biased estimation, we conservatively
- * assume the original NDV relationship is maintained.
- */
-static void
-qo_get_term_hit_prob (QO_TERM * term, QO_INFO * head_info, QO_INFO * tail_info, QO_ENV * env,
-		      double *out_head_factor, double *out_tail_factor)
-{
-  const BITSET *term_segs = (const BITSET *) &(term->segments);
-  BITSET_ITERATOR seg_iter;
-  int seg_idx;
-  QO_SEGMENT *head_seg = NULL, *tail_seg = NULL;
-  INT64 head_ndv = 1, tail_ndv = 1;
-
-  *out_head_factor = 1.0;
-  *out_tail_factor = 1.0;
-  if (bitset_cardinality (term_segs) != 2)
-    {
-      return;
-    }
-
-  for (seg_idx = bitset_iterate (term_segs, &seg_iter); seg_idx != -1; seg_idx = bitset_next_member (&seg_iter))
-    {
-      QO_SEGMENT *seg = QO_ENV_SEG (env, seg_idx);
-      QO_NODE *node = QO_SEG_HEAD (seg);
-      int node_idx = QO_NODE_IDX (node);
-
-      if (BITSET_MEMBER (head_info->nodes, node_idx))
-	{
-	  head_seg = seg;
-	}
-      else if (BITSET_MEMBER (tail_info->nodes, node_idx))
-	{
-	  tail_seg = seg;
-	}
-    }
-  if (head_seg == NULL || tail_seg == NULL)
-    {
-      return;
-    }
-
-  if (QO_SEG_INFO (head_seg) != NULL && QO_SEG_INFO (head_seg)->ndv > 0)
-    {
-      head_ndv = QO_SEG_INFO (head_seg)->ndv;
-    }
-  else
-    {
-      return;
-    }
-
-  if (QO_SEG_INFO (tail_seg) != NULL && QO_SEG_INFO (tail_seg)->ndv > 0)
-    {
-      tail_ndv = QO_SEG_INFO (tail_seg)->ndv;
-    }
-  else
-    {
-      return;
-    }
-
-  *out_head_factor = MIN (1.0, (double) tail_ndv / (double) head_ndv);
-  *out_tail_factor = MIN (1.0, (double) head_ndv / (double) tail_ndv);
-}
-
 static void
 planner_visit_node (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM hint, QO_NODE * head_node,
 		    QO_NODE * tail_node, BITSET * visited_nodes, BITSET * visited_rel_nodes, BITSET * visited_terms,
@@ -8015,7 +7948,7 @@ planner_visit_node (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM
   if (new_info == NULL)
     {
 
-      double selectivity, cardinality, total_rows, head_hit_prob, tail_hit_prob;
+      double selectivity, cardinality, total_rows;
       BITSET eqclasses;
 
       bitset_init (&eqclasses, planner->env);
@@ -8025,8 +7958,6 @@ planner_visit_node (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM
 
       cardinality = head_info->cardinality * tail_info->cardinality;
       total_rows = head_info->total_rows * tail_info->total_rows;
-      head_hit_prob = 1.0;
-      tail_hit_prob = 1.0;
       if (IS_OUTER_JOIN_TYPE (join_type))
 	{
 	  /* set lower bound of outer join result */
@@ -8063,14 +7994,8 @@ planner_visit_node (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM
 		   * conditional share qo_derived_term_compensate () left it with. */
 		  if (!QO_TERM_IS_FLAGED (term, QO_TERM_LIKE_DERIVED_RANGE | QO_TERM_OR_DERIVED))
 		    {
-		      double head_factor, tail_factor;
-
 		      selectivity *= QO_TERM_SELECTIVITY (term);
 		      selectivity = MAX (1.0 / MAX (cardinality, 1.0), selectivity);
-
-		      qo_get_term_hit_prob (term, head_info, tail_info, planner->env, &head_factor, &tail_factor);
-		      head_hit_prob *= head_factor;
-		      tail_hit_prob *= tail_factor;
 		    }
 		}
 	    }
@@ -8095,21 +8020,6 @@ planner_visit_node (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM
 
       bitset_assign (&eqclasses, &(head_info->eqclasses));
       bitset_union (&eqclasses, &(tail_info->eqclasses));
-
-      head_info->hit_prob = head_hit_prob;
-      tail_info->hit_prob = tail_hit_prob;
-      if (IS_OUTER_JOIN_TYPE (join_type))
-	{
-	  /* set lower bound of outer join result */
-	  if (join_type == JOIN_RIGHT)
-	    {
-	      tail_info->hit_prob = 1.0;
-	    }
-	  else
-	    {
-	      head_info->hit_prob = 1.0;
-	    }
-	}
 
       new_info = planner->join_info[QO_INFO_INDEX (QO_PARTITION_M_OFFSET (partition), *visited_rel_nodes)] =
 	qo_alloc_info (planner, visited_nodes, visited_terms, &eqclasses, cardinality, total_rows);

--- a/src/optimizer/query_planner.h
+++ b/src/optimizer/query_planner.h
@@ -331,6 +331,7 @@ struct qo_info
   double scan_rows;		/* Number of rows required for scanning */
   double total_rows;		/* Number of rows excluding search conditions */
   double group_rows;		/* Number of rows expected after grouping */
+  double hit_prob;		/* Hit probability for NL join: B's hit_prob = NDV(B.key)/NDV(A.key); used like fanout in cost */
 
   /*
    * One plan for each equivalence class, in each case the best we have

--- a/src/optimizer/query_planner.h
+++ b/src/optimizer/query_planner.h
@@ -242,7 +242,8 @@ struct qo_plan
   bool use_iscan_descending;
   bool need_final_sort;
 
-  /* Guessed result cardinality for NL join when LIMIT is present (3+ tables); used for cost and dump */
+  /* Rows this NL join is expected to emit under LIMIT: the LIMIT itself, or fewer when the outer runs out
+   * first. Used as the next join level's driving row count and for the plan dump. */
   double limit_nljoin_guessed_card;
 };
 

--- a/src/optimizer/query_planner.h
+++ b/src/optimizer/query_planner.h
@@ -331,7 +331,6 @@ struct qo_info
   double scan_rows;		/* Number of rows required for scanning */
   double total_rows;		/* Number of rows excluding search conditions */
   double group_rows;		/* Number of rows expected after grouping */
-  double hit_prob;		/* Hit probability for NL join: B's hit_prob = NDV(B.key)/NDV(A.key); used like fanout in cost */
 
   /*
    * One plan for each equivalence class, in each case the best we have


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26354

## Purpose
CBRD-26354(#6818)의 LIMIT 기반 NL 조인 추정에서 리뷰로 드러난 두 가지 불일치를 바로잡습니다.

1. **card가 LIMIT을 넘게 표시됨.** 첫 조인의 `limit_nljoin_guessed_card`가 "outer에서 읽을 행수"(limit / hit_prob)였고 상한이 없어, LIMIT이 조인 결과보다 크면 card가 결과보다 크게 나오고(케이스 18: 200000, 결과 약 10만) 3테이블 이상에서는 그 값으로 다음 조인 비용이 과대 산정됐습니다. 상위 조인 분기도 LIMIT으로 자르지 않아 두 번째 조인의 fanout이 크면 card가 LIMIT을 넘었습니다(2200, 리뷰 지적 1).
2. **card가 LIMIT 아래로 떨어짐.** hit_prob는 조인 컬럼 NDV 비율만 보고 inner의 조회조건을 무시하는데, card(읽은 행수 × plan_card / outer_card)는 조회조건을 반영해서 두 값의 전제가 달랐습니다. inner에 선택적 필터가 있으면 card 1(실제 11)이 나오고, outer 스캔 비용도 필요한 만큼 읽지 않는 것으로 계산됐습니다(리뷰 지적 2).

## Implementation
`query_planner.c`:
- **card(필드)** `qo_nljoin_cost()`: `MAX(1, MIN(limit_val, 읽은 outer 행수 × plan_card / outer_card))`. "이 조인이 내는 행수"이며 LIMIT에서 멈추고, outer를 다 읽어도 못 채우면 실제 산출입니다. outer가 JOIN인 분기도 같은 LIMIT 상한을 적용해 모든 단계에서 card ≤ LIMIT입니다. 읽을 outer 행수(limit / hit_prob)와 outer 스캔 비용 계산 구조는 기존과 같습니다.
- **hit_prob에 조회조건 반영** `qo_get_term_hit_prob()`: 각 쪽 조인 컬럼 NDV를 그 쪽의 조회조건을 통과한 뒤 남는 값 개수로 바꿉니다. `qo_estimate_ndv(전체 행수, 조회조건 후 행수, NDV)`를 쓰며, 이 함수는 GROUP BY 그룹 수 추정(CBRD-26309)에 이미 같은 목적으로 쓰이는 것입니다. 조회조건이 없으면 NDV가 그대로라 기존 동작과 같고, 분모(outer NDV)는 값의 전체 영역이라 그대로 둡니다.

hit_prob의 항별 `MIN(1, NDV 비율)` 형태는 의도적으로 유지합니다. 검토 과정에서 조인 card 기반(plan_card / outer_card)으로 바꿔 보았으나, 같은 두 테이블에 조인 조건이 여러 개인 질의에서 독립 가정으로 곱한 선택도가 과소해져 LIMIT 효과가 사라지고 해시 조인으로 넘어가는 회귀(cbrd_24795)가 있어 되돌렸습니다. 항별 비율은 1:1 조인이면 항 수와 무관하게 1로 유지됩니다.

## Remarks
PR head 빌드로 SA 모드 실측(TC #3758 픽스처 t1 100,000행 / t2 500행, 리뷰 재현 테이블 f1/f2, cbrd_24795 테이블 tbla):

| 질의 | 이전 card | 이전 outer 읽기 | 수정 후 card | 수정 후 outer 읽기 |
|---|---|---|---|---|
| 케이스 1 `limit 10,1` | 11 | 11 | 11 | 11 |
| 케이스 4 3테이블 `limit 1000,1` | 1002 | - | 1001 | - |
| 케이스 16 hit_prob 0.2 | 55 | 55 | 11 | 55 |
| 케이스 18 `limit 200000` | 200000 | 500 | 99993 (조인 추정치) | 500 |
| 리뷰 재현 1: 3테이블 fanout 200 | 2200 | - | 11 | - |
| 리뷰 재현 2: inner 필터 (결과 20행, LIMIT 11) | 1 | 11 | 11 | 115 (실제 101) |
| cbrd_24795 8번: 조인 조건 3개, `limit 1` | 1, NL | 1 | 1, NL | 1 |

조회조건이 없는 조인은 읽을 행수와 비용이 바뀌지 않습니다. inner에 선택적 조회조건이 있는 LIMIT NL 질의는 더 많이 읽는 것으로 비용이 올라갑니다.

CTP: 첫 커밋 기준 `bug_bts_4670`(3-way join, 통계 없는 8행 테이블)의 조인 순서가 바뀌어 tc/pr-7892에 답지 재베이스라인(cubrid-testcases#3452). 최종 커밋에서도 같은 플랜·결과임을 확인했습니다.

영향받는 TC: cubrid-testcases-private-ex#3758 케이스 4(1002 → 1001), 5(2002 → 2001), 16(55 → 11), 18(200000 → 조인 추정치) 답지와 케이스 16·18 주석은 머지 후 수정이 필요합니다. JIRA 본문의 공식과 가정 1은 이 PR 내용으로 갱신했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
