### PR TITLE
[CUBRIDQA-1582] Pick the CTP branch, and carry a dead shard's cases into a re-run

### DIFF
--- a/.github/workflows/gha-ci.yml
+++ b/.github/workflows/gha-ci.yml
@@ -75,7 +75,7 @@ on:
         default: ""
         type: string
       sabotage:
-        description: "Break the split on purpose to check the guards: none | empty-shard | lose-shard"
+        description: "Break the split on purpose to check the guards: none | empty-shard | lose-shard | kill-shard"
         required: false
         default: "none"
         type: string
@@ -722,8 +722,8 @@ jobs:
             echo "::error::limit must be an integer"; exit 1
           fi
           case "$IN_SAB" in
-            none|empty-shard|lose-shard) ;;
-            *) echo "::error::sabotage must be none|empty-shard|lose-shard"; exit 1 ;;
+            none|empty-shard|lose-shard|kill-shard) ;;
+            *) echo "::error::sabotage must be none|empty-shard|lose-shard|kill-shard"; exit 1 ;;
           esac
           if [ -n "$IN_RERUN" ] && [[ ! "$IN_RERUN" =~ ^[0-9]{1,20}$ ]]; then
             echo "::error::rerun_from must be a run id (integer)"; exit 1
@@ -1116,6 +1116,13 @@ jobs:
               echo "::warning::sabotage=lose-shard, deleting shard 00's share file. shard 00 must fail"
               rm -f "$rundir/shards/00.list"
               ;;
+            kill-shard)
+              # The other two take the share away, so there is nothing left to carry
+              # into a re-run. This one leaves it whole and kills the shard before it
+              # reads anything -- the shape a pod that dies at the hook layer leaves.
+              echo "::warning::sabotage=kill-shard, shard 00 will die with its share intact. shard 00 must fail"
+              : > "$rundir/shards/00.kill"
+              ;;
           esac
 
           # --- matrix ---
@@ -1210,6 +1217,14 @@ jobs:
         run: |
           set -eo pipefail
           printf 'start\t%s\n' "$(date -u +%s)" > "$STAMPS/shard-${IDX}.tsv"
+
+          # sabotage=kill-shard. Here, not in a step of its own: dying in the first
+          # step with the share untouched is the shape a pod lost at the hook layer
+          # leaves, and what the re-run has to carry.
+          if [ -f "$RUNDIR/shards/${IDX}.kill" ]; then
+            echo "::error::sabotage=kill-shard: shard ${IDX} is dying on purpose, with its share intact"
+            exit 1
+          fi
 
           # Without shareProcessNamespace, PID 1 never reaps the double-forked server,
           # so `cubrid server stop` waits forever and the job hangs to the timeout.

--- a/.github/workflows/gha-ci.yml
+++ b/.github/workflows/gha-ci.yml
@@ -700,6 +700,9 @@ jobs:
       tc_branch: ${{ steps.tc.outputs.tc_branch }}
       ctp_sha: ${{ steps.tc.outputs.ctp_sha }}
       ctp_branch: ${{ steps.tc.outputs.ctp_branch }}
+      rerun_want: ${{ steps.split.outputs.rerun_want }}
+      rerun_unrun: ${{ steps.split.outputs.rerun_unrun }}
+      rerun_short: ${{ steps.split.outputs.rerun_short }}
 
     steps:
       - name: Validate inputs
@@ -906,7 +909,10 @@ jobs:
             | { grep -P '/([^/]+)/cases/\1\.sh$' || :; } \
             | sed "s#^$TC_DIR/#cubrid-testcases-private-ex/#" \
             | sort > /tmp/all.list
-          # Re-run only failures. failed.list is <shard>\t<shell/...>; align the prefix.
+          # Re-run what the source run left unhandled: its failures, and the share of
+          # any shard that died whole. failed.list is <shard>\t<shell/...>; align the
+          # prefix. Published whether or not this is a re-run -- collect's guard reads them.
+          want=0; unrun=0; short=0
           if [ -n "$RERUN_FROM" ]; then
             src="$CI_ROOT/runs/$RERUN_FROM/failed.list"
             if [ ! -f "$src" ]; then
@@ -937,12 +943,45 @@ jobs:
               echo "  A re-run may only re-run the failures of the same commit. Use /run all."
               exit 1
             fi
-            cut -f2 "$src" | sed 's#^#cubrid-testcases-private-ex/#' | sort -u > /tmp/want.list
+            # failed.list is built from test-shell.xml, so a shard that died whole is
+            # absent from it: it published no XML. Re-running failed.list alone would
+            # leave that share unrun and still end green, because every guard measures
+            # a run against its own split. Carry the share over here.
+            srcdir="$CI_ROOT/runs/$RERUN_FROM"
+            : > /tmp/unrun.list
+            for f in "$srcdir"/shards/*.list; do
+              [ -f "$f" ] || continue
+              i=$(basename "$f" .list)
+              st="$srcdir/results/$i/test_status.data"
+              if [ ! -f "$st" ]; then
+                # The suite never ran there, so the whole share is unrun. The file
+                # already carries the repo prefix want.list uses.
+                cat "$f" >> /tmp/unrun.list
+                continue
+              fi
+              # It ran, but handled fewer than it was given. Nothing records which
+              # ones were left, so they can be counted and never named.
+              a=$(wc -l < "$f")
+              h=$(awk -F= '/total_executed_case_count/ {e=$2+0}
+                           /total_skip_case_count/     {k=$2+0}
+                           END {print e + k + 0}' "$st")
+              [ "$a" -gt "$h" ] && short=$((short + a - h))
+            done
+            unrun=$(wc -l < /tmp/unrun.list)
+
+            cut -f2 "$src" | sed 's#^#cubrid-testcases-private-ex/#' > /tmp/want.list
+            cat /tmp/unrun.list >> /tmp/want.list
+            sort -u -o /tmp/want.list /tmp/want.list
             want=$(wc -l < /tmp/want.list)
+            echo "from run $RERUN_FROM: $(wc -l < "$src") failed + $unrun unrun in shards that died whole"
+            if [ "$short" -gt 0 ]; then
+              echo "::warning::run $RERUN_FROM left $short more cases assigned but never handled."
+              echo "::warning::  Nothing names them, so this re-run cannot carry them and cannot pass."
+            fi
             # Keep only what is in the tree now; cases deleted since are dropped.
             grep -xF -f /tmp/want.list /tmp/all.list > /tmp/cases.list || : > /tmp/cases.list
             got=$(wc -l < /tmp/cases.list)
-            echo "re-running: $got of the $want failures from run $RERUN_FROM are still in the tree"
+            echo "re-running: $got of the $want cases from run $RERUN_FROM are still in the tree"
             if [ "$got" -ne "$want" ]; then
               echo "::warning::$((want - got)) are not in the tree now (deleted or renamed)"
               comm -23 /tmp/want.list <(sort /tmp/cases.list) | sed 's/^/  missing: /'
@@ -957,7 +996,8 @@ jobs:
           # Zero from a re-run and zero from a broken glob have different causes.
           if [ "$total" -eq 0 ]; then
             if [ -n "$RERUN_FROM" ]; then
-              echo "::error::nothing to run: none of the failures from run $RERUN_FROM can be run now"
+              echo "::error::nothing to run: none of the $want cases run $RERUN_FROM left unhandled can be run now"
+              echo "  That run had $unrun unrun and $(wc -l < "$src") failed. Use /run shell for a full run."
             else
               echo "::error::no cases at all: the glob matched nothing. Check the testcase tree"
             fi
@@ -1085,6 +1125,9 @@ jobs:
             echo "total=$total"
             echo "timed=$timed"
             echo "rundir=$rundir"
+            echo "rerun_want=$want"
+            echo "rerun_unrun=$unrun"
+            echo "rerun_short=$short"
           } >> "$GITHUB_OUTPUT"
           echo
           echo "published: $rundir"
@@ -1539,6 +1582,24 @@ jobs:
           tcread_n=$(find "$RUNDIR/results" -mindepth 2 -maxdepth 2 -name tc.read 2>/dev/null | wc -l)
           echo "shard: planned $planned / published $done_n / build provenance $read_n / tc provenance $tcread_n"
 
+          # Cases a shard that died whole never ran. They reach no test-shell.xml, so
+          # the failure list below cannot see them; without this count the summary
+          # would offer no way to get them run.
+          unrun_n=0
+          dead_n=0
+          : > /tmp/dead_shards.list
+          for f in "$RUNDIR"/shards/*.list; do
+            [ -f "$f" ] || continue
+            i=$(basename "$f" .list)
+            [ -f "$RUNDIR/results/$i/test_status.data" ] && continue
+            n=$(wc -l < "$f")
+            dead_n=$((dead_n + 1))
+            unrun_n=$((unrun_n + n))
+            printf 'shard %s: %s cases\n' "$i" "$n" >> /tmp/dead_shards.list
+          done
+          echo "shards that never ran a case: $dead_n / cases left unrun: $unrun_n"
+          [ "$dead_n" -eq 0 ] || cat /tmp/dead_shards.list
+
           : > /tmp/agg.tsv
           for d in "$RUNDIR"/results/*/; do
             i=$(basename "$d")
@@ -1562,7 +1623,7 @@ jobs:
           skip_sum=$(awk -F'\t' '{s+=$6} END {print s+0}' /tmp/agg.tsv)
           echo "run $exec_sum / passed $succ_sum / failed $fail_sum / skipped $skip_sum (of $TOTAL)"
 
-          for k in planned done_n read_n tcread_n exec_sum succ_sum fail_sum skip_sum; do
+          for k in planned done_n read_n tcread_n dead_n unrun_n exec_sum succ_sum fail_sum skip_sum; do
             echo "$k=${!k}" >> "$GITHUB_OUTPUT"
           done
 
@@ -1838,6 +1899,11 @@ jobs:
           CTP_SHA: ${{ needs.plan.outputs.ctp_sha }}
           CTP_BRANCH: ${{ needs.plan.outputs.ctp_branch }}
           RERUN_FROM: ${{ needs.gate.outputs.rerun_from }}   # names the source run in the summary
+          UNRUN_N: ${{ steps.gather.outputs.unrun_n }}
+          DEAD_N: ${{ steps.gather.outputs.dead_n }}
+          RERUN_WANT: ${{ needs.plan.outputs.rerun_want }}
+          RERUN_UNRUN: ${{ needs.plan.outputs.rerun_unrun }}
+          RERUN_SHORT: ${{ needs.plan.outputs.rerun_short }}
           C_QUEUE: ${{ steps.clock.outputs.clock_queue }}
           C_BUILD: ${{ steps.clock.outputs.clock_build }}
           C_PLAN: ${{ steps.clock.outputs.clock_plan }}
@@ -1872,7 +1938,10 @@ jobs:
             echo
             # Name the source run at the top: results land under the new run id.
             if [ -n "$RERUN_FROM" ]; then
-              echo "> **Only the failures from run \`$RERUN_FROM\` were re-run. This is not a full run.**"
+              echo "> **Only what run \`$RERUN_FROM\` left unhandled was re-run. This is not a full run.**"
+              echo ">"
+              echo "> carried over: $RERUN_WANT cases — its failures, plus $RERUN_UNRUN that never ran because a shard died whole."
+              [ "${RERUN_SHORT:-0}" -eq 0 ] || echo "> **$RERUN_SHORT more were assigned there and never handled. Nothing names them, so this run cannot pass.**"
               echo ">"
               echo "> source run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$RERUN_FROM"
               echo
@@ -1886,6 +1955,8 @@ jobs:
             echo "| run | $EXEC_SUM |"
             echo "| skipped | $SKIP_SUM |"
             echo "| handled | $covered / $TOTAL $v_cov |"
+            s_dead=shards; [ "${DEAD_N:-0}" -eq 1 ] && s_dead=shard
+            [ "${UNRUN_N:-0}" -eq 0 ] || echo "| **never run** | **$UNRUN_N** cases in $DEAD_N $s_dead that died whole |"
             echo "| passed | $SUCC_SUM |"
             echo "| **failed** | **$FAIL_SUM** |"
             echo "| cases split by measured timings | $TIMED |"
@@ -1943,12 +2014,24 @@ jobs:
               head -50 /tmp/failed.list | awk -F'\t' '{printf "| %s | `%s` |\n", $1, $2}'
               [ "$FAILED_N" -gt 50 ] && echo && echo "_... and $((FAILED_N - 50)) more. The full list is \`$RUNDIR/failed.list\`_"
               echo
+            else
+              echo "### No failed cases"
+              echo
+            fi
+            if [ "${UNRUN_N:-0}" -gt 0 ]; then
+              echo "### Never run ($UNRUN_N)"
+              echo
+              echo "$DEAD_N $s_dead died before running a case, so these never ran and are in no failure list."
+              echo "A re-run of this run carries them: they are not lost, but they are not green either."
+              echo
+              awk '{print "- `" $0 "`"}' /tmp/dead_shards.list
+              echo
+            fi
+            if [ "$FAILED_N" -gt 0 ] || [ "${UNRUN_N:-0}" -gt 0 ]; then
               # The CTP branch has to ride along, or the re-run silently takes develop.
               rerun_cmd="/run rerun $GITHUB_RUN_ID"
               [ "$CTP_BRANCH" = develop ] || rerun_cmd="$rerun_cmd testtools=$CTP_BRANCH"
-              echo "Re-run just these: \`$rerun_cmd\`"
-            else
-              echo "### No failed cases"
+              echo "Re-run the failures and everything that never ran: \`$rerun_cmd\`"
             fi
             echo
             echo "---"
@@ -2010,6 +2093,16 @@ jobs:
           esac
           if [ "$FAIL_SUM" -gt 0 ]; then
             echo "::error::$FAIL_SUM failed"
+            rc=1
+          fi
+          # A re-run replaces the source run's commit status, so it must not be able
+          # to report green over cases the source never handled. The share of a shard
+          # that died whole is carried over by plan and is covered by the checks
+          # above. What cannot be carried is a shard that ran and stopped early:
+          # nothing records which of its cases were left, so they can only be counted.
+          if [ -n "$RERUN_FROM" ] && [ "${RERUN_SHORT:-0}" -gt 0 ]; then
+            echo "::error::run $RERUN_FROM left $RERUN_SHORT cases assigned but never handled, and nothing names them"
+            echo "  This re-run could not carry them, so it cannot stand in for that run. Use /run shell."
             rc=1
           fi
           [ "$rc" -eq 0 ] && echo "completed with no failures."

--- a/.github/workflows/gha-ci.yml
+++ b/.github/workflows/gha-ci.yml
@@ -967,6 +967,16 @@ jobs:
                            END {print e + k + 0}' "$st")
               [ "$a" -gt "$h" ] && short=$((short + a - h))
             done
+            # plan.tsv names every shard the split made. A share file that is gone
+            # takes its case names with it, so those can only be counted too --
+            # without this, a lost share file would let this re-run pass in silence.
+            if [ -f "$srcdir/plan.tsv" ]; then
+              while IFS=$'\t' read -r si scnt _; do
+                [ -n "$si" ] || continue
+                [ -f "$srcdir/shards/$si.list" ] && continue
+                short=$((short + scnt))
+              done < "$srcdir/plan.tsv"
+            fi
             unrun=$(wc -l < /tmp/unrun.list)
 
             cut -f2 "$src" | sed 's#^#cubrid-testcases-private-ex/#' > /tmp/want.list

--- a/.github/workflows/gha-ci.yml
+++ b/.github/workflows/gha-ci.yml
@@ -909,9 +909,7 @@ jobs:
             | { grep -P '/([^/]+)/cases/\1\.sh$' || :; } \
             | sed "s#^$TC_DIR/#cubrid-testcases-private-ex/#" \
             | sort > /tmp/all.list
-          # Re-run what the source run left unhandled: its failures, and the share of
-          # any shard that died whole. failed.list is <shard>\t<shell/...>; align the
-          # prefix. Published whether or not this is a re-run -- collect's guard reads them.
+          # failed.list is <shard>\t<shell/...>; align the prefix.
           want=0; unrun=0; short=0
           if [ -n "$RERUN_FROM" ]; then
             src="$CI_ROOT/runs/$RERUN_FROM/failed.list"
@@ -943,10 +941,8 @@ jobs:
               echo "  A re-run may only re-run the failures of the same commit. Use /run all."
               exit 1
             fi
-            # failed.list is built from test-shell.xml, so a shard that died whole is
-            # absent from it: it published no XML. Re-running failed.list alone would
-            # leave that share unrun and still end green, because every guard measures
-            # a run against its own split. Carry the share over here.
+            # A shard that died whole published no test-shell.xml, so failed.list
+            # cannot see its cases and a re-run of that list alone would end green.
             srcdir="$CI_ROOT/runs/$RERUN_FROM"
             : > /tmp/unrun.list
             for f in "$srcdir"/shards/*.list; do
@@ -954,22 +950,19 @@ jobs:
               i=$(basename "$f" .list)
               st="$srcdir/results/$i/test_status.data"
               if [ ! -f "$st" ]; then
-                # The suite never ran there, so the whole share is unrun. The file
-                # already carries the repo prefix want.list uses.
-                cat "$f" >> /tmp/unrun.list
+                cat "$f" >> /tmp/unrun.list   # already carries want.list's repo prefix
                 continue
               fi
-              # It ran, but handled fewer than it was given. Nothing records which
-              # ones were left, so they can be counted and never named.
+              # Handled fewer than it was given. Nothing records which were left, so
+              # they can be counted and never named.
               a=$(wc -l < "$f")
               h=$(awk -F= '/total_executed_case_count/ {e=$2+0}
                            /total_skip_case_count/     {k=$2+0}
                            END {print e + k + 0}' "$st")
               [ "$a" -gt "$h" ] && short=$((short + a - h))
             done
-            # plan.tsv names every shard the split made. A share file that is gone
-            # takes its case names with it, so those can only be counted too --
-            # without this, a lost share file would let this re-run pass in silence.
+            # A share file that is gone takes its case names with it; plan.tsv is the
+            # only remaining record that those cases existed.
             if [ -f "$srcdir/plan.tsv" ]; then
               while IFS=$'\t' read -r si scnt _; do
                 [ -n "$si" ] || continue
@@ -1127,9 +1120,7 @@ jobs:
               rm -f "$rundir/shards/00.list"
               ;;
             kill-shard)
-              # The other two take the share away, so there is nothing left to carry
-              # into a re-run. This one leaves it whole and kills the shard before it
-              # reads anything -- the shape a pod that dies at the hook layer leaves.
+              # The other two take the share away, leaving a re-run nothing to carry.
               echo "::warning::sabotage=kill-shard, shard 00 will die with its share intact. shard 00 must fail"
               : > "$rundir/shards/00.kill"
               ;;
@@ -1228,9 +1219,8 @@ jobs:
           set -eo pipefail
           printf 'start\t%s\n' "$(date -u +%s)" > "$STAMPS/shard-${IDX}.tsv"
 
-          # sabotage=kill-shard. Here, not in a step of its own: dying in the first
-          # step with the share untouched is the shape a pod lost at the hook layer
-          # leaves, and what the re-run has to carry.
+          # Dying here, before the share is read, is the shape a pod lost at the hook
+          # layer leaves.
           if [ -f "$RUNDIR/shards/${IDX}.kill" ]; then
             echo "::error::sabotage=kill-shard: shard ${IDX} is dying on purpose, with its share intact"
             exit 1
@@ -1607,9 +1597,7 @@ jobs:
           tcread_n=$(find "$RUNDIR/results" -mindepth 2 -maxdepth 2 -name tc.read 2>/dev/null | wc -l)
           echo "shard: planned $planned / published $done_n / build provenance $read_n / tc provenance $tcread_n"
 
-          # Cases a shard that died whole never ran. They reach no test-shell.xml, so
-          # the failure list below cannot see them; without this count the summary
-          # would offer no way to get them run.
+          # These reach no test-shell.xml, so the failure list below cannot see them.
           unrun_n=0
           dead_n=0
           : > /tmp/dead_shards.list
@@ -2120,11 +2108,9 @@ jobs:
             echo "::error::$FAIL_SUM failed"
             rc=1
           fi
-          # A re-run replaces the source run's commit status, so it must not be able
-          # to report green over cases the source never handled. The share of a shard
-          # that died whole is carried over by plan and is covered by the checks
-          # above. What cannot be carried is a shard that ran and stopped early:
-          # nothing records which of its cases were left, so they can only be counted.
+          # A re-run replaces the source run's commit status, so it must not go green
+          # over cases nothing can name. A dead shard's share is carried by plan; this
+          # is what is left.
           if [ -n "$RERUN_FROM" ] && [ "${RERUN_SHORT:-0}" -gt 0 ]; then
             echo "::error::run $RERUN_FROM left $RERUN_SHORT cases assigned but never handled, and nothing names them"
             echo "  This re-run could not carry them, so it cannot stand in for that run. Use /run shell."

--- a/.github/workflows/gha-ci.yml
+++ b/.github/workflows/gha-ci.yml
@@ -703,6 +703,7 @@ jobs:
       rerun_want: ${{ steps.split.outputs.rerun_want }}
       rerun_unrun: ${{ steps.split.outputs.rerun_unrun }}
       rerun_short: ${{ steps.split.outputs.rerun_short }}
+      rerun_gone: ${{ steps.split.outputs.rerun_gone }}
 
     steps:
       - name: Validate inputs
@@ -910,7 +911,7 @@ jobs:
             | sed "s#^$TC_DIR/#cubrid-testcases-private-ex/#" \
             | sort > /tmp/all.list
           # failed.list is <shard>\t<shell/...>; align the prefix.
-          want=0; unrun=0; short=0
+          want=0; unrun=0; short=0; gone=0
           if [ -n "$RERUN_FROM" ]; then
             src="$CI_ROOT/runs/$RERUN_FROM/failed.list"
             if [ ! -f "$src" ]; then
@@ -984,6 +985,14 @@ jobs:
             # Keep only what is in the tree now; cases deleted since are dropped.
             grep -xF -f /tmp/want.list /tmp/all.list > /tmp/cases.list || : > /tmp/cases.list
             got=$(wc -l < /tmp/cases.list)
+            # A failed case that is gone is ambiguous -- deleting it can be the fix.
+            # One that never ran is not: nothing was ever recorded about it.
+            sort -u /tmp/unrun.list > /tmp/unrun.sorted
+            gone=$(comm -23 /tmp/unrun.sorted /tmp/all.list | wc -l)
+            if [ "$gone" -gt 0 ]; then
+              echo "::warning::$gone of the $unrun unrun cases are no longer in the tree"
+              comm -23 /tmp/unrun.sorted /tmp/all.list | sed 's/^/  gone: /'
+            fi
             echo "re-running: $got of the $want cases from run $RERUN_FROM are still in the tree"
             if [ "$got" -ne "$want" ]; then
               echo "::warning::$((want - got)) are not in the tree now (deleted or renamed)"
@@ -1136,6 +1145,7 @@ jobs:
             echo "rerun_want=$want"
             echo "rerun_unrun=$unrun"
             echo "rerun_short=$short"
+            echo "rerun_gone=$gone"
           } >> "$GITHUB_OUTPUT"
           echo
           echo "published: $rundir"
@@ -1917,6 +1927,7 @@ jobs:
           RERUN_WANT: ${{ needs.plan.outputs.rerun_want }}
           RERUN_UNRUN: ${{ needs.plan.outputs.rerun_unrun }}
           RERUN_SHORT: ${{ needs.plan.outputs.rerun_short }}
+          RERUN_GONE: ${{ needs.plan.outputs.rerun_gone }}
           C_QUEUE: ${{ steps.clock.outputs.clock_queue }}
           C_BUILD: ${{ steps.clock.outputs.clock_build }}
           C_PLAN: ${{ steps.clock.outputs.clock_plan }}
@@ -1955,6 +1966,7 @@ jobs:
               echo ">"
               echo "> carried over: $RERUN_WANT cases — its failures, plus $RERUN_UNRUN that never ran because a shard died whole."
               [ "${RERUN_SHORT:-0}" -eq 0 ] || echo "> **$RERUN_SHORT more were assigned there and never handled. Nothing names them, so this run cannot pass.**"
+              [ "${RERUN_GONE:-0}" -eq 0 ] || echo "> **$RERUN_GONE of those that never ran are no longer in the tree, so this run cannot pass.**"
               echo ">"
               echo "> source run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$RERUN_FROM"
               echo
@@ -2114,6 +2126,12 @@ jobs:
           if [ -n "$RERUN_FROM" ] && [ "${RERUN_SHORT:-0}" -gt 0 ]; then
             echo "::error::run $RERUN_FROM left $RERUN_SHORT cases assigned but never handled, and nothing names them"
             echo "  This re-run could not carry them, so it cannot stand in for that run. Use /run shell."
+            rc=1
+          fi
+          if [ -n "$RERUN_FROM" ] && [ "${RERUN_GONE:-0}" -gt 0 ]; then
+            echo "::error::$RERUN_GONE cases that never ran in run $RERUN_FROM are no longer in the tree"
+            echo "  A renamed case has to run under its new name, and nothing was ever recorded"
+            echo "  about these. Use /run shell."
             rc=1
           fi
           [ "$rc" -eq 0 ] && echo "completed with no failures."

--- a/.github/workflows/gha-ci.yml
+++ b/.github/workflows/gha-ci.yml
@@ -10,6 +10,11 @@
 #   push develop, feature/**           build only. develop also writes the ccache
 #   workflow_dispatch                  build; tests always run
 #
+# Any request that runs the suite takes an optional trailing testtools=<branch> --
+# `/run shell testtools=fix/x` or the dispatch input -- and then CTP comes from that
+# cubrid-testtools branch instead of the image's develop. CircleCI's comment_trigger.yml
+# does not know the key, so a comment carrying it never reaches CircleCI.
+#
 # Which copy of this file runs differs by trigger. issue_comment has no ref of its
 # own and always reads the DEFAULT BRANCH, so /run does nothing until this is merged.
 # workflow_dispatch runs the copy in the ref it is given, and appears in the UI only
@@ -76,6 +81,11 @@ on:
         type: string
       pr:
         description: "Engine PR number. Testcases come from tc/pr-<number> and results are posted there"
+        required: false
+        default: ""
+        type: string
+      testtools:
+        description: "cubrid-testtools branch to take CTP from; empty means develop"
         required: false
         default: ""
         type: string
@@ -156,6 +166,7 @@ jobs:
       force_build: ${{ steps.g.outputs.force_build }}
       rerun_from: ${{ steps.g.outputs.rerun_from }}
       sabotage: ${{ steps.g.outputs.sabotage }}
+      testtools: ${{ steps.g.outputs.testtools }} # CTP branch; empty means develop
     steps:
       - name: Resolve the trigger
         id: g
@@ -177,6 +188,7 @@ jobs:
           IN_FORCE: ${{ inputs.force_build }}
           IN_RERUN: ${{ inputs.rerun_from }}
           IN_SAB: ${{ inputs.sabotage }}
+          IN_TT: ${{ inputs.testtools }}
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
         run: |
@@ -186,7 +198,7 @@ jobs:
 
           # Knobs no path but workflow_dispatch exposes. plan clamps parallelism when
           # rerun_from is set, so both rerun paths land on one shard.
-          par=50; limit=0; force=false; rerun=''; sab=none
+          par=50; limit=0; force=false; rerun=''; sab=none; tt=''
           # Builds only, PR namespace, ccache read-only. Each branch below narrows this.
           test_run=false; pr=''; ns='pr'; cache_write=false
 
@@ -212,23 +224,38 @@ jobs:
               # A dispatch supplies every value; pass them through.
               sha="$IN_SHA"; pr="$IN_PR"
               par="$IN_PAR"; limit="$IN_LIMIT"; force="$IN_FORCE"
-              rerun="$IN_RERUN"; sab="$IN_SAB"
+              rerun="$IN_RERUN"; sab="$IN_SAB"; tt="$IN_TT"
               test_run=true
               echo "dispatch: sha=${sha} pr=${pr:-(none)} parallelism=${par}"
               ;;
 
             issue_comment)
               pr="$ISSUE"
+              # A trailing testtools=<branch> is taken off first, so both grammars below
+              # read the request without it and neither regex had to change.
+              req="$BODY"
+              if [[ "$req" =~ ^(/run[[:space:]].*)[[:space:]]+testtools=([^[:space:]]+)[[:space:]]*$ ]]; then
+                req="${BASH_REMATCH[1]}"
+                tt="${BASH_REMATCH[2]}"
+                echo "comment: CTP from cubrid-testtools branch ${tt}"
+              fi
               # Checked before the shared grammar so that regex can stay byte-identical
               # to comment_trigger.yml. The run id comes from the comment collect posts.
-              if [[ "$BODY" =~ ^/run[[:space:]]+rerun[[:space:]]+([0-9]{1,20})[[:space:]]*$ ]]; then
+              if [[ "$req" =~ ^/run[[:space:]]+rerun[[:space:]]+([0-9]{1,20})[[:space:]]*$ ]]; then
                 rerun="${BASH_REMATCH[1]}"
                 test_run=true
                 echo "comment: re-run only the failures of run ${rerun}"
               # Regex must stay identical to comment_trigger.yml: one syntax to learn.
-              elif [[ "$BODY" =~ ^/run([[:space:]]+(all|shell|sql|medium)){1,4}$ ]]; then
+              elif [[ "$req" =~ ^/run([[:space:]]+(all|shell|sql|medium)){1,4}$ ]]; then
                 # Only shell lives here; sql and medium are CircleCI's.
-                if ! [[ "$BODY" =~ (^|[[:space:]])(all|shell)($|[[:space:]]) ]]; then
+                if ! [[ "$req" =~ (^|[[:space:]])(all|shell)($|[[:space:]]) ]]; then
+                  # Loud, not ignored: this comment reached the run concurrency group and
+                  # may have cancelled a suite, so silence would hide why it died.
+                  if [ -n "$tt" ]; then
+                    echo "::error::testtools= names a CTP branch, but this comment does not"
+                    echo "  ask for the shell suite: $BODY"
+                    exit 1
+                  fi
                   echo "[info] shell was not requested, ignoring: $BODY"
                   emit run false
                   exit 0
@@ -267,6 +294,15 @@ jobs:
           if [[ ! "$sha" =~ ^[0-9a-f]{40}$ ]]; then
             echo "::error::sha must be 40 lowercase hex characters, got: ${sha}"; exit 1
           fi
+          # The branch reaches git as `clone --branch` and `ls-remote`, so refuse
+          # anything but the shape a branch has. A leading dash would be read as an
+          # option, and `..` reaches outside the ref it names.
+          if [ -n "$tt" ] \
+             && { [[ ! "$tt" =~ ^[A-Za-z0-9][A-Za-z0-9._/-]{0,99}$ ]] || [[ "$tt" == *..* ]]; }; then
+            echo "::error::testtools must be a branch name of letters, digits and . _ / -"
+            echo "  starting with a letter or a digit, at most 100 of them. Got: ${tt}"
+            exit 1
+          fi
 
           emit run true
           emit test "$test_run"
@@ -279,6 +315,7 @@ jobs:
           emit force_build "$force"
           emit rerun_from "$rerun"
           emit sabotage "$sab"
+          emit testtools "$tt"
           echo "resolved: event=$EV test=$test_run namespace=$ns ccache_write=$cache_write"
 
   # The check ticket 28 makes required. Posted from here and not from collect: that
@@ -661,6 +698,8 @@ jobs:
       build_run_id: ${{ steps.build.outputs.build_run_id }}
       tc_sha: ${{ steps.tc.outputs.tc_sha }}
       tc_branch: ${{ steps.tc.outputs.tc_branch }}
+      ctp_sha: ${{ steps.tc.outputs.ctp_sha }}
+      ctp_branch: ${{ steps.tc.outputs.ctp_branch }}
 
     steps:
       - name: Validate inputs
@@ -748,6 +787,7 @@ jobs:
         env:
           GHI_TOKEN: ${{ steps.app-token.outputs.token }}
           INPUT_PR: ${{ needs.gate.outputs.pr }}
+          INPUT_TT: ${{ needs.gate.outputs.testtools }}
         run: |
           set -eo pipefail
           # Overlay first: the node seed (/ro) is the lowerdir, so entrypoint sees .git.
@@ -774,20 +814,20 @@ jobs:
           # "no such ref" and non-zero otherwise, so retry like the baseline's
           # resolve_sha (config.yml 168-179) and only fall back on a real absence --
           # a transient failure silently testing develop's cases misattributes results.
-          tc_probe() {
+          probe_branch() {
             local i rc
             for i in 1 2 3 4 5; do
               rc=0
-              git ls-remote --exit-code --heads "$TC_REPO" "$1" >/dev/null 2>&1 || rc=$?
+              git ls-remote --exit-code --heads "$1" "$2" >/dev/null 2>&1 || rc=$?
               [ "$rc" -eq 0 ] && return 0
               [ "$rc" -eq 2 ] && return 2
-              echo "::warning::ls-remote '$1' failed (attempt $i, exit $rc); retrying"
+              echo "::warning::ls-remote '$2' failed (attempt $i, exit $rc); retrying"
               sleep $((i * 3))
             done
             return 1
           }
           probe_rc=0
-          tc_probe "$TC_BRANCH" || probe_rc=$?
+          probe_branch "$TC_REPO" "$TC_BRANCH" || probe_rc=$?
           case "$probe_rc" in
             0) ;;
             2)
@@ -800,8 +840,32 @@ jobs:
           esac
           echo "tc branch  : $TC_BRANCH"
 
+          # CTP is the other half of the same checkout. The image defaults to develop,
+          # so only a named branch has to be decided here -- and it gets no fallback:
+          # running develop's CTP instead would report failures against a tree the
+          # requester never asked for. Probed rather than left to the entrypoint, whose
+          # clone retries five times over 100s before it says the branch is missing.
+          CTP_BRANCH="${INPUT_TT:-develop}"
+          if [ -n "$INPUT_TT" ]; then
+            CTP_REPO=https://github.com/CUBRID/cubrid-testtools.git
+            probe_rc=0
+            probe_branch "$CTP_REPO" "$CTP_BRANCH" || probe_rc=$?
+            case "$probe_rc" in
+              0) ;;
+              2)
+                echo "::error::cubrid-testtools has no branch '$CTP_BRANCH'. Push it there"
+                echo "  first, or drop testtools= to run CTP from develop."
+                exit 1 ;;
+              *)
+                echo "::error::could not reach $CTP_REPO after 5 attempts"; exit 1 ;;
+            esac
+          fi
+          echo "ctp branch : $CTP_BRANCH"
+
           # Same command the CircleCI test_shell runs on every node.
           export BRANCH_TESTCASES="$TC_BRANCH"
+          # CTP_BRANCH_NAME follows this in the entrypoint, so the CTP logs name it too.
+          export BRANCH_TESTTOOLS="$CTP_BRANCH"
           rx0=$(awk 'NR>2 {n=$1; sub(/:.*/,"",n); if (n!="lo") r+=$2} END {print r+0}' /proc/net/dev)
           /entrypoint.sh checkout shell
           rx1=$(awk 'NR>2 {n=$1; sub(/:.*/,"",n); if (n!="lo") r+=$2} END {print r+0}' /proc/net/dev)
@@ -811,9 +875,15 @@ jobs:
           TC_SHA=$(git -C "$TC_DIR" rev-parse HEAD)
           echo "tc SHA    : $TC_SHA"
           echo "tc HEAD   : $(git -C "$TC_DIR" log -1 --format='%ci %s')"
+          # The same pin for CTP: the shards take the branch tip again, and a push
+          # during the suite would leave them running different CTP from each other.
+          CTP_SHA=$(git -C "$WORKDIR/cubrid-testtools" rev-parse HEAD)
+          echo "ctp SHA   : $CTP_SHA"
           {
             echo "tc_sha=$TC_SHA"
             echo "tc_branch=$TC_BRANCH"
+            echo "ctp_sha=$CTP_SHA"
+            echo "ctp_branch=$CTP_BRANCH"
           } >> "$GITHUB_OUTPUT"
 
       - name: Case list and LPT split
@@ -1208,11 +1278,13 @@ jobs:
           APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: echo "::add-mask::$APP_TOKEN"
 
-      - name: Align testcases to the commit plan saw
+      - name: Align CTP and testcases to the commits plan saw
         env:
           GHI_TOKEN: ${{ steps.app-token.outputs.token }}
           TC_BRANCH: ${{ needs.plan.outputs.tc_branch }}
           WANT_TC_SHA: ${{ needs.plan.outputs.tc_sha }}
+          CTP_BRANCH: ${{ needs.plan.outputs.ctp_branch }}
+          WANT_CTP_SHA: ${{ needs.plan.outputs.ctp_sha }}
         run: |
           set -eo pipefail
           # CTP must be copied first: entrypoint needs .git to fetch instead of clone.
@@ -1220,8 +1292,25 @@ jobs:
             echo "::error::CTP is missing. The steps are in the wrong order"; exit 1; }
 
           export BRANCH_TESTCASES="$TC_BRANCH"
+          # Without this the checkout below moves the copied seed back to develop, and
+          # a suite asked to run another CTP branch would run develop's in every shard.
+          export BRANCH_TESTTOOLS="$CTP_BRANCH"
           rx0=$(awk 'NR>2 {n=$1; sub(/:.*/,"",n); if (n!="lo") r+=$2} END {print r+0}' /proc/net/dev)
           /entrypoint.sh checkout shell
+
+          # Pin CTP the way the testcases are pinned below: the checkout took the branch
+          # tip, which moves under a suite whose CTP branch is still being pushed to.
+          # The seed carries this commit already, so the fetch is only for the case where
+          # the tip moved and the object arrived from somewhere else.
+          ctp="$WORKDIR/cubrid-testtools"
+          git -C "$ctp" cat-file -e "${WANT_CTP_SHA}^{commit}" 2>/dev/null \
+            || git -C "$ctp" fetch -q --depth 1 --no-tags origin "$WANT_CTP_SHA"
+          git -C "$ctp" reset -q --hard "$WANT_CTP_SHA"
+          got_ctp=$(git -C "$ctp" rev-parse HEAD)
+          echo "ctp branch : $CTP_BRANCH"
+          echo "ctp SHA   : $got_ctp"
+          [ "$got_ctp" = "$WANT_CTP_SHA" ] || {
+            echo "::error::could not align CTP to the SHA plan saw($WANT_CTP_SHA); at $got_ctp"; exit 1; }
 
           # Pin to the commit plan saw. checkout aligns to the tip; undo that here.
           cd "$TC_DIR"
@@ -1746,6 +1835,8 @@ jobs:
           TCREAD_N: ${{ steps.gather.outputs.tcread_n }}
           TC_SHA: ${{ needs.plan.outputs.tc_sha }}
           TC_BRANCH: ${{ needs.plan.outputs.tc_branch }}
+          CTP_SHA: ${{ needs.plan.outputs.ctp_sha }}
+          CTP_BRANCH: ${{ needs.plan.outputs.ctp_branch }}
           RERUN_FROM: ${{ needs.gate.outputs.rerun_from }}   # names the source run in the summary
           C_QUEUE: ${{ steps.clock.outputs.clock_queue }}
           C_BUILD: ${{ steps.clock.outputs.clock_build }}
@@ -1821,6 +1912,15 @@ jobs:
             echo "| shards that recorded a tc provenance | $TCREAD_N / $PLANNED $v_tcread |"
             echo "| same commit across shards | $v_tcsame |"
             echo
+            echo "### CTP provenance"
+            echo
+            echo "| item | value |"
+            echo "|---|---|"
+            echo "| CTP branch | \`$CTP_BRANCH\` |"
+            echo "| CTP commit | \`$CTP_SHA\` |"
+            echo
+            echo "Every shard is reset to this commit, and one that cannot reach it fails."
+            echo
             echo "### Shards and wall clock"
             echo
             echo "| stage | time |"
@@ -1843,7 +1943,10 @@ jobs:
               head -50 /tmp/failed.list | awk -F'\t' '{printf "| %s | `%s` |\n", $1, $2}'
               [ "$FAILED_N" -gt 50 ] && echo && echo "_... and $((FAILED_N - 50)) more. The full list is \`$RUNDIR/failed.list\`_"
               echo
-              echo "Re-run just these: \`/run rerun $GITHUB_RUN_ID\`"
+              # The CTP branch has to ride along, or the re-run silently takes develop.
+              rerun_cmd="/run rerun $GITHUB_RUN_ID"
+              [ "$CTP_BRANCH" = develop ] || rerun_cmd="$rerun_cmd testtools=$CTP_BRANCH"
+              echo "Re-run just these: \`$rerun_cmd\`"
             else
               echo "### No failed cases"
             fi


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBRIDQA-1582>

### Purpose

두 가지를 담았다. 둘 다 가산적이고 기본 동작을 바꾸지 않는다.

**① 개발자가 CTP(`cubrid-testtools`)를 고친 채로 자기 PR 의 shell suite 를 돌릴 방법이 없었다.**

테스트 이미지가 `ENV BRANCH_TESTTOOLS=develop` 을 갖고, `gha-ci.yml` 은 그 값을 한 번도 세우지 않았다. 그래서 CTP 는 언제나 develop 이었다. 테스트케이스 쪽은 이미 PR 별로 갈린다 — plan 이 PR 번호로 `tc/pr-<N>` 을 고른다. CTP 만 구멍이었다.

우회로는 임시 브랜치에 push 한 뒤 `workflow_dispatch --ref` 로 돌리는 것뿐이었다. `/run` 은 언제나 기본 브랜치의 워크플로 사본을 읽는다. 그래서 PR 브랜치에 `gha-ci.yml` 수정을 얹어도 `/run` 에는 안 먹는다.

**② shard 하나가 케이스를 한 건도 못 돌리고 죽으면, 그 몫이 조용히 사라졌다.**

죽은 shard 는 결과 XML 을 안 남긴다. 그래서 그 케이스들이 `failed.list` 에 안 들어간다. `/run rerun <id>` 는 `failed.list` 만 읽어 케이스를 고르고, 재실행 run 의 판정은 **자기 split** 을 기준으로 한다. 결과가 둘로 갈렸다.

- 죽은 shard 와 케이스 실패가 **섞인** run → 재실행이 케이스 실패만 돌고 **초록**이 된다. 안 돈 케이스가 사라진 채 `gha-ci: test_shell` 이 통과한다. 9/10 부터 그게 머지 필수 체크다.
- 죽은 shard **만** 있는 run → 재실행이 "돌릴 것이 없다"로 끊긴다. summary 는 "No failed cases" 라 쓰고 재실행 명령도 주지 않는다. 사람이 할 수 있는 일이 전체 재실행뿐이었다.

첫 줄은 CircleCI 시절 실제로 난 사고와 같은 모양이다. 인프라 실패로 재수행한 run 이 체크를 초록으로 만들었고, 개발자가 문제 없다고 보고 머지했다. 그 PR 이 유발한 실패의 답지 수정이 안 들어가 다음 사람들이 계속 막혔다.

전제조건을 갖춘 run 이 실제로 있었다 — 9/09 의 run `34346402129` (케이스 실패 19 shard + 죽은 shard 1).

### Implementation

#### ① CTP 브랜치를 코멘트로 고른다

PR 에 이렇게 쓴다.

```
/run shell testtools=<브랜치>
/run all testtools=<브랜치>
/run rerun <run id> testtools=<브랜치>
```

`workflow_dispatch` 에도 `testtools` 입력이 생겼다.

**지정하지 않으면 지금과 같다.** 기본값은 develop 이고, 기존 `/run shell`·`/run all`·`/run rerun <id>` 의 동작은 한 군데도 바뀌지 않는다.

**없는 브랜치는 실패로 끊는다.** plan 이 `ls-remote` 로 먼저 확인한다. 없으면 그 자리에서 실패한다. develop 로 조용히 폴백하지 않는다 — 폴백하면 요청자가 안 고른 CTP 로 돌고, 실패가 그의 변경으로 오귀속된다. 네트워크 오류는 폴백이 아니라 재시도다.

**shard 50개가 한 커밋을 본다.** plan 이 자기가 체크아웃한 CTP 커밋을 발행하고, 각 shard 가 checkout 뒤 그 커밋으로 맞춘다. shard 의 checkout 은 브랜치 tip 을 잡는데, 그 tip 은 suite 가 도는 30~60분 사이에 움직인다 — 개발자가 바로 그 브랜치에 push 하는 중이기 때문이다. 맞추지 못한 shard 는 실패한다.

**summary 가 그 브랜치와 커밋을 보여준다.** `CTP provenance` 표가 새로 생겼다.

**코멘트 문법 처리.** 꼬리의 `testtools=<브랜치>` 토큰을 먼저 떼고, 남은 문장을 기존 정규식 둘에 그대로 물린다. 그래서 정규식이 한 글자도 안 바뀌었다 — 공용 문법은 `comment_trigger.yml` 과 여전히 완전히 같다.

#### ② 죽은 shard 가 안 돌린 케이스를 재실행이 이어받는다

**`/run rerun <id>` 가 두 가지를 같이 담는다.** 원본 run 에서 실패한 케이스, 그리고 통째로 죽은 shard 가 한 건도 못 돌린 케이스다. plan 이 원본 run 의 몫 목록과 결과를 대조해 CTP 상태 파일이 없는 shard 의 몫을 통째로 이어받는다.

**이어받을 수 없으면 재실행이 빨강으로 끝난다.** 경우가 둘이다 — shard 가 돌다 중간에 멈춘 경우, 그리고 몫 목록 파일 자체가 사라진 경우다. 어느 케이스가 남았는지 아무 데도 기록이 없어 이름을 붙일 수 없다. plan 이 그 수를 세고 collect 가 그 재실행을 통과시키지 않는다. 재실행이 조용히 원본을 대신하지 못하게 하는 것이 목적이고, 그 경우의 정답은 `/run shell` 전체 재실행이다.

**summary 가 안 돈 케이스를 드러낸다.** Coverage 표에 `never run` 줄이 생겼고, 죽은 shard 를 나열하고, **케이스 실패가 0건이어도** 재실행 명령을 준다. 재실행 화면 머리에는 몇 건을 이어받았는지 적는다.

**자동 재시도는 만들지 않았다.** 근거 둘이다.

- CTP 가 케이스 단위 재시도를 이미 한다 — `shell_ci.conf` 의 `testcase_retry_num=1`. 실패한 케이스를 뒤로 미뤘다 한 번 더 돌린다. ⚠ 코어가 떨어지거나 시간 초과된 케이스는 제외한다.
- 실측이 반대다. 8/20 이후 실패한 shard job 879건 중 808건(92%)이 진짜 케이스 실패다. 통째 사망 71건은 run 6개에 몰려 있고, 가장 큰 둘이 **결정론적**이다 — 50개 전부가 pod 설정 점검에서 죽은 run 하나, 15개가 `Set up job` 에서 죽은 run 하나. 재시도하면 그대로 다시 죽는다.

**`sabotage=kill-shard` 를 더했다.** 기존 `empty-shard`·`lose-shard` 는 몫을 없애 버려서 재실행이 이어받을 것을 안 남긴다. 새 모드는 몫을 남긴 채 shard 를 첫 step 에서 죽인다 — 훅 층에서 pod 를 잃었을 때의 모양이다.

### Remarks

**CTP 브랜치 쓰는 법**: 브랜치를 `CUBRID/cubrid-testtools` 에 push 한다. 그 뒤 PR 에 `/run shell testtools=<브랜치>` 를 쓴다.

**⚠ `testtools=` 를 단 코멘트는 CircleCI 를 안 태운다.** `comment_trigger.yml` 이 완전일치 정규식이라 그 코멘트를 무시한다. 그래서 `/run all testtools=<브랜치>` 는 sql·medium 을 안 돌린다. sql·medium 이 필요하면 `/run sql medium` 을 따로 쓴다.

**⚠ shell 을 안 물은 코멘트에 `testtools=` 를 달면 gate 가 실패로 끊는다.** 조용히 무시하지 않는다. 그 코멘트가 이미 run concurrency group 에 들어가 도는 suite 를 취소했을 수 있고, 침묵은 그 이유를 감춘다.

**⚠ 테스트케이스 트리를 고친 뒤의 재실행에는 한계가 있다.** `tc/pr-<N>` 갱신 자체는 문제없다 — plan 이 매번 tip 을 다시 잡고 shard 가 그 커밋으로 정렬하므로 새 답지가 쓰인다. 다만 재실행은 원본에서 실패한 케이스만 돌기 때문에 **새로 추가한 케이스는 안 돈다**. 그리고 케이스 이름을 바꾸면 재실행이 그것을 건너뛴다 — 삭제와 구분할 방법이 없어 지금은 경고만 낸다. 이 건은 별도 티켓으로 뺐다.

**검증.** 포크 저장소에서 `sabotage=kill-shard` 로 두 번 돌렸다.

| | 죽은 shard 의 몫 | 재실행 결과 |
|---|---|---|
| 1차 | 1건 | 1건 이어받아 초록 |
| 2차 | 21건 | 21건 다 이어받아 돌리고 초록 |

고치기 전이면 둘 다 "돌릴 것이 없다"로 끊겼을 자리다. 두 run 모두 `pr` 입력을 비워 commit status 는 쏘지 않았다.

여기서 기록 하나를 정정했다. 죽은 shard 를 가려내는 조건으로 `shard.done` 부재를 써 왔는데, 실물에서 그 조건이 **통과해 버렸다**(`planned 10 / published 10 OK`). `Publish results for collect` 가 `always()` 라 컨테이너만 살아 있으면 그 표시가 남기 때문이다. 믿을 수 있는 조건은 `test_status.data` 부재 하나이고, 이 변경이 그것을 쓴다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TfQsjDh4ejGXKyTLmTwtAK
