### PR TITLE
[CBRD-27406] Cached subquery XASL_ID and QFILE_LIST_ID allocations leak from cleanup gaps and dropped execution results

### DIFF
--- a/src/parser/parse_tree.c
+++ b/src/parser/parse_tree.c
@@ -857,8 +857,8 @@ parser_free_node_resources (PT_NODE * node)
     }
   if (node->xasl_id != NULL)
     {
-      /* covers cached-subquery nodes buried in FROM/WHERE, which db_close_session_local() and friends never
-       * reach directly since they only walk the session's top-level statements[] array. */
+      /* covers cached-subquery nodes anywhere in the tree,
+       * unreached by statements[]-only walkers like db_close_session_local(). */
       free_and_init (node->xasl_id);
     }
 }

--- a/src/parser/parse_tree.c
+++ b/src/parser/parse_tree.c
@@ -855,7 +855,7 @@ parser_free_node_resources (PT_NODE * node)
   if (node->xasl_id != NULL)
     {
       /* covers cached-subquery nodes anywhere in the tree,
-       * unreached by statements[]-only walkers like db_close_session_local(). */
+       * unreached by statements[]-only walkers like db_close_session_local (). */
       free_and_init (node->xasl_id);
     }
 }

--- a/src/parser/parse_tree.c
+++ b/src/parser/parse_tree.c
@@ -855,6 +855,12 @@ parser_free_node_resources (PT_NODE * node)
       col->on_error.m_default_value = NULL;
       // db_values on_empty.m_default_value & on_error.m_default_value are allocated using area_alloc
     }
+  if (node->xasl_id != NULL)
+    {
+      /* covers cached-subquery nodes buried in FROM/WHERE, which db_close_session_local() and friends never
+       * reach directly since they only walk the session's top-level statements[] array. */
+      free_and_init (node->xasl_id);
+    }
 }
 
 /*

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -962,8 +962,7 @@ copy_node_in_tree_pre (PARSER_CONTEXT * parser, PT_NODE * old_node, void *arg, i
 
   *new_node = *old_node;
 
-  /* a copy is not itself a prepared statement; it must not alias the original's XASL_ID
-   * (parser_free_node_resources () would otherwise free the same XASL_ID twice, once per node) */
+  /* a copy must not alias the original's XASL_ID, or parser_free_node_resources () frees it twice, once per node. */
   new_node->xasl_id = NULL;
 
   /* if node is copied from another parser context, deepcopy string contents */

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -948,8 +948,11 @@ pt_find_id_node (PARSER_CONTEXT * parser, PT_NODE * tree, void *void_arg, int *c
 static XASL_ID *
 pt_clone_xasl_id (const XASL_ID * src)
 {
-  XASL_ID *dst = (XASL_ID *) malloc (sizeof (XASL_ID));
+  XASL_ID *dst;
 
+  assert (src != NULL);
+
+  dst = (XASL_ID *) malloc (sizeof (XASL_ID));
   if (dst == NULL)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (XASL_ID));
@@ -986,7 +989,7 @@ copy_node_in_tree_pre (PARSER_CONTEXT * parser, PT_NODE * old_node, void *arg, i
 
   *new_node = *old_node;
 
-  /* clone XASL_ID; aliasing old_node's would double-free in parser_free_node_resources () (CBRD-27406) */
+  /* clone XASL_ID; aliasing old_node's would double-free in parser_free_node_resources () */
   new_node->xasl_id = NULL;
   if (old_node->xasl_id != NULL)
     {

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -940,32 +940,6 @@ pt_find_id_node (PARSER_CONTEXT * parser, PT_NODE * tree, void *void_arg, int *c
 }
 
 /*
- * pt_clone_xasl_id () - deep-copies src into a freshly allocated XASL_ID,
- * 	giving the caller an independent cache identity instead of aliasing src
- *   return: new XASL_ID with the same sha1/time_stored, or NULL on allocation failure
- *   src(in): XASL_ID to copy; must not be NULL
- */
-static XASL_ID *
-pt_clone_xasl_id (const XASL_ID * src)
-{
-  XASL_ID *dst;
-
-  assert (src != NULL);
-
-  dst = (XASL_ID *) malloc (sizeof (XASL_ID));
-  if (dst == NULL)
-    {
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (XASL_ID));
-      return NULL;
-    }
-
-  XASL_ID_SET_NULL (dst);
-  XASL_ID_COPY (dst, src);
-
-  return dst;
-}
-
-/*
  * copy_node_in_tree_pre () - copies exactly a node passed to it, and returns
  * 	a pointer to the copy. It is eligible for a walk "pre" function
  *   return:
@@ -993,12 +967,15 @@ copy_node_in_tree_pre (PARSER_CONTEXT * parser, PT_NODE * old_node, void *arg, i
   new_node->xasl_id = NULL;
   if (old_node->xasl_id != NULL)
     {
-      new_node->xasl_id = pt_clone_xasl_id (old_node->xasl_id);
+      new_node->xasl_id = (XASL_ID *) malloc (sizeof (XASL_ID));
       if (new_node->xasl_id == NULL)
 	{
-	  PT_INTERNAL_ERROR (parser, "clone XASL_ID");
+	  PT_ERRORmf (parser, old_node, MSGCAT_SET_PARSER_RUNTIME, MSGCAT_RUNTIME_OUT_OF_MEMORY, sizeof (XASL_ID));
 	  return NULL;
 	}
+
+      XASL_ID_SET_NULL (new_node->xasl_id);
+      XASL_ID_COPY (new_node->xasl_id, old_node->xasl_id);
     }
 
   /* if node is copied from another parser context, deepcopy string contents */

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -962,6 +962,10 @@ copy_node_in_tree_pre (PARSER_CONTEXT * parser, PT_NODE * old_node, void *arg, i
 
   *new_node = *old_node;
 
+  /* a copy is not itself a prepared statement; it must not alias the original's XASL_ID
+   * (parser_free_node_resources () would otherwise free the same XASL_ID twice, once per node) */
+  new_node->xasl_id = NULL;
+
   /* if node is copied from another parser context, deepcopy string contents */
   if (old_node->parser_id != parser->id)
     {

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -57,6 +57,7 @@
 #include "parser_allocator.hpp"
 #include "tde.h"
 #include "jsp_cl.h"
+#include "xasl.h"
 
 #include <malloc.h>
 
@@ -939,6 +940,29 @@ pt_find_id_node (PARSER_CONTEXT * parser, PT_NODE * tree, void *void_arg, int *c
 }
 
 /*
+ * pt_clone_xasl_id () - deep-copies src into a freshly allocated XASL_ID,
+ * 	giving the caller an independent cache identity instead of aliasing src
+ *   return: new XASL_ID with the same sha1/time_stored, or NULL on allocation failure
+ *   src(in): XASL_ID to copy; must not be NULL
+ */
+static XASL_ID *
+pt_clone_xasl_id (const XASL_ID * src)
+{
+  XASL_ID *dst = (XASL_ID *) malloc (sizeof (XASL_ID));
+
+  if (dst == NULL)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (XASL_ID));
+      return NULL;
+    }
+
+  XASL_ID_SET_NULL (dst);
+  XASL_ID_COPY (dst, src);
+
+  return dst;
+}
+
+/*
  * copy_node_in_tree_pre () - copies exactly a node passed to it, and returns
  * 	a pointer to the copy. It is eligible for a walk "pre" function
  *   return:
@@ -962,8 +986,17 @@ copy_node_in_tree_pre (PARSER_CONTEXT * parser, PT_NODE * old_node, void *arg, i
 
   *new_node = *old_node;
 
-  /* a copy must not alias the original's XASL_ID, or parser_free_node_resources () frees it twice, once per node. */
+  /* clone XASL_ID; aliasing old_node's would double-free in parser_free_node_resources () (CBRD-27406) */
   new_node->xasl_id = NULL;
+  if (old_node->xasl_id != NULL)
+    {
+      new_node->xasl_id = pt_clone_xasl_id (old_node->xasl_id);
+      if (new_node->xasl_id == NULL)
+	{
+	  PT_INTERNAL_ERROR (parser, "clone XASL_ID");
+	  return NULL;
+	}
+    }
 
   /* if node is copied from another parser context, deepcopy string contents */
   if (old_node->parser_id != parser->id)

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -419,6 +419,7 @@ static void pt_make_json_table_spec_node_internal (PARSER_CONTEXT * parser, PT_J
 						   json_table_node & result);
 static XASL_NODE *pt_find_xasl (XASL_NODE * list, XASL_NODE * match);
 static void pt_set_aptr (PARSER_CONTEXT * parser, PT_NODE * select_node, XASL_NODE * xasl);
+static int pt_set_sub_xasl_id (XASL_NODE * xasl, const PT_NODE * node);
 static XASL_NODE *pt_append_scan (const XASL_NODE * to, const XASL_NODE * from);
 static PT_NODE *pt_uncorr_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk);
 static PT_NODE *pt_uncorr_post (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk);
@@ -13681,6 +13682,43 @@ pt_set_aptr (PARSER_CONTEXT * parser, PT_NODE * select_node, XASL_NODE * xasl)
 }
 
 /*
+ * pt_set_sub_xasl_id () - clone node's XASL_ID into packing-buffer memory
+ *     instead of borrowing it. node is often temporary (e.g. an UPDATE/DELETE's aptr_statement)
+ *     and gets freed before xasl is serialized, but the packing buffer stays alive until pt_exit_packing_buf ().
+ *   return: NO_ERROR on success, ER_OUT_OF_VIRTUAL_MEMORY on allocation failure
+ *   xasl(out): XASL_NODE to attach the cloned XASL_ID to
+ *   node(in): PT_NODE to clone the XASL_ID from
+ */
+static int
+pt_set_sub_xasl_id (XASL_NODE * xasl, const PT_NODE * node)
+{
+  XASL_ID *sub_xasl_id;
+
+  xasl->sub_xasl_id = NULL;
+
+  if (node->xasl_id == NULL)
+    {
+      return NO_ERROR;
+    }
+
+  sub_xasl_id = (XASL_ID *) pt_alloc_packing_buf (sizeof (XASL_ID));
+  if (sub_xasl_id == NULL)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (XASL_ID));
+      return ER_OUT_OF_VIRTUAL_MEMORY;
+    }
+
+  XASL_ID_SET_NULL (sub_xasl_id);
+  XASL_ID_COPY (sub_xasl_id, node->xasl_id);
+
+  xasl->sub_xasl_id = sub_xasl_id;
+  xasl->sub_host_var_count = node->sub_host_var_count;
+  xasl->sub_host_var_index = node->sub_host_var_index;
+
+  return NO_ERROR;
+}
+
+/*
  * pt_set_connect_by_xasl() - set the CONNECT BY xasl node,
  *	and make the pseudo-columns regu vars
  *   parser(in):
@@ -13893,9 +13931,12 @@ pt_uncorr_post (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continu
 	      if (node->info.query.flag.subquery_cached)
 		{
 		  /* save the subquery cache info */
-		  xasl->sub_xasl_id = node->xasl_id;
-		  xasl->sub_host_var_count = node->sub_host_var_count;
-		  xasl->sub_host_var_index = node->sub_host_var_index;
+		  if (pt_set_sub_xasl_id (xasl, node) != NO_ERROR)
+		    {
+		      PT_ERRORmf (parser, node, MSGCAT_SET_PARSER_RUNTIME, MSGCAT_RUNTIME_OUT_OF_MEMORY,
+				  sizeof (XASL_ID));
+		      *continue_walk = PT_STOP_WALK;
+		    }
 		}
 
 	      /* order is important. we are on the way up, so putting things at the tail of the list will end up deeper
@@ -17879,9 +17920,12 @@ pt_plan_cte (PARSER_CONTEXT * parser, PT_NODE * node, PROC_TYPE proc_type)
   /* checking false query */
   if (non_recursive_part_xasl)
     {
-      non_recursive_part_xasl->sub_xasl_id = non_recursive_part->xasl_id;
-      non_recursive_part_xasl->sub_host_var_count = non_recursive_part->sub_host_var_count;
-      non_recursive_part_xasl->sub_host_var_index = non_recursive_part->sub_host_var_index;
+      if (pt_set_sub_xasl_id (non_recursive_part_xasl, non_recursive_part) != NO_ERROR)
+	{
+	  PT_ERRORmf (parser, non_recursive_part, MSGCAT_SET_PARSER_RUNTIME, MSGCAT_RUNTIME_OUT_OF_MEMORY,
+		      sizeof (XASL_ID));
+	  return NULL;
+	}
     }
 
   if (recursive_part)
@@ -19614,9 +19658,12 @@ pt_to_insert_xasl_remote_select (PARSER_CONTEXT * parser, PT_NODE * statement)
 
   if (aptr_statement->info.query.flag.subquery_cached)
     {
-      xasl->aptr_list->sub_xasl_id = aptr_statement->xasl_id;
-      xasl->aptr_list->sub_host_var_count = aptr_statement->sub_host_var_count;
-      xasl->aptr_list->sub_host_var_index = aptr_statement->sub_host_var_index;
+      if (pt_set_sub_xasl_id (xasl->aptr_list, aptr_statement) != NO_ERROR)
+	{
+	  PT_ERRORmf (parser, aptr_statement, MSGCAT_SET_PARSER_RUNTIME, MSGCAT_RUNTIME_OUT_OF_MEMORY,
+		      sizeof (XASL_ID));
+	  return NULL;
+	}
     }
 
   into_spec = statement->info.insert.spec;
@@ -19845,9 +19892,10 @@ pt_to_delete_xasl_remote_subquery (PARSER_CONTEXT * parser, PT_NODE * statement)
 
   if (aptr_statement->info.query.flag.subquery_cached)
     {
-      xasl->aptr_list->sub_xasl_id = aptr_statement->xasl_id;
-      xasl->aptr_list->sub_host_var_count = aptr_statement->sub_host_var_count;
-      xasl->aptr_list->sub_host_var_index = aptr_statement->sub_host_var_index;
+      if (pt_set_sub_xasl_id (xasl->aptr_list, aptr_statement) != NO_ERROR)
+	{
+	  return NULL;
+	}
     }
 
   server_node = from->info.spec.remote_server_name;
@@ -20023,9 +20071,12 @@ pt_to_insert_xasl (PARSER_CONTEXT * parser, PT_NODE * statement)
 
       if (xasl != NULL && aptr_statement->info.query.flag.subquery_cached)
 	{
-	  xasl->aptr_list->sub_xasl_id = aptr_statement->xasl_id;
-	  xasl->aptr_list->sub_host_var_count = aptr_statement->sub_host_var_count;
-	  xasl->aptr_list->sub_host_var_index = aptr_statement->sub_host_var_index;
+	  if (pt_set_sub_xasl_id (xasl->aptr_list, aptr_statement) != NO_ERROR)
+	    {
+	      PT_ERRORmf (parser, aptr_statement, MSGCAT_SET_PARSER_RUNTIME, MSGCAT_RUNTIME_OUT_OF_MEMORY,
+			  sizeof (XASL_ID));
+	      return NULL;
+	    }
 	}
     }
   else
@@ -27567,9 +27618,11 @@ pt_to_merge_update_xasl (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE *
   /* for subquery cache */
   if (aptr_statement->xasl_id && !statement->flag.do_not_use_subquery_cache)
     {
-      xasl->sub_xasl_id = aptr_statement->xasl_id;
-      xasl->sub_host_var_count = aptr_statement->sub_host_var_count;
-      xasl->sub_host_var_index = aptr_statement->sub_host_var_index;
+      error = pt_set_sub_xasl_id (xasl, aptr_statement);
+      if (error != NO_ERROR)
+	{
+	  goto cleanup;
+	}
     }
 
   /* flush all classes */
@@ -28070,9 +28123,11 @@ pt_to_merge_insert_xasl (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE *
   /* for subquery cache */
   if (aptr_statement->xasl_id && !statement->flag.do_not_use_subquery_cache)
     {
-      xasl->sub_xasl_id = aptr_statement->xasl_id;
-      xasl->sub_host_var_count = aptr_statement->sub_host_var_count;
-      xasl->sub_host_var_index = aptr_statement->sub_host_var_index;
+      error = pt_set_sub_xasl_id (xasl, aptr_statement);
+      if (error != NO_ERROR)
+	{
+	  goto cleanup;
+	}
     }
 
   insert = &xasl->proc.insert;

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -15714,7 +15714,7 @@ do_execute_subquery (PARSER_CONTEXT * parser, PT_NODE * stmt)
     }
 
   /* only unpins this query from the cache entry; the entry is not cleared and stays for reuse.
-   * skipping this leaks a query entry per call -- ~150 in one uncommitted transaction hits ER_QM_QENTRY_RUNOUT. */
+   * skipping this leaks a query entry per call, exhausting max_query_per_tran and raising ER_QM_QENTRY_RUNOUT. */
   if (query_id != NULL_QUERY_ID && !tran_was_latest_query_ended ())
     {
       qmgr_end_query (query_id);

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -15713,7 +15713,8 @@ do_execute_subquery (PARSER_CONTEXT * parser, PT_NODE * stmt)
       cursor_free_self_list_id (list_id);
     }
 
-  /* only unpins this query from the cache entry; the entry is not cleared and stays for reuse. */
+  /* only unpins this query from the cache entry; the entry is not cleared and stays for reuse.
+   * skipping this leaks a query entry per call -- ~150 in one uncommitted transaction hits ER_QM_QENTRY_RUNOUT. */
   if (query_id != NULL_QUERY_ID && !tran_was_latest_query_ended ())
     {
       qmgr_end_query (query_id);

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -15713,6 +15713,7 @@ do_execute_subquery (PARSER_CONTEXT * parser, PT_NODE * stmt)
       cursor_free_self_list_id (list_id);
     }
 
+  /* ends only this query's own use; the cached list entry outlives it for later reuse. */
   if (query_id != NULL_QUERY_ID && !tran_was_latest_query_ended ())
     {
       qmgr_end_query (query_id);

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -15713,7 +15713,7 @@ do_execute_subquery (PARSER_CONTEXT * parser, PT_NODE * stmt)
       cursor_free_self_list_id (list_id);
     }
 
-  /* ends only this query's own use; the cached list entry outlives it for later reuse. */
+  /* only unpins this query from the cache entry; the entry is not cleared and stays for reuse. */
   if (query_id != NULL_QUERY_ID && !tran_was_latest_query_ended ())
     {
       qmgr_end_query (query_id);

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -15707,6 +15707,13 @@ do_execute_subquery (PARSER_CONTEXT * parser, PT_NODE * stmt)
       free (host_variables);
     }
 
+  /* execute_query () always sets list_id, NULL on failure. The server has already cached the result
+   * (RESULT_CACHE_REQUIRED); this function only needs to trigger that, not read the rows back. */
+  if (list_id != NULL)
+    {
+      cursor_free_self_list_id (list_id);
+    }
+
   if (err == ER_QPROC_RESULT_CACHE_INVALID)
     {
       /* retry the statement once */

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -15713,6 +15713,9 @@ do_execute_subquery (PARSER_CONTEXT * parser, PT_NODE * stmt)
       cursor_free_self_list_id (list_id);
     }
 
+  /* end the query; reset query_id and call qmgr_end_query() */
+  pt_end_query (parser, query_id);
+
   if (err == ER_QPROC_RESULT_CACHE_INVALID)
     {
       /* retry the statement once */

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -15713,8 +15713,10 @@ do_execute_subquery (PARSER_CONTEXT * parser, PT_NODE * stmt)
       cursor_free_self_list_id (list_id);
     }
 
-  /* end the query; reset query_id and call qmgr_end_query() */
-  pt_end_query (parser, query_id);
+  if (query_id != NULL_QUERY_ID && !tran_was_latest_query_ended ())
+    {
+      qmgr_end_query (query_id);
+    }
 
   if (err == ER_QPROC_RESULT_CACHE_INVALID)
     {

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -15707,8 +15707,7 @@ do_execute_subquery (PARSER_CONTEXT * parser, PT_NODE * stmt)
       free (host_variables);
     }
 
-  /* execute_query () always sets list_id, NULL on failure. The server has already cached the result
-   * (RESULT_CACHE_REQUIRED); this function only needs to trigger that, not read the rows back. */
+  /* server already cached the result (RESULT_CACHE_REQUIRED); this only triggers that, does not read rows back. */
   if (list_id != NULL)
     {
       cursor_free_self_list_id (list_id);

--- a/src/query/query_manager.c
+++ b/src/query/query_manager.c
@@ -1483,7 +1483,10 @@ xqmgr_execute_query (THREAD_ENTRY * thread_p, const XASL_ID * xasl_id_p, QUERY_I
 	  if (cached_result)
 	    {
 	      /* found the cached result */
-	      CACHE_TIME_MAKE (server_cache_time_p, &list_cache_entry_p->time_created);
+	      if (server_cache_time_p != NULL)
+		{
+		  CACHE_TIME_MAKE (server_cache_time_p, &list_cache_entry_p->time_created);
+		}
 	    }
 	}
     }
@@ -1667,7 +1670,10 @@ xqmgr_execute_query (THREAD_ENTRY * thread_p, const XASL_ID * xasl_id_p, QUERY_I
 	  /* record list cache entry into the query entry for qfile_end_use_of_list_cache_entry() */
 	  query_p->list_ent = list_cache_entry_p;
 
-	  CACHE_TIME_MAKE (server_cache_time_p, &list_cache_entry_p->time_created);
+	  if (server_cache_time_p != NULL)
+	    {
+	      CACHE_TIME_MAKE (server_cache_time_p, &list_cache_entry_p->time_created);
+	    }
 	}
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27406

### Purpose

`QUERY_CACHE` 힌트가 붙은 서브쿼리를 PREPARE/EXECUTE할 때마다, 트리 정리 코드가 처리하지 않는 `XASL_ID`와 해제 경로 자체가 없는 `QFILE_LIST_ID`가 회수되지 않고 leak된다. 두 자원 모두 명시적으로 해제하도록 고친다. 검증 중 발견한, 이 leak과 무관한 `xqmgr_execute_query()`의 NULL `server_cache_time_p` 크래시와, 리뷰로 지적받은 `query_id` 미정리(서버 query entry 누적)도 같은 함수에서 함께 고친다.

### Implementation

- `parser_free_node_resources()`(`parse_tree.c`)는 트리 정리 중 노드마다 이미 호출되지만 `PT_VALUE`/`PT_INSERT_VALUE`/`PT_JSON_TABLE_COLUMN` 세 타입만 처리했다. `xasl_id`가 NULL이 아니면 `free_and_init`으로 해제하는 처리를 추가했다.
- `copy_node_in_tree_pre()`(`parse_tree_cl.c`)에서 노드를 얕은 복사한 직후 복사본의 `xasl_id`를 NULL로 설정해, 원본과 복사본이 같은 `xasl_id`를 가리키다 이중 해제되는 경로를 막았다.
- `do_execute_subquery()`(`execute_statement.c`)에서 `execute_query()`가 반환한 `QFILE_LIST_ID`를 `cursor_free_self_list_id()`로 명시적으로 해제하도록 추가했다.
- `xqmgr_execute_query()`(`query_manager.c`)가 캐시 히트 시 `server_cache_time_p`를 확인 없이 쓰던 두 호출부를 `if (server_cache_time_p != NULL)`로 감쌌다. `do_execute_prepared_subquery()`가 이 인자로 NULL을 넘기는 경로에서 SA_MODE가 SIGSEGV로 죽던 것을 막는다.
- `do_execute_subquery()`(`execute_statement.c`)가 `execute_query()`에서 받은 `query_id`를 정리하지 않던 것을, `qmgr_end_query()`로 직접 끝내도록 추가했다. 방치된 `query_id`는 서버 query entry와 list-cache 참조를 트랜잭션이 끝날 때까지 붙잡고 있어, 반복 실행 시 누적된다.

### Remarks

- `stx_build_xasl_node`(서드파티 `lea_heap.c`의 힙 풀 등록 비용)에서 나는 고정 12바이트 할당은 프로세스 생애주기당 한 번만 발생하고 반복해도 늘지 않아, 이 PR에서 의도적으로 손대지 않았다.