### PR TITLE
[CBRD-27409] Use CLOCK_MONOTONIC in tsc_getticks for microsecond-precision elapsed time measurement

### DIFF
--- a/src/base/tsc_timer.c
+++ b/src/base/tsc_timer.c
@@ -92,8 +92,9 @@ tsc_getticks (TSC_TICKS * tck)
       gettimeofday (&(tck->tv), NULL);
 #else
       struct timespec ts;
-      /* replace gettimeofday with clock_gettime for performance */
-      clock_gettime (CLOCK_REALTIME_COARSE, &ts);
+      /* replace gettimeofday with clock_gettime(CLOCK_MONOTONIC) for performance and monotonicity,
+       * avoiding CLOCK_REALTIME_COARSE's low resolution and exposure to NTP jumps */
+      clock_gettime (CLOCK_MONOTONIC, &ts);
       tck->tv.tv_sec = ts.tv_sec;
       tck->tv.tv_usec = ts.tv_nsec / 1000;
 #endif


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27409

### Purpose

`tsc_getticks()`(`src/base/tsc_timer.c`)가 `power_savings` 모드에서 `CLOCK_REALTIME_COARSE`로 경과 시간을 측정하고 있어, 환경별 HZ 설정에 따라 1~4ms인 coarse 해상도 때문에 1ms 미만 작업의 경과 시간이 0ms 또는 1tick으로 양자화되어 측정되는 문제(이 dev 박스 실측 43%가 0으로 측정)와, non-monotonic이라 NTP 조정 등으로 시간이 역행할 수 있는 문제를 해결합니다.

### Implementation

- `src/base/tsc_timer.c:96`: `CLOCK_REALTIME_COARSE` → `CLOCK_MONOTONIC`

### Remarks

- `CLOCK_MONOTONIC_COARSE`도 검토했으나, 두 COARSE clock은 같은 커널 tick 캐시를 공유해 HZ 설정과 무관하게 항상 `CLOCK_REALTIME_COARSE`와 동일한 해상도(HZ=1000이면 1ms, HZ=250이면 4ms. 이 dev 박스는 `clock_getres()` 실측 1ms)이므로 monotonic 보장만 얻을 뿐 `tsc_elapsed_time_usec()` 등이 필요로 하는 µs 단위 정밀도는 여전히 얻지 못합니다.
- 호출당 오버헤드는 이 dev 박스 기준 COARSE ~7ns에서 MONOTONIC ~22ns로 늘어납니다(+15ns). `tsc_getticks()` 호출부 대부분은 perfmon/스레드 모니터링/trace 등 다양한 조건으로 게이트돼 있어 기본 운영에선 호출되지 않고, 게이트 없이 항상 도는 `critical_section.c`의 잠금 획득 시간 측정(14곳)조차 `pthread_mutex_lock`/`unlock` 비용에 비하면 무시할 수 있는 수준이라 성능 영향은 없다고 판단해 `CLOCK_MONOTONIC`을 채택했습니다.