### PR TITLE
[CBRD-27407] Keep the hash aggregate partial list writable after a parallel scan merges worker lists into it

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -5630,8 +5630,32 @@ qexec_groupby (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_stat
   if (gbstate.hash_eligible && gbstate.agg_hash_context->tuple_count > 0
       && mht_count (gbstate.agg_hash_context->hash_table) > 0)
     {
+      QFILE_LIST_ID *part_list_id = gbstate.agg_hash_context->part_list_id;
+
       /* reopen unsorted list to accept new tuples */
       if (qfile_reopen_list_as_append_mode (thread_p, list_id) != NO_ERROR)
+	{
+	  GOTO_EXIT_ON_ERROR;
+	}
+
+      /* After a parallel scan, the partial list holds the merged worker lists. The
+       * list is closed, and its tuple descriptor is missing when the main list was
+       * empty and the worker list was copied to it. Restore both before appending.
+       */
+      if (part_list_id->tpl_descr.f_valp == NULL && part_list_id->type_list.type_cnt > 0)
+	{
+	  size_t size = sizeof (DB_VALUE *) * part_list_id->type_list.type_cnt;
+
+	  part_list_id->tpl_descr.f_valp = (DB_VALUE **) malloc (size);
+	  if (part_list_id->tpl_descr.f_valp == NULL)
+	    {
+	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, size);
+	      GOTO_EXIT_ON_ERROR;
+	    }
+	  part_list_id->tpl_descr.f_cnt = part_list_id->type_list.type_cnt;
+	}
+      if (part_list_id->tuple_cnt > 0 && part_list_id->last_pgptr == NULL
+	  && qfile_reopen_list_as_append_mode (thread_p, part_list_id) != NO_ERROR)
 	{
 	  GOTO_EXIT_ON_ERROR;
 	}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27407

### Purpose

파티션 테이블에 GROUP BY를 수행하면 파티션마다 스캔이 열리고, parallel scan 여부도 파티션마다 정해진다.
작은 파티션은 메인 스레드가 직접 해시 집계하고, 큰 파티션은 워커가 해시 집계한 뒤 결과를 부분 리스트로 넘긴다.

메인이 워커 부분 리스트를 자기 부분 리스트에 병합할 때(`merge_list_ids`), 메인 리스트가 비어 있으면 워커 리스트 객체를 `qfile_copy_list_id`로 그대로 넘겨받는다.
이 복사는 tuple descriptor(`tpl_descr.f_valp`)를 비우고, 워커가 닫아 둔 리스트라 닫힌 상태로 남긴다.
그 뒤 `qexec_groupby`가 메인 해시 테이블에 남은 그룹(메인이 직접 처리한 파티션)을 같은 부분 리스트에 내려쓰면서 `qdata_save_agg_hentry_to_list`가 NULL 배열에 쓰다 서버가 종료된다.

일반 테이블은 메인 해시 테이블이 비어 있어 이 내려쓰기가 없고, parallel scan이 아니면 병합이 없다.
CBRD-27326으로 parallel scan 진입 임계가 256페이지로 낮아지면서 10만 행 파티션 테이블이 이 경로에 들어와 드러났다.

### Implementation

`query_executor.c` `qexec_groupby`: 메인 해시 테이블을 부분 리스트에 내려쓰기 직전에 리스트를 쓸 수 있는 상태로 되돌린다.

- `tpl_descr.f_valp`가 없으면 `type_list.type_cnt` 크기로 다시 할당하고 `f_cnt`를 맞춘다.
- 튜플이 있는데 닫혀 있으면(`last_pgptr == NULL`) `qfile_reopen_list_as_append_mode`로 다시 연다. 
- 바로 위에서 unsorted list(`list_id`)에 하는 처리와 같다.

병합(`merge_list_ids`)과 `qfile_copy_list_id`는 그대로 둔다. 
병합은 parallel scan이 결과를 메인에 넘기는 공통 경로이고, 복사 시 descriptor를 비우는 것은 원본과 배열을 공유하지 않기 위한 의도된 동작이다.

빠진 것은 "병합 뒤 메인이 그 리스트에 이어 쓰는 경우"에 대한 대비이며, 이 경우는 파티션 스캔에서만 생기므로 이어 쓰는 지점에서 처리한다.
병합 시점에 메인 해시를 먼저 내리는 방법은 파티션 순서(큰 파티션이 먼저)에 따라 효과가 없고 실행기의 내려쓰기 절차를 px 코드에 복제해야 하므로 택하지 않았다.

### Remarks

- 재현: 
  - 파티션 테이블 + parallel scan(힙 256페이지 이상) + 해시 집계(GROUP BY 기본). 
  - 세 조건 중 하나라도 빠지면 재현되지 않는다(일반 테이블 / `NO_PARALLEL_SCAN` / `NO_HASH_AGGREGATE` 모두 정상).
- 검증: 
  - 재현 질의(파티션 재구성 유무, `count(id)`/`count(*)`/`sum(id)`)가 정상 종료하고, 결과가 `NO_PARALLEL_SCAN`, `NO_HASH_AGGREGATE` 실행과 행 단위로 동일하다. 
  - 수정 후에도 trace에 `parallel workers: 2`, `GROUPBY hash: partial`이 찍힌다. 
  - 즉 병렬 스캔과 해시 집계를 우회한 것이 아니라, 코어가 나던 경로를 그대로 실행하고 정상 종료한다.
