### PR TITLE
[CBRD-27400] Fix torn read of append_lsa during log page rollover

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -25253,14 +25253,14 @@ heap_get_visible_version_from_log (THREAD_ENTRY * thread_p, RECDES * recdes, LOG
     }
 
   /* make sure prev_version_lsa is flushed from prior lsa list - wake up log flush thread if it's not flushed */
-  oldest_prior_lsa = *log_get_append_lsa ();	/* TODO: fix atomicity issue on x86 */
+  lsa_atomic_load (&oldest_prior_lsa, log_get_append_lsa ());
   if (LSA_LT (&oldest_prior_lsa, previous_version_lsa))
     {
       LOG_CS_ENTER (thread_p);
       logpb_prior_lsa_append_all_list (thread_p);
       LOG_CS_EXIT (thread_p);
 
-      oldest_prior_lsa = *log_get_append_lsa ();
+      lsa_atomic_load (&oldest_prior_lsa, log_get_append_lsa ());
       assert (!LSA_LT (&oldest_prior_lsa, previous_version_lsa));
     }
 

--- a/src/transaction/log_lsa.hpp
+++ b/src/transaction/log_lsa.hpp
@@ -31,6 +31,9 @@
 #include <cstring>
 #include <cinttypes>
 #include <cstddef>
+#if defined (WINDOWS)
+#include <intrin.h>
+#endif
 
 struct log_lsa
 {
@@ -73,6 +76,8 @@ constexpr log_lsa MAX_LSA = { MAX_LOG_LSA_PAGEID, MAX_LOG_LSA_OFFSET };
 
 // functions
 void lsa_to_string (char *buf, int buf_size, const log_lsa *lsa);
+inline void lsa_atomic_load (log_lsa *dest, const log_lsa *src);
+inline void lsa_atomic_store (log_lsa *dest, const log_lsa *src);
 
 //
 // macro replacements
@@ -207,6 +212,41 @@ LSA_GT (const log_lsa *plsa1, const log_lsa *plsa2)
 {
   assert (plsa1 != NULL && plsa2 != NULL);
   return *plsa1 > *plsa2;
+}
+
+//
+// atomic copy of an LSA that one thread updates while other threads read it without a lock
+//
+// log_Gl.hdr.append_lsa is advanced under LOG_CS but copied without it by log_get_undo_record,
+// heap_get_visible_version_from_log and logpb_fetch_page. A plain copy lets the compiler access pageid and offset
+// separately, so a reader can pair the page id of one value with the offset of another (CBRD-27400). These helpers
+// copy the whole value with one 8-byte atomic access.
+//
+void
+lsa_atomic_load (log_lsa *dest, const log_lsa *src)
+{
+  assert (dest != NULL && src != NULL);
+#if defined (WINDOWS)
+  volatile std::int64_t *src_word = reinterpret_cast<volatile std::int64_t *> (const_cast<log_lsa *> (src));
+  std::int64_t word = _InterlockedCompareExchange64 (src_word, 0, 0);
+  std::memcpy (dest, &word, sizeof (word));
+#else
+  // the generic builtin takes non-const pointers (clang rejects const); *src is not modified
+  __atomic_load (const_cast<log_lsa *> (src), dest, __ATOMIC_ACQUIRE);
+#endif
+}
+
+void
+lsa_atomic_store (log_lsa *dest, const log_lsa *src)
+{
+  assert (dest != NULL && src != NULL);
+#if defined (WINDOWS)
+  std::int64_t word;
+  std::memcpy (&word, src, sizeof (word));
+  (void) _InterlockedExchange64 (reinterpret_cast<volatile std::int64_t *> (dest), word);
+#else
+  __atomic_store (dest, const_cast<log_lsa *> (src), __ATOMIC_RELEASE);
+#endif
 }
 
 #endif  // _LOG_LSA_HPP_

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -9855,7 +9855,7 @@ log_get_undo_record (THREAD_ENTRY * thread_p, LOG_PAGE * log_page_p, LOG_LSA pro
   bool area_was_mallocated = false;
 
   /* assert log record is not in prior list */
-  oldest_prior_lsa = *log_get_append_lsa ();
+  lsa_atomic_load (&oldest_prior_lsa, log_get_append_lsa ());
   assert (LSA_LT (&process_lsa, &oldest_prior_lsa));
 
   log_rec_header = LOG_GET_LOG_RECORD_HEADER (log_page_p, &process_lsa);

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -1751,7 +1751,7 @@ logpb_fetch_page (THREAD_ENTRY * thread_p, const LOG_LSA * req_lsa, LOG_CS_ACCES
 
   logpb_log ("called logpb_fetch_page with pageid = %lld\n", (long long int) req_lsa->pageid);
 
-  LSA_COPY (&append_lsa, &log_Gl.hdr.append_lsa);
+  lsa_atomic_load (&append_lsa, &log_Gl.hdr.append_lsa);
   LSA_COPY (&append_prev_lsa, &log_Gl.append.prev_lsa);
 
   /*
@@ -2633,6 +2633,7 @@ static void
 logpb_next_append_page (THREAD_ENTRY * thread_p, LOG_SETDIRTY current_setdirty)
 {
   LOG_FLUSH_INFO *flush_info = &log_Gl.flush_info;
+  LOG_LSA next_append_lsa;
   bool need_flush;
 #if defined(SERVER_MODE)
   int rv;
@@ -2658,8 +2659,13 @@ logpb_next_append_page (THREAD_ENTRY * thread_p, LOG_SETDIRTY current_setdirty)
 
   log_Gl.append.log_pgptr = NULL;
 
-  log_Gl.hdr.append_lsa.pageid++;
-  log_Gl.hdr.append_lsa.offset = 0;
+  /* Move to the next page with a single 8-byte store. log_get_undo_record, heap_get_visible_version_from_log and
+   * logpb_fetch_page copy append_lsa without LOG_CS; separate stores of pageid and offset would let them observe the old
+   * page paired with the new offset, or the new page paired with the old offset. */
+  LSA_COPY (&next_append_lsa, &log_Gl.hdr.append_lsa);
+  next_append_lsa.pageid++;
+  next_append_lsa.offset = 0;
+  lsa_atomic_store (&log_Gl.hdr.append_lsa, &next_append_lsa);
 
   /*
    * Is the next logical page to archive, currently located at the physical


### PR DESCRIPTION
https://jira.cubrid.org/browse/CBRD-27400

## Purpose

- 로그의 다음 기록 위치(`append_lsa`, 8바이트 값)를 락 없이 읽는 조회 코드가, 이 위치를 앞으로 넘기는 코드와 겹칠 때 값을 반쪽씩 잘못 읽어 `cub_server` 가 assert 로 죽는 문제를 고칩니다.
- AS-IS: 40개 스레드가 동시에 갱신·조회하는 워크로드(`bug_bts_4633`)를 optdebug 빌드에서 돌리면, 드물게 이전 버전을 로그에서 읽는 경로에서 서버가 core 를 남깁니다.
- TO-BE: 로그 페이지가 넘어가는 도중에 조회가 실행돼도 서버가 살아 있고 정상 결과를 돌려줍니다.

## Implementation

- 원인: 읽는 쪽은 8바이트를 `pageid`(48비트)와 `offset`(16비트)으로 나눠 두 번 읽고, 페이지를 넘기는 `logpb_next_append_page` 는 `pageid++` 와 `offset=0` 을 두 번에 나눠 씁니다. 이 둘이 겹치면 로그가 가진 적 없는 `(옛 페이지, 새 offset)` 값이 조합되어 assert 가 터집니다.
- `src/transaction/log_lsa.hpp` 에 8바이트를 한 번에 원자적으로 복사하는 `lsa_atomic_load` / `lsa_atomic_store` 를 추가했습니다.
- 쓰는 쪽 `logpb_next_append_page` 는 새 위치를 지역 변수에 만들어 store 한 번으로 발행하고, 락 없이 읽는 세 곳(`log_get_undo_record`, `heap_get_visible_version_from_log`, `logpb_fetch_page`)은 load 한 번으로 지역 복사본에 담아 비교합니다.
- 온디스크 포맷과 단일 스레드 동작은 그대로입니다. assert 는 회귀 감지를 위해 유지했습니다.

## Remarks

- 이 결함은 2016년부터 있던 기존 결함이라 OOS 와 무관하며, `develop` 과 `feat/oos` 에서 코드가 같습니다. JIRA 제목의 `[Regression]` 태그를 떼는 것을 제안합니다.
- 검증: 고친 optdebug 빌드의 디스어셈블에서 읽기/쓰기가 각각 8바이트 접근 하나로 바뀐 것을 확인했고, GDB 프로브로 옛 코드였다면 죽었을 페이지 전환 55회를 잡아 고친 서버가 모두 견디는 것을 확인했습니다(core 0). 디버거 없는 재현 11회도 core 가 없었습니다.
- 자세한 설명: https://github.com/vimkim/my-cubrid-docs/blob/main/cbrd-27400/CBRD-27400-append-lsa-atomic-torn-read_a590292_claude.md
