### PR TITLE
[CBRD-27408] Round the NUMERIC SUM accumulator at the 41-digit boundary like binary addition

### DIFF
--- a/src/query/numeric_opfunc.c
+++ b/src/query/numeric_opfunc.c
@@ -319,7 +319,11 @@ static int numeric_sum_acc_add_rounded (SUM_ACC * acc, const DB_VALUE * val_dbv)
 /* the addition exceeds the accumulator's capacity, so the caller retries with numeric_sum_acc_add_rounded () */
 #define SUM_ACC_NUMERIC_CAPACITY (1)
 
-/* 10^40 (41 digits) as a 3-word coefficient */
+/* 10^40 (41 digits) as a big-endian 3-word coefficient
+ *   0x1DULL               =                   29 * 2^128 = 9868188640707215440437863615521278132224
+ *   0x6329F1C35CA4BFABULL =  7145508105175220139 * 2^64  =  131811359292784559548736661559783194624
+ *   0xB9F5610000000000ULL                                =                     13399722918938673152
+ *                                                        = 10000000000000000000000000000000000000000 */
 static const uint64_t _gv_numeric_sum_acc_pow10_max_prec[SUM_ACC_NUMERIC_WORDS] =
   { 0x1DULL, 0x6329F1C35CA4BFABULL, 0xB9F5610000000000ULL };
 

--- a/src/query/numeric_opfunc.c
+++ b/src/query/numeric_opfunc.c
@@ -319,6 +319,10 @@ static int numeric_sum_acc_add_rounded (SUM_ACC * acc, const DB_VALUE * val_dbv)
 /* the addition exceeds the accumulator's capacity, so the caller retries with numeric_sum_acc_add_rounded () */
 #define SUM_ACC_NUMERIC_CAPACITY (1)
 
+/* 10^40 (41 digits) as a 3-word coefficient */
+static const uint64_t _gv_numeric_sum_acc_pow10_max_prec[SUM_ACC_NUMERIC_WORDS] =
+  { 0x1DULL, 0x6329F1C35CA4BFABULL, 0xB9F5610000000000ULL };
+
 /*
  * numeric_is_negative () -
  *   return: true, false
@@ -4233,8 +4237,9 @@ numeric_sum_acc_merge (SUM_ACC * acc, const SUM_ACC * other)
  * numeric_sum_acc_add_core () - accumulate a NUMERIC coefficient into the
  *                               running sum
  *   return: NO_ERROR, or SUM_ACC_NUMERIC_CAPACITY when the aligned value or
- *           the sum does not fit the accumulator's 3-word coefficient (the
- *           accumulator is untouched)
+ *           the sum does not fit the accumulator's 3-word coefficient, or the
+ *           sum has more than DB_MAX_NUMERIC_PRECISION digits (the accumulator
+ *           is untouched)
  *   acc(in/out)   : active accumulator
  *   val_words(in) : coefficient of the value (3 words); not modified
  *   val_scale(in) : scale of the value
@@ -4252,6 +4257,7 @@ numeric_sum_acc_add_core (SUM_ACC * acc, const uint64_t * val_words, int val_sca
   uint64_t aligned_words[SUM_ACC_NUMERIC_WORDS];
   uint64_t sum_words[SUM_ACC_NUMERIC_WORDS];
   const uint64_t *acc_words = acc->v.words;
+  bool sum_neg = acc->is_negative;
   int diff = val_scale - acc->scale;
 
   if (diff != 0)
@@ -4280,10 +4286,17 @@ numeric_sum_acc_add_core (SUM_ACC * acc, const uint64_t * val_words, int val_sca
   else
     {
       (void) float_numeric_sub (val_words, acc_words, sum_words, SUM_ACC_NUMERIC_WORDS);
-      acc->is_negative = val_neg;
+      sum_neg = val_neg;
+    }
+
+  /* round at the 41-digit boundary for consistency with binary operations */
+  if (float_numeric_operation_compare (sum_words, _gv_numeric_sum_acc_pow10_max_prec, SUM_ACC_NUMERIC_WORDS) >= 0)
+    {
+      return SUM_ACC_NUMERIC_CAPACITY;
     }
 
   memcpy (acc->v.words, sum_words, sizeof (sum_words));
+  acc->is_negative = sum_neg;
   if (diff > 0)
     {
       acc->scale = val_scale;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27408

### Purpose

CBRD-27178(#7763)에서 도입한 NUMERIC SUM/AVG 누산기는 3워드(57자리) 버퍼에 합을 반올림 없이 쌓고 그룹 finalize에서 1회만 40자리로 반올림한다.
이항 덧셈(+)은 결과가 40자리를 넘는 순간마다 반올림하므로, 같은 값을 더해도 SUM(n)과 n1 + n2 + n3의 결과가 달라진다.

```sql
create table tn (n numeric);
insert into tn values (9999999999999999999999999999999999999998), (4), (4);

select 9999999999999999999999999999999999999998 + 4 + 4 as chain;  -- 10000000000000000000000000000000000000000
select sum(n) from tn;                                             -- 10000000000000000000000000000000000000010
```

40자리 초과 구간은 둘 다 반올림된 값이라 어느 쪽이 정답이라 할 수 없지만, 사용자는 집계와 연산자의 결과가 다른 것을 버그로 인식한다(Oracle은 두 결과가 일치한다).
이 PR은 누산기가 40자리를 넘는 순간 이항 덧셈과 같은 반올림을 수행해 두 경로의 결과를 일치시킨다.

### Implementation

`numeric_opfunc.c` `numeric_sum_acc_add_core`

- 스케일 정렬 후의 덧셈·뺄셈 결과 계수가 10^40 이상(41자리 이상)이면 `SUM_ACC_NUMERIC_CAPACITY`를 반환한다.
  - 호출자는 기존 3워드 용량 초과 우회와 같은 경로(`numeric_sum_acc_add_rounded` → `float_numeric_db_value_add` → 재적재)로 그 행을 처리한다. 이항 덧셈과 같은 함수를 쓰므로 반올림 규칙과 결과 scale이 일치한다.
  - 판정은 `float_numeric_operation_compare (sum_words, 10^40) >= 0` 한 번(3워드 비교)이며, 이항 덧셈의 `result_prec > DB_MAX_NUMERIC_PRECISION` 과 같은 경계다. 10^40은 3워드 정적 상수(`_gv_numeric_sum_acc_pow10_max_prec`)로 둔다.
- 판정은 덧셈 분기뿐 아니라 뺄셈(부호가 다른 경우) 분기 뒤에도 공통으로 적용한다.
  - 두 피연산자가 모두 40자리 이하라도, 스케일 정렬 곱으로 누산기 계수가 41자리로 넓어진 뒤 뺄셈 결과가 41자리로 남을 수 있다(예: 40자리 정수 누산값 + `-0.5`). 이항 연산은 이 경우도 반올림한다.
- 결과 부호는 로컬(`sum_neg`)에 받아 두고 판정 통과 후 계수와 함께 대입한다. `SUM_ACC_NUMERIC_CAPACITY` 반환 시 누산기가 변경되지 않는다는 기존 계약이 유지된다.
- `numeric_sum_acc_merge`(병렬 부분합 병합), `numeric_sum_acc_add_expr_val`(agg_expr 직결)은 같은 core를 사용하므로 별도 수정 없이 동일하게 동작한다.

| 경로 | 변경 전 | 변경 후 |
|---|---|---|
| 합 ≤ 40자리 | 누산기에 정확히 누적 | 동일 |
| 합 41~57자리 | 누산기에 정확히 누적, finalize 1회 반올림 | 그 행을 이항 덧셈과 같은 반올림 경로로 우회 후 재적재 |
| 합 > 57자리 (3워드 캐리) | 그 행을 반올림 경로로 우회 | 동일 |

### Remarks

### 관찰 가능한 변화 (Jira Specification Changes)

- NUMERIC SUM/AVG(집계·분석 함수)의 40자리 초과 결과가 같은 값을 `+`로 순서대로 더한 결과와 일치한다.
  - #7763 Remarks의 "40자리 초과 누적 결과가 더 정확해진다"를 철회한다. 
  - 결과는 레거시(행 단위 반올림)와 다시 동일해지므로, 예고했던 40자리 초과 answer 갱신(14행)은 필요하지 않다.
- 40자리 이하 구간의 결과·성능은 변하지 않는다. 
  - 추가 비용은 행당 3워드 비교 1회다.
- 병렬 집계에서 부분합 병합 순서에 따른 40자리 초과 결과 차이는 기존과 동일하게 존재한다(이항 연산의 결합 순서 차이와 같은 성질, 본 이슈 범위 밖).

### 검증

- Repro의 `sum(n)`이 `chain`과 같은 값(10^40)을 반환한다.
- 뺄셈·스케일 혼합 케이스(`9999...9999`(40자리) + `-0.5` + `-0.5`)에서 `sum(n)`이 `chain`과 일치한다.
