### PR TITLE
[CBRD-27404] Allow parallel index/list scans in sort-merge join inputs

### DIFF
--- a/src/query/parallel/px_scan/px_scan_checker.cpp
+++ b/src/query/parallel/px_scan/px_scan_checker.cpp
@@ -133,7 +133,6 @@ namespace parallel_scan
 
   void process_xasl_node_recursive (XASL_NODE *arg);
   void process_xasl_node_recursive_force_cannot_parallel (XASL_NODE *arg);
-  void block_parallel_index_and_temp_in_subtree (XASL_NODE *arg);
 
   template <bool is_outptr_list>
   possible_flags check (REGU_VARIABLE *arg)
@@ -780,10 +779,6 @@ namespace parallel_scan
 	  {
 	    ACCESS_SPEC_SET_FLAG (specp, ACCESS_SPEC_FLAG_NO_PARALLEL_SCAN);
 	  }
-	for (XASL_NODE *xaslp = arg->aptr_list; xaslp; xaslp = xaslp->next)
-	  {
-	    block_parallel_index_and_temp_in_subtree (xaslp);
-	  }
 	break;
       case BUILDLIST_PROC:
       case BUILDVALUE_PROC:
@@ -909,42 +904,6 @@ namespace parallel_scan
 	  }
       }
 
-  }
-
-  void block_parallel_index_and_temp_in_subtree (XASL_NODE *arg)
-  {
-    if (!arg)
-      {
-	return;
-      }
-    for (ACCESS_SPEC_TYPE *specp = arg->spec_list; specp; specp = specp->next)
-      {
-	if (specp->type == TARGET_LIST
-	    || (specp->type == TARGET_CLASS && IS_ANY_INDEX_ACCESS (specp->access)))
-	  {
-	    ACCESS_SPEC_SET_FLAG (specp, ACCESS_SPEC_FLAG_NO_PARALLEL_SCAN);
-	  }
-      }
-    for (XASL_NODE *xaslp = arg->aptr_list; xaslp; xaslp = xaslp->next)
-      {
-	block_parallel_index_and_temp_in_subtree (xaslp);
-      }
-    for (XASL_NODE *xaslp = arg->bptr_list; xaslp; xaslp = xaslp->next)
-      {
-	block_parallel_index_and_temp_in_subtree (xaslp);
-      }
-    for (XASL_NODE *xaslp = arg->dptr_list; xaslp; xaslp = xaslp->next)
-      {
-	block_parallel_index_and_temp_in_subtree (xaslp);
-      }
-    for (XASL_NODE *xaslp = arg->fptr_list; xaslp; xaslp = xaslp->next)
-      {
-	block_parallel_index_and_temp_in_subtree (xaslp);
-      }
-    for (XASL_NODE *xaslp = arg->scan_ptr; xaslp; xaslp = xaslp->scan_ptr)
-      {
-	block_parallel_index_and_temp_in_subtree (xaslp);
-      }
   }
 
   void process_xasl_node_recursive_force_cannot_parallel (XASL_NODE *arg)


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27404>

### Purpose

sort-merge join(`MERGELIST_PROC`)의 두 입력(aptr) 서브트리에서 parallel scan checker가 index 스캔과 temp(list) 스캔을 조건 없이 직렬로 강제하던 차단을 제거합니다. 이 차단은 merge 정합성에 필요하지 않으며, 제거하면 merge 입력의 index/list 스캔이 다른 노드와 같은 generic gate 기준으로 parallel scan 적격 범위에 들어옵니다. 이전에는 merge 입력 밑에서 heap 스캔만 병렬이 가능했고 index/list 스캔은 항상 직렬이었습니다. merge 소비 단계 자체는 직렬로 유지합니다(그 병렬화는 CBRD-27307에서 별도로 진행하며, 이 입력 스캔 완화를 전제로 합니다).

### Implementation

- `src/query/parallel/px_scan/px_scan_checker.cpp` 에서 `block_parallel_index_and_temp_in_subtree` 함수와 그 선언, `process_xasl_node_recursive` 의 `MERGELIST_PROC` case에서 aptr 자식마다 이 함수를 호출하던 루프를 제거합니다. 코드 변경은 이 파일 한 곳(41 deletions)입니다.
- 제거된 함수는 aptr 서브트리를 aptr/bptr/dptr/fptr/scan_ptr까지 재귀하며 `TARGET_LIST` 스펙과 index 접근 `TARGET_CLASS` 스펙에 `ACCESS_SPEC_FLAG_NO_PARALLEL_SCAN` 을 조건 없이 부여했습니다. 이 함수의 유일한 호출자가 `MERGELIST_PROC` case였으므로 실질적으로 sort-merge join 입력 전용 차단이었습니다.
- 제거 후에도 aptr 자식은 `process_xasl_node_recursive` 의 switch 이후 공통 경로에서 재귀 처리되어 기존 generic gate를 그대로 거칩니다. 따라서 검사가 사라지는 것이 아니라 "무조건 직렬"이 "조건 통과 시 병렬"로 바뀝니다. 제거된 함수의 bptr/dptr/fptr/scan_ptr 재귀는 이 공통 경로의 `force_cannot_parallel` 처리와 중복이었으므로 상관 서브쿼리 등의 직렬 처리는 변하지 않습니다.
- 제거가 안전한 근거: 두 입력은 `make_buildlist_proc` 산출물이라 `after_iscan_list` 가 NULL이고 list 파일이 `sort_list == NULL` 로 열립니다. `make_mergelist_proc` 이 자식의 `orderby_list` 를 NULL로 리셋한 뒤 조인 컬럼으로 무조건 재구성하므로 `qexec_orderby_distinct` 의 정렬 생략 조건(`qfile_is_sort_list_covered`)이 성립할 수 없습니다. 즉 입력 스캔 순서는 merge 결과에 영향을 주지 않습니다.
- merge 자신의 `outer_spec_list` / `inner_spec_list` 차단은 유지합니다. 이 두 스캔은 outer join 경로에서 `qexec_merge_list_outer` 가 `SCAN_ID` 의 `s.llsid` 멤버를 직접 읽어 정렬된 두 입력을 lockstep으로 소비하는 스캔이므로(inner join 경로는 spec을 열지 않고 `list_id` 를 직접 병합), 병렬 스캔용 union 멤버(`s.pllsid_parallel`)로 열리면 안 되고 소비 뒤에 재정렬도 없습니다.
- 입력 서브트리의 순서 의존 index 모드(ISS/ILS, user keylimit, orderby·groupby skip/desc, `XASL_SKIP_ORDERBY_LIST`, instnum/analytic)는 모든 노드에 적용되는 기존 generic gate가 그대로 막습니다.

### Remarks

- `/*+ USE_MERGE PARALLEL(N) */` sort-merge join에서 입력 index/list 스캔 trace에 `(parallel workers: N, index time: ...)` / `(parallel workers: N, temp time: ...)` 이 나타나고, 각 입력의 `ORDERBY (... sort: true ...)` 줄이 유지되며, MERGELIST 노드는 직렬(parallel workers 표기 없음)임을 확인했습니다.
- 결과는 `NO_PARALLEL_SCAN` 및 `USE_NL` 과 가환 집계로 동일함을 확인했습니다(테스트케이스 `CBRD-27404_testcases.sql` 과 설명 `CBRD-27404_testcase_description.md` 를 Jira에 첨부).
- 우산 이슈: CBRD-27152.