### PR TITLE
[CUBRIDQA-1570] log jvmheapdump.hprof's creation in the CI job log

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -342,6 +342,13 @@ commands:
           command: |
             mkdir -p /tmp/logs
             cp -f /tmp/tests/* /tmp/logs || true
+            # JVM PL server writes jvmheapdump.hprof on an OutOfMemoryError.
+            # Log the file's creation in such cases.
+            for root in CUBRID/log /home/CUBRID/log; do
+              [ -d "$root" ] && find "$root" -name '*.hprof' 2>/dev/null
+            done | while IFS= read -r hp; do
+              echo "JVM_HEAPDUMP_MARKER node=${CIRCLE_NODE_INDEX:-0} suite=${TEST_SUITE:-?} file=${hp} bytes=$(wc -c < "$hp" 2>/dev/null || echo 0)"
+            done
             if [ "$TEST_SUITE" = "shell" ]; then
               mv -f cubrid-testtools/CTP/result/shell/current_runtime_logs /tmp/logs/ctp_log || true
             else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -344,9 +344,7 @@ commands:
             cp -f /tmp/tests/* /tmp/logs || true
             # JVM PL server writes jvmheapdump.hprof on an OutOfMemoryError.
             # Log the file's creation in such cases.
-            for root in CUBRID/log /home/CUBRID/log; do
-              [ -d "$root" ] && find "$root" -name '*.hprof' 2>/dev/null
-            done | while IFS= read -r hp; do
+            [ -d CUBRID/log ] && find CUBRID/log -name '*.hprof' 2>/dev/null | while IFS= read -r hp; do
               echo "JVM_HEAPDUMP_MARKER node=${CIRCLE_NODE_INDEX:-0} suite=${TEST_SUITE:-?} file=${hp} bytes=$(wc -c < "$hp" 2>/dev/null || echo 0)"
             done
             if [ "$TEST_SUITE" = "shell" ]; then

--- a/.github/workflows/gha-ci.yml
+++ b/.github/workflows/gha-ci.yml
@@ -1350,6 +1350,28 @@ jobs:
             fi
           fi
 
+          # A PL server OOM leaves jvmheapdump.hprof in the mounted CUBRID's log dir.
+          # Check always, not just on failure: the dump proves an OOM even if CTP did
+          # not flag a case, and the pod is torn down seconds from here. Same 1 GiB cap
+          # as cores -- 50 shards share one volume.
+          dumps="$CUBRID_DIR/log"
+          if [ -d "$dumps" ]; then
+            find "$dumps" -maxdepth 1 -type f -name '*.hprof' -print | while read -r hp; do
+              sz=$(stat -c '%s' "$hp")
+              # Every shard writes the same fixed name (pl_sr_jvm.cpp: jvmheapdump.hprof),
+              # so qualify by shard: the dumps stay unique and self-identifying once they
+              # are gathered out of their per-shard results/<IDX>/ dirs.
+              name="shard-${IDX}-$(basename "$hp")"
+              printf 'shard=%s\tfile=%s\tbytes=%s\n' "$IDX" "$name" "$sz" >> "$out/jvm_heapdump.marker"
+              if [ "$sz" -le 1073741824 ]; then
+                cp -f "$hp" "$out/$name" || echo "::warning::could not copy $name"
+                echo "::warning::JVM heap dump kept as $name ($((sz / 1048576)) MB): PL server OOM on shard $IDX"
+              else
+                echo "::warning::JVM heap dump $(basename "$hp") is $((sz / 1048576)) MB, over the 1 GiB cap: recorded, not copied"
+              fi
+            done
+          fi
+
           # Marks that the shard got this far. Without it collect counts it as dead.
           printf 'idx=%s\nassigned=%s\nctp_rc=%s\n' \
             "$IDX" "$MINE_N" "${CTP_RC}" > "$out/shard.done"
@@ -1848,6 +1870,21 @@ jobs:
               echo "### No failed cases"
             fi
             echo
+            # PL server OOM leaves a jvmheapdump.hprof; each shard that saw one wrote a
+            # marker. Surface it here -- an OOM is not an ordinary case failure.
+            hpmark=$(cat "$RUNDIR"/results/*/jvm_heapdump.marker 2>/dev/null || true)
+            if [ -n "$hpmark" ]; then
+              hpn=$(printf '%s\n' "$hpmark" | grep -c . || true)
+              echo "### ⚠ JVM heap dump detected ($hpn)"
+              echo
+              echo "The PL server hit an OutOfMemoryError and wrote a heap dump. Any \`.hprof\` under the"
+              echo "1 GiB cap is kept under the Artifacts link below (pruned 7 days after the run)."
+              echo
+              echo "| shard | file | bytes |"
+              echo "|---|---|---|"
+              printf '%s\n' "$hpmark" | awk -F'\t' 'NF{delete v; for(i=1;i<=NF;i++){split($i,kv,"=");v[kv[1]]=kv[2]} printf "| %s | `%s` | %s |\n", v["shard"], v["file"], v["bytes"]}'
+              echo
+            fi
             echo "---"
             # Next to the published build, not under the run directory: a reused
             # build outlives the run that made it. debug is what the suite mounted.


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBRIDQA-1570>

### Purpose

PL server 는 OutOfMemoryError 로 인해 crash 할 때 jvmheapdump.hprof 라는 파일을 $CUBRID/log/ 디렉토리 아래에 남기도록 설정되어 있다. 단, CI에서 이 파일을 포함한 Artifacts 는 몇 일 동안만 보존된다.
파일 크기가 커서 파일 내용을 오래 보관할 수는 없지만, jvmheapdump.hprof 생성 여부 (JVM의 OutOfMemoryError 로 인한 사망여부) 를 Job Log 에 남기면 사후에 PL server 의 OOM crash 여부와 빈도수를 확인할 수 있게 된다. 

### Implementation
.circleci/config.yml 에 로그 과정 추가.

