### PR TITLE
[CBRD-27363] Require the caller to be authorized for the owner named on a dblink server object(#7860)

### DIFF
--- a/src/object/authenticate.c
+++ b/src/object/authenticate.c
@@ -510,7 +510,16 @@ au_check_server_authorization (MOP server_object)
 bool
 au_is_server_authorized_user (DB_VALUE * owner_val)
 {
-  return (au_check_owner (owner_val) == NO_ERROR);
+  bool authorized;
+  int save;
+
+  /* au_check_owner () reads Au_user's "groups" bare: without this its group term drops out, and with
+   * no error. Disabling here rather than in each caller keeps every caller on the same predicate. */
+  AU_SAVE_AND_DISABLE (save);
+  authorized = (au_check_owner (owner_val) == NO_ERROR);
+  AU_RESTORE (save);
+
+  return authorized;
 }
 
 void

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -206,6 +206,9 @@ static void pt_check_method (PARSER_CONTEXT * parser, PT_NODE * node);
 static void pt_check_truncate (PARSER_CONTEXT * parser, PT_NODE * node);
 static void pt_check_kill (PARSER_CONTEXT * parser, PT_NODE * node);
 static void pt_check_alter_serial (PARSER_CONTEXT * parser, PT_NODE * node);
+static bool pt_check_one_server_owner (PARSER_CONTEXT * parser, PT_NODE * node, PT_NODE * owner_name,
+				       const char *statement);
+static void pt_check_server_owners (PARSER_CONTEXT * parser, PT_NODE * node);
 static void pt_check_update_stats (PARSER_CONTEXT * parser, PT_NODE * node);
 static PT_NODE *pt_check_single_valued_node (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk);
 static PT_NODE *pt_check_single_valued_node_post (PARSER_CONTEXT * parser, PT_NODE * node, void *arg,
@@ -10424,6 +10427,104 @@ pt_check_alter_serial (PARSER_CONTEXT * parser, PT_NODE * node)
 }
 
 /*
+ * pt_check_one_server_owner () - is the caller authorized for one owner named on a server statement?
+ *   return:  false if it raised an error, true otherwise
+ *   parser(in): the parser context used to derive the statement
+ *   node(in): the statement, for error positioning
+ *   owner_name(in): the owner qualifier, or NULL when the statement carries none
+ *   statement(in): the statement name to name in the error
+ */
+static bool
+pt_check_one_server_owner (PARSER_CONTEXT * parser, PT_NODE * node, PT_NODE * owner_name, const char *statement)
+{
+  const char *name = NULL;
+  DB_OBJECT *owner = NULL;
+  DB_VALUE owner_val;
+
+  if (owner_name == NULL)
+    {
+      /* No qualifier, so the caller's own schema. */
+      return true;
+    }
+
+  assert (owner_name->node_type == PT_NAME);
+  name = PT_NAME_ORIGINAL (owner_name);
+  assert (name != NULL && *name != '\0');
+
+  owner = db_find_user (name);
+  if (owner == NULL)
+    {
+      assert (er_errid () != NO_ERROR);
+
+      /* Only a name that is not a user is a semantic error. Anything else - a down server, say -
+       * is left standing for the execution path, which maps it. */
+      if (er_errid () == ER_AU_INVALID_USER)
+	{
+	  PT_ERRORmf (parser, node, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_USER_IS_NOT_IN_DB, name);
+	  return false;
+	}
+      return true;
+    }
+
+  db_make_object (&owner_val, owner);
+  if (au_is_server_authorized_user (&owner_val) == false)
+    {
+      PT_ERRORmf (parser, node, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_SYNONYM_NOT_OWNER, statement);
+      return false;
+    }
+
+  return true;
+}
+
+/*
+ * pt_check_server_owners () - is the caller authorized for the owners named on a dblink server statement?
+ *   return:  none
+ *   parser(in): the parser context used to derive the statement
+ *   node(in): a server statement
+ *
+ * Note: the check sits here rather than in server_find () so that it does not depend on whether the
+ * object exists. DROP ... IF EXISTS then still means "skip a missing object", not "skip one the caller
+ * is not authorized for". DROP SYNONYM orders its two checks the same way.
+ */
+static void
+pt_check_server_owners (PARSER_CONTEXT * parser, PT_NODE * node)
+{
+  if (parser == NULL || node == NULL)
+    {
+      return;
+    }
+
+  switch (node->node_type)
+    {
+    case PT_CREATE_SERVER:
+      pt_check_one_server_owner (parser, node, node->info.create_server.owner_name, "CREATE SERVER");
+      break;
+
+    case PT_ALTER_SERVER:
+      /* Two owners can be named - the one the object sits under, and the one OWNER TO moves it to. */
+      if (pt_check_one_server_owner (parser, node, node->info.alter_server.current_owner_name, "ALTER SERVER")
+	  && node->info.alter_server.xbits.bit_owner != 0)
+	{
+	  /* The grammar dereferences owner_name when it sets bit_owner, so it is here. */
+	  pt_check_one_server_owner (parser, node, node->info.alter_server.owner_name, "ALTER SERVER OWNER TO");
+	}
+      break;
+
+    case PT_DROP_SERVER:
+      pt_check_one_server_owner (parser, node, node->info.drop_server.owner_name, "DROP SERVER");
+      break;
+
+    case PT_RENAME_SERVER:
+      pt_check_one_server_owner (parser, node, node->info.rename_server.owner_name, "RENAME SERVER");
+      break;
+
+    default:
+      assert (false);
+      break;
+    }
+}
+
+/*
  * pt_check_update_stats () - do semantic checks on the UPDATE STATISTICS statement
  *   return:  none
  *   parser(in): the parser context used to derive the statement
@@ -12335,9 +12436,10 @@ pt_check_with_info (PARSER_CONTEXT * parser, PT_NODE * node, SEMANTIC_CHK_INFO *
       break;
 
     case PT_CREATE_SERVER:
+    case PT_ALTER_SERVER:
     case PT_DROP_SERVER:
     case PT_RENAME_SERVER:
-    case PT_ALTER_SERVER:
+      pt_check_server_owners (parser, node);
       break;
 
     case PT_ALTER:

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -21938,7 +21938,7 @@ server_find (PT_NODE * node_server, PT_NODE * node_owner)
 	    {
 	      goto err;
 	    }
-	  /* check if user is creator or DBA  */
+	  /* check if user is the owner, a member of the owning group, or a DBA */
 	  if (au_is_server_authorized_user (&values[1]))
 	    {
 	      rec_cnt++;
@@ -21958,7 +21958,11 @@ server_find (PT_NODE * node_server, PT_NODE * node_owner)
       while (db_query_next_tuple (query_result) == DB_CURSOR_SUCCESS);
       if (rec_cnt == 0)
 	{
-	  error = ER_DBLINK_SERVER_ALTER_NOT_ALLOWED;	// ER_DBLINK_CANNOT_UPDATE_SERVER
+	  /* Treat "exists but not authorized" as missing - a distinct error would tell the caller that
+	   * this name is taken in another user's schema. The duplicate-name checks read a miss as "this
+	   * name is free", which holds because pt_check_server_owners () has authorized the caller for
+	   * the owner they look up. Query name resolution is what still arrives here unauthorized. */
+	  error = ER_DBLINK_SERVER_NOT_FOUND;
 	}
     }
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27363>

### Purpose

* backport #7860

### Implementation

N/A

### Remarks

cherry-pick 은 충돌 없이 적용됐다(3 파일, +119/-4).

이 라인에서는 shell TC `_37_elderberry/cbrd_23843_dblink/cbrd_23843_3` 가 아직 수정 전 기대값을
갖고 있어 `_07_server_check` 와 `_08_user_check` 가 깨진다. `release/11.4` 의 PR CI 에는 shell job
자체가 없으므로 이 PR 의 체크에는 드러나지 않고, **일일 QA 의 shell 스위트**에서 드러난다. develop
에서는 같은 TC 가 `_25_unstable` 아래에 있어 shell 스위트가 돌리지 않는다 — 그래서 develop 쪽 정답지
재조정(cubrid-testcases-private-ex#4061)에도 CI 신호가 없었다.

11.4 정답지는 cubrid-testcases-private-ex#4131 로 올려 뒀다. 두 PR 중 하나만 머지되면 그 사이 일일
QA 가 그 두 케이스에서 깨지므로, 붙여서 머지해야 한다.
