### PR TITLE
[CBRD-27156] Read the object the caller asked the scanrange to start at

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -599,8 +599,10 @@ static int heap_get_last_page (THREAD_ENTRY * thread_p, const HFID * hfid, HEAP_
 			       HEAP_SCANCACHE * scan_cache, VPID * last_vpid, PGBUF_WATCHER * pg_watcher);
 
 static int heap_vpid_init_new (THREAD_ENTRY * thread_p, PAGE_PTR page, void *args);
+#if defined (ENABLE_UNUSED_FUNCTION)
 static int heap_vpid_alloc (THREAD_ENTRY * thread_p, const HFID * hfid, PAGE_PTR hdr_pgptr, HEAP_HDR_STATS * heap_hdr,
 			    HEAP_SCANCACHE * scan_cache, PGBUF_WATCHER * new_pg_watcher);
+#endif /* ENABLE_UNUSED_FUNCTION */
 static VPID *heap_vpid_remove (THREAD_ENTRY * thread_p, const HFID * hfid, HEAP_HDR_STATS * heap_hdr, VPID * rm_vpid);
 
 static void heap_bestspace_clear_candidates (cubstorage::bestspace_entry * candidates, std::size_t * num_candidates,
@@ -643,7 +645,9 @@ static OID *heap_ovf_insert (THREAD_ENTRY * thread_p, const HFID * hfid, OID * o
 static const OID *heap_ovf_update (THREAD_ENTRY * thread_p, const HFID * hfid, const OID * ovf_oid, RECDES * recdes,
 				   LOG_LSA * change_link_lsa);
 static int heap_ovf_flush (THREAD_ENTRY * thread_p, const OID * ovf_oid);
+#if defined (ENABLE_UNUSED_FUNCTION)
 static int heap_ovf_get_length (THREAD_ENTRY * thread_p, const OID * ovf_oid);
+#endif /* ENABLE_UNUSED_FUNCTION */
 static SCAN_CODE heap_ovf_get (THREAD_ENTRY * thread_p, const OID * ovf_oid, RECDES * recdes, int chn,
 			       MVCC_SNAPSHOT * mvcc_snapshot);
 static int heap_ovf_get_capacity (THREAD_ENTRY * thread_p, const OID * ovf_oid, int *ovf_len, int *ovf_num_pages,
@@ -760,8 +764,10 @@ static int heap_get_partitions_from_subclasses (THREAD_ENTRY * thread_p, const O
 						OR_PARTITION * partitions);
 static int heap_class_get_partition_info (THREAD_ENTRY * thread_p, const OID * class_oid, OR_PARTITION * partition_info,
 					  HFID * class_hfid, REPR_ID * repr_id, int *has_partition_info);
+#if defined (ENABLE_UNUSED_FUNCTION)
 static int heap_get_partition_attributes (THREAD_ENTRY * thread_p, const OID * cls_oid, ATTR_ID * type_id,
 					  ATTR_ID * values_id);
+#endif /* ENABLE_UNUSED_FUNCTION */
 static int heap_get_class_subclasses (THREAD_ENTRY * thread_p, const OID * class_oid, int *count, OID ** subclasses);
 
 static SCAN_CODE heap_get_record_info (THREAD_ENTRY * thread_p, const OID oid, RECDES * recdes, RECDES forward_recdes,
@@ -863,8 +869,10 @@ static void heap_page_update_chain_after_mvcc_op (THREAD_ENTRY * thread_p, PAGE_
 static void heap_page_rv_chain_update (THREAD_ENTRY * thread_p, PAGE_PTR heap_page, MVCCID mvccid,
 				       bool vacuum_status_change);
 
+#if defined (ENABLE_UNUSED_FUNCTION)
 static int heap_scancache_add_partition_node (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cache,
 					      OID * partition_oid);
+#endif /* ENABLE_UNUSED_FUNCTION */
 static SCAN_CODE heap_get_visible_version_from_log (THREAD_ENTRY * thread_p, RECDES * recdes,
 						    LOG_LSA * previous_version_lsa, HEAP_SCANCACHE * scan_cache,
 						    int has_chn);
@@ -877,8 +885,10 @@ static int heap_get_header_page (THREAD_ENTRY * thread_p, const HFID * hfid, VPI
 
 STATIC_INLINE HEAP_HDR_STATS *heap_get_header_stats_ptr (THREAD_ENTRY * thread_p, PAGE_PTR page_header)
   __attribute__ ((ALWAYS_INLINE));
+#if defined (ENABLE_UNUSED_FUNCTION)
 STATIC_INLINE int heap_copy_header_stats (THREAD_ENTRY * thread_p, PAGE_PTR page_header, HEAP_HDR_STATS * header_stats)
   __attribute__ ((ALWAYS_INLINE));
+#endif /* ENABLE_UNUSED_FUNCTION */
 STATIC_INLINE HEAP_CHAIN *heap_get_chain_ptr (THREAD_ENTRY * thread_p, PAGE_PTR page_heap)
   __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE int heap_copy_chain (THREAD_ENTRY * thread_p, PAGE_PTR page_heap, HEAP_CHAIN * chain)
@@ -2681,6 +2691,7 @@ heap_get_header_stats_ptr (THREAD_ENTRY * thread_p, PAGE_PTR page_header)
   return (HEAP_HDR_STATS *) recdes.data;
 }
 
+#if defined (ENABLE_UNUSED_FUNCTION)
 /*
  * heap_copy_header_stats () - Copy heap header statistics
  *
@@ -2702,6 +2713,7 @@ heap_copy_header_stats (THREAD_ENTRY * thread_p, PAGE_PTR page_header, HEAP_HDR_
     }
   return NO_ERROR;
 }
+#endif /* ENABLE_UNUSED_FUNCTION */
 
 /*
  * heap_get_chain_ptr () - Get pointer to chain in heap page
@@ -2869,6 +2881,7 @@ heap_vpid_init_new (THREAD_ENTRY * thread_p, PAGE_PTR page, void *args)
   return NO_ERROR;
 }
 
+#if defined (ENABLE_UNUSED_FUNCTION)
 /*
  * heap_vpid_alloc () - allocate, fetch, and initialize a new page
  *   return: error code
@@ -3002,6 +3015,7 @@ error:
 
   return error_code;
 }
+#endif /* ENABLE_UNUSED_FUNCTION */
 
 /*
  * heap_vpid_remove () - Deallocate a heap page
@@ -6207,6 +6221,7 @@ heap_ovf_flush (THREAD_ENTRY * thread_p, const OID * ovf_oid)
   return NO_ERROR;
 }
 
+#if defined (ENABLE_UNUSED_FUNCTION)
 /*
  * heap_ovf_get_length () - Find length of overflow object
  *   return: length
@@ -6226,6 +6241,7 @@ heap_ovf_get_length (THREAD_ENTRY * thread_p, const OID * ovf_oid)
 
   return overflow_get_length (thread_p, &ovf_vpid);
 }
+#endif /* ENABLE_UNUSED_FUNCTION */
 
 /*
  * heap_ovf_get () - get/retrieve the content of a multipage object from overflow
@@ -6719,6 +6735,7 @@ heap_scancache_quick_start (HEAP_SCANCACHE * scan_cache)
   return NO_ERROR;
 }
 
+#if defined (ENABLE_UNUSED_FUNCTION)
 /*
  * heap_scancache_quick_start_modify () - Start caching information
  *                                      for a heap modifications
@@ -6734,6 +6751,7 @@ heap_scancache_quick_start_modify (HEAP_SCANCACHE * scan_cache)
 
   return NO_ERROR;
 }
+#endif /* ENABLE_UNUSED_FUNCTION */
 
 /*
  * heap_scancache_quick_start_internal () -
@@ -11156,6 +11174,7 @@ cleanup:
   return error;
 }
 
+#if defined (ENABLE_UNUSED_FUNCTION)
 /*
  * heap_get_partition_attributes () - get attribute ids for columns of
  *				      _db_partition class
@@ -11257,6 +11276,7 @@ cleanup:
     }
   return error;
 }
+#endif /* ENABLE_UNUSED_FUNCTION */
 
 /*
  * heap_get_partitions_from_subclasses () - Get partition information from a
@@ -17362,6 +17382,7 @@ exit_on_error:
   return ret;
 }
 
+#if defined (ENABLE_UNUSED_FUNCTION)
 /*
  * heap_attrinfo_set_uninitialized_global () -
  *   return: NO_ERROR
@@ -17380,6 +17401,7 @@ heap_attrinfo_set_uninitialized_global (THREAD_ENTRY * thread_p, OID * inst_oid,
 
   return heap_attrinfo_set_uninitialized (thread_p, inst_oid, recdes, attr_info);
 }
+#endif /* ENABLE_UNUSED_FUNCTION */
 
 /*
  * heap_get_class_info () - get HFID and file type for class.
@@ -24961,6 +24983,7 @@ heap_rv_remove_flags_from_offset (INT16 offset)
   return offset & (~HEAP_RV_FLAG_VACUUM_STATUS_CHANGE);
 }
 
+#if defined (ENABLE_UNUSED_FUNCTION)
 /*
  * heap_scancache_add_partition_node () - add a new partition information to
  *				      to the scan_cache's partition list.
@@ -25010,6 +25033,7 @@ heap_scancache_add_partition_node (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * sca
 
   return NO_ERROR;
 }
+#endif /* ENABLE_UNUSED_FUNCTION */
 
 /*
  * heap_mvcc_log_redistribute () - Log partition redistribute data

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -8429,7 +8429,7 @@ heap_scanrange_to_prior (THREAD_ENTRY * thread_p, HEAP_SCANRANGE * scan_range, O
 		{
 		  scan =
 		    heap_prev (thread_p, &scan_range->scan_cache.node.hfid, &scan_range->scan_cache.node.class_oid,
-			       &scan_range->first_oid, &recdes, &scan_range->scan_cache, PEEK);
+			       &scan_range->last_oid, &recdes, &scan_range->scan_cache, PEEK);
 		  if (scan != S_SUCCESS)
 		    {
 		      return scan;

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -8311,7 +8311,7 @@ heap_scanrange_to_following (THREAD_ENTRY * thread_p, HEAP_SCANRANGE * scan_rang
 	{
 	  /* Scanrange starts with the given object */
 	  scan_range->first_oid = *start_oid;
-	  scan = heap_get_visible_version (thread_p, &scan_range->last_oid, &scan_range->scan_cache.node.class_oid,
+	  scan = heap_get_visible_version (thread_p, &scan_range->first_oid, &scan_range->scan_cache.node.class_oid,
 					   &recdes, &scan_range->scan_cache, PEEK, NULL_CHN);
 	  if (scan != S_SUCCESS)
 	    {

--- a/src/storage/heap_file.h
+++ b/src/storage/heap_file.h
@@ -409,7 +409,9 @@ extern int heap_scancache_start (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_
 extern int heap_scancache_start_modify (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cache, const HFID * hfid,
 					const OID * class_oid, int op_type, MVCC_SNAPSHOT * mvcc_snapshot);
 extern int heap_scancache_quick_start (HEAP_SCANCACHE * scan_cache);
+#if defined (ENABLE_UNUSED_FUNCTION)
 extern int heap_scancache_quick_start_modify (HEAP_SCANCACHE * scan_cache);
+#endif /* ENABLE_UNUSED_FUNCTION */
 extern int heap_scancache_end (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cache);
 extern int heap_scancache_end_when_scan_will_resume (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cache);
 extern void heap_scancache_end_modify (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cache);
@@ -573,8 +575,10 @@ extern OR_CLASSREP *heap_classrepr_get (THREAD_ENTRY * thread_p, const OID * cla
 extern int heap_classrepr_free (OR_CLASSREP * classrep, int *idx_incache);
 extern REPR_ID heap_get_class_repr_id (THREAD_ENTRY * thread_p, OID * class_oid);
 extern int heap_classrepr_find_index_id (OR_CLASSREP * classrepr, const BTID * btid);
+#if defined (ENABLE_UNUSED_FUNCTION)
 extern int heap_attrinfo_set_uninitialized_global (THREAD_ENTRY * thread_p, OID * inst_oid, RECDES * recdes,
 						   HEAP_CACHE_ATTRINFO * attr_info);
+#endif /* ENABLE_UNUSED_FUNCTION */
 
 /* Recovery functions */
 extern int heap_rv_redo_newpage (THREAD_ENTRY * thread_p, LOG_RCV * rcv);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27156

**Purpose**

heap_scanrange_to_following()은 호출자가 준 시작 주소 start_oid부터 스캔 범위를 열도록 되어 있습니다. 그런데 그 주소를 scan_range->first_oid에 저장해 놓고, 바로 다음 줄의 객체 조회에는 아직 값이 채워지지 않은 scan_range->last_oid를 넘깁니다. 함수가 약속한 입력이 실제 조회에 쓰이지 않는 코드 실수입니다.

heap_scanrange_start()가 범위를 열 때 first_oid를 NULL OID로 초기화한 뒤 last_oid에 그대로 복사하므로, 범위를 처음 여는 호출에서 last_oid는 NULL OID입니다. 그 상태로 조회하면 debug 빌드는 heap_prepare_object_page()의 assert (oid != NULL && !OID_ISNULL (oid))에서 죽고, 릴리스 빌드는 페이지 고정이 ER_PB_BAD_PAGEID → ER_HEAP_UNKNOWN_OBJECT로 실패해 S_DOESNT_EXIST fallback을 타고 지정한 객체를 건너뛴 다음 객체부터 범위를 엽니다. 같은 scanrange로 두 번째 이후 호출이라면 last_oid에는 직전 범위의 마지막 객체가 남아 있어 엉뚱한 객체를 조회합니다.

현재 이 함수의 유일한 호출자(scan_manager.c의 grouped fixed scan)는 start_oid에 NULL을 넘기므로 이 분기를 타지 않습니다. 사용자에게 보이는 증상으로 보고된 것이 아니라, 코드를 읽어 찾은 설계 의도 훼손입니다.

**Implementation**

조회에 넘기는 OID를 start_oid가 방금 기록된 필드로 맞춥니다.

   /* Scanrange starts with the given object */
   scan_range->first_oid = *start_oid;
-  scan = heap_get_visible_version (thread_p, &scan_range->last_oid, &scan_range->scan_cache.node.class_oid,
+  scan = heap_get_visible_version (thread_p, &scan_range->first_oid, &scan_range->scan_cache.node.class_oid,
                                    &recdes, &scan_range->scan_cache, PEEK, NULL_CHN);

대칭 함수인 heap_scanrange_to_prior()는 같은 구조에서 last_oid를 쓰는 것이 맞습니다 — 그쪽은 범위의 끝 주소를 받기 때문입니다. 이 분기는 그 코드를 복사하면서 필드만 바꾸지 않은 형태이고, git log -S로 보면 저장소 최초 커밋(cba60decb, 2008 R1.0)부터 같은 인자였습니다. 2016년 9d1ef4cbf [CBRD-20272] Heap get functions refactoring은 heap_get() → heap_get_visible_version() 이름만 바꾼 기계적 변경이라 유입 커밋이 아닙니다.

호출자가 NULL만 넘기고 있으므로 이 수정으로 바뀌는 런타임 동작은 없습니다.

**Remarks**

- 호출처가 없어 함수에 넘기는 인자만 바로잡았습니다. 추후 이 경로를 사용하는 곳이 생기면, 지정한 객체가 이미 삭제됐거나 현재 읽을 수 없을 때 어느 객체부터 읽을지를 이슈에 TBD - 합의 미확인으로 남겨 두었으니 그때 함께 정해야 합니다.
- heap_file.c에서 호출처가 없는데 #if defined (ENABLE_UNUSED_FUNCTION) 처리가 빠져 있던 함수 7개를 같이 묶었습니다. 마이너한 내용이라 이번에 함께 처리했고, 커밋은 버그 수정과 분리해 두었습니다.