### PR TITLE
[CBRD-26218] Guard cursor tuple navigation against a NULL page buffer

### DIFF
--- a/src/query/cursor.c
+++ b/src/query/cursor.c
@@ -1516,6 +1516,16 @@ cursor_next_tuple (CURSOR_ID * cursor_id_p)
     {
       VPID next_vpid;
 
+      if (cursor_id_p->buffer == NULL)
+	{
+	  /* The cursor's page buffer has been released due to a previous fetch failure.
+	   * Page data referenced by tuple members is no longer valid;
+	   * neither the page header nor tuple pointers must be used.
+	   */
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QPROC_INVALID_CRSPOS, 0);
+	  return DB_CURSOR_ERROR;
+	}
+
       if (cursor_id_p->current_tuple_no < cursor_id_p->buffer_tuple_count - 1)
 	{
 	  cursor_id_p->tuple_no++;
@@ -1582,6 +1592,16 @@ cursor_prev_tuple (CURSOR_ID * cursor_id_p)
   else if (cursor_id_p->position == C_ON)
     {
       VPID prev_vpid;
+
+      if (cursor_id_p->buffer == NULL)
+	{
+	  /* The cursor's page buffer has been released due to a previous fetch failure.
+	   * Page data referenced by tuple members is no longer valid;
+	   * neither the page header nor tuple pointers must be used.
+	   */
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QPROC_INVALID_CRSPOS, 0);
+	  return DB_CURSOR_ERROR;
+	}
 
       if (cursor_id_p->current_tuple_no > 0)
 	{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26218

### Purpose

쿼리 취소(SIGUSR1)로 리스트파일 페이지 fetch가 -4(ER_INTERRUPTED)로 실패하면, 커서가 `buffer == NULL` 인데 `position == C_ON` 인 불일치 상태로 남는다.
이후 클라이언트가 같은 결과셋을 다시 요청하면 `cursor_next_tuple()` / `cursor_prev_tuple()` 이 페이지 헤더를 NULL 포인터로 읽어 CAS가 SIGSEGV로 죽는다.

참고로, JDBC는 cubrid-jdbc#72(APIS-1074)로 -4 수신 시 재요청하지 않도록 이미 수정 최신 JDBC에서는 재현이 되지 않는다.
다만 CCI/타 드라이버/구버전 JDBC 등 잘못 동작하는 클라이언트로부터 CAS를 보호하는 가드가 서버 측에도 필요하다.



