### PR TITLE
[CUBRIDQA-1501] Name the current run by its id in the summary, and point /run rerun at it

### DIFF
--- a/.github/workflows/gha-ci.yml
+++ b/.github/workflows/gha-ci.yml
@@ -840,9 +840,20 @@ jobs:
           if [ -n "$RERUN_FROM" ]; then
             src="$CI_ROOT/runs/$RERUN_FROM/failed.list"
             if [ ! -f "$src" ]; then
-              echo "::error::run $RERUN_FROM has no shell results: it never ran the suite"
-              echo "  Only a run that ran the shell suite can be re-run. A pull_request run builds only."
-              echo "  Take the id from the 'current run' row of that run's summary, not 'built by run'."
+              # Absent for three different reasons; naming the wrong one sends the
+              # reader after the wrong id. results/ is what separates them.
+              rd="$CI_ROOT/runs/$RERUN_FROM"
+              if [ ! -d "$rd" ]; then
+                echo "::error::run $RERUN_FROM has no run directory: $rd"
+                echo "  Pruned 7 days after the run, or never a gha-ci run at all."
+              elif [ ! -d "$rd/results" ]; then
+                echo "::error::run $RERUN_FROM never ran the shell suite: no $rd/results"
+                echo "  A pull_request run builds only. Take the id from the 'current run' row"
+                echo "  of a run that ran the suite, not from 'built by run'."
+              else
+                echo "::error::run $RERUN_FROM ran the suite but published no failure list"
+                echo "  collect has not finished: still running, cancelled, or it died first."
+              fi
               exit 1
             fi
             # CircleCI's rerun runs the same commit as the workflow it came from.

--- a/.github/workflows/gha-ci.yml
+++ b/.github/workflows/gha-ci.yml
@@ -839,7 +839,12 @@ jobs:
           # Re-run only failures. failed.list is <shard>\t<shell/...>; align the prefix.
           if [ -n "$RERUN_FROM" ]; then
             src="$CI_ROOT/runs/$RERUN_FROM/failed.list"
-            [ -f "$src" ] || { echo "::error::no failed.list: $src"; exit 1; }
+            if [ ! -f "$src" ]; then
+              echo "::error::run $RERUN_FROM has no shell results: it never ran the suite"
+              echo "  Only a run that ran the shell suite can be re-run. A pull_request run builds only."
+              echo "  Take the id from the 'current run' row of that run's summary, not 'built by run'."
+              exit 1
+            fi
             # CircleCI's rerun runs the same commit as the workflow it came from.
             # gate re-resolves the head, so hold that guarantee here.
             prev_sha=$(find "$CI_ROOT/runs/$RERUN_FROM/results" -mindepth 2 -maxdepth 2 \
@@ -1036,7 +1041,6 @@ jobs:
           TIMED: ${{ steps.split.outputs.timed }}
           SHA: ${{ needs.gate.outputs.sha }}
           BRID: ${{ steps.build.outputs.build_run_id }}
-          RUNDIR: ${{ steps.split.outputs.rundir }}
         run: |
           set -eo pipefail
           {
@@ -1049,7 +1053,7 @@ jobs:
             echo "| cases with measured timings | $TIMED |"
             echo "| build SHA | \`$SHA\` |"
             echo "| build | built by run \`$BRID\` |"
-            echo "| run directory | \`$RUNDIR\` |"
+            echo "| current run | \`$GITHUB_RUN_ID\` |"
           } >> "$GITHUB_STEP_SUMMARY"
 
   shard:
@@ -1790,7 +1794,8 @@ jobs:
             echo "|---|---|"
             echo "| build SHA | \`$SHA\` |"
             echo "| build namespace | \`$BUILD_NS\` |"
-            echo "| built by run | \`$BRID\` (this run \`$GITHUB_RUN_ID\`) $v_this |"
+            echo "| current run | \`$GITHUB_RUN_ID\` |"
+            echo "| built by run | \`$BRID\` $v_this |"
             echo "| shards that read the meta inside the mounted CUBRID | $READ_N / $PLANNED $v_read |"
             echo "| did every shard read the same build | $v_same |"
             echo
@@ -1826,6 +1831,8 @@ jobs:
               echo "|---|---|"
               head -50 /tmp/failed.list | awk -F'\t' '{printf "| %s | `%s` |\n", $1, $2}'
               [ "$FAILED_N" -gt 50 ] && echo && echo "_... and $((FAILED_N - 50)) more. The full list is \`$RUNDIR/failed.list\`_"
+              echo
+              echo "Re-run just these: \`/run rerun $GITHUB_RUN_ID\`"
             else
               echo "### No failed cases"
             fi


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBRIDQA-1501>

### Purpose

gha-ci summary 는 run id 를 둘 보여준다. 그런데 **재실행에 못 쓰는 id 쪽이 더 눈에 띈다.**

- `Split` 표에서 지금 run 의 id 는 `run directory` 값의 경로 안에만 있다. 그 라벨은 id 를 찾는 사람의 눈에 안 걸린다.
- `build | built by run <id>` 는 라벨이 짧고 값이 id 하나다. run 번호를 찾는 사람이 이것을 집는다.
- `Build provenance` 는 두 id 를 한 행에 넣고, 못 쓰는 id 를 앞에 둔다.

`built by run` 이 가리키는 run 은 **재실행이 원리상 불가능하다.** `pull_request` run 은 빌드만 하고 plan·shard·collect 를 건너뛴다. 그래서 `runs/<id>/` 도 `failed.list` 도 없다.

실제로 사용자가 `built by run` 의 id 로 `/run rerun` 을 쳤고 plan 이 실패했다. 빌드 재사용은 정상 동작이므로, 라벨을 안 고치면 같은 오해가 다시 난다.

에러 문안도 원인을 안 말했다. `no failed.list: <경로>` 는 파일이 없다는 사실만 말한다. 읽는 사람은 "그 run 은 shell 을 안 돌렸다" 를 못 읽는다.

### Implementation

summary 에서 지금 run 을 **`current run` 이라는 라벨과 id 로** 보여준다. 재실행에 쓸 id 가 한눈에 읽힌다.

**1. `Split` 표 — `run directory` 를 `current run` 으로 갈았다.**

```
| build       | built by run `34198059273` |
| current run | `34198259227`              |
```

경로는 `runs/<current run>` 규칙이라 id 만 있으면 재구성된다. 산출물로 가는 진입점은 collect 표의 `Artifacts` 링크다.

**2. `Build provenance` — 한 행에 있던 두 id 를 두 행으로 쪼갰다.** 지금 run 이 앞이다.

```
| current run  | `34198259227`        |
| built by run | `34198059273` reused |
```

**3. `Failed cases` 절에 재실행 명령을 넣었다.** 실패가 있을 때만 나온다.

```
Re-run just these: `/run rerun 34198259227`
```

**4. plan 의 에러 문안을 고쳤다.** 잘못된 id 를 어디서 복사해 왔든 다음 사람이 원인을 읽는다.

```
::error::run 34198059273 has no shell results: it never ran the suite
  Only a run that ran the shell suite can be re-run. A pull_request run builds only.
  Take the id from the 'current run' row of that run's summary, not 'built by run'.
```

동작·판정·저장 경로는 안 바뀐다. summary 의 표시와 에러 문안만 바뀐다.

### Remarks

- **재실행할 id 는 `current run` 이다.** `built by run` 은 빌드가 어디서 왔는지만 말한다. 두 값이 같으면 그 run 이 자기 빌드를 만든 것이다.
- 실패가 있는 run 의 summary 에는 `/run rerun <id>` 가 그대로 적혀 있다. 복사해서 코멘트에 붙이면 된다.
- `run directory` 의 절대 경로는 `Split` 표에서 빠졌다. 노드에서 직접 열어야 하면 `/home/gha-ci/runs/<current run>` 이다.
- 이 PR 은 `collect` 의 summary 부근을 고친다. 같은 자리를 고치는 후속 PR 은 이 커밋 위에서 rebase 해야 한다.
- 검증: `gha-ci.yml` 의 run script 35 개 전부 `bash -n` 통과. 두 표를 지역에서 렌더해 실패 1 건 · 302 건 · 0 건 · `rerun_from` run 네 경우를 다 확인했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fuSB7rGfDdP1AKnvjjPtE
