### PR TITLE
[CUBRIDQA-1583] Let /run own the build, and post it to the pull request

### DIFF
--- a/.github/workflows/gha-ci.yml
+++ b/.github/workflows/gha-ci.yml
@@ -2,9 +2,9 @@
 # Replaces the CircleCI jobs build + build_debug + download-build + test_shell.
 # Both stay live during the migration, so one /run comment can be compared.
 #
-# Trigger, and what each one runs. A commit builds nothing by itself: asking for the
-# tests is what asks for the build, so the run that tests a commit is the one that
-# builds it.
+# Trigger, and what each one runs. A pull request builds nothing on its own: asking
+# for the tests is what asks for the build, so the run that tests a commit is the one
+# that builds it. push still builds what it merges or pushes.
 #
 #   issue_comment  /run shell | all    build, then the shell suite on the debug build
 #   push develop, feature/**           build only. develop also writes the ccache
@@ -125,6 +125,11 @@ concurrency:
   cancel-in-progress: ${{ github.event_name != 'push' }}
 
 env:
+  # The two checks build_status posts and status_pending marks pending. Defined here
+  # so the pair cannot drift apart: a context that differs between the two jobs is a
+  # required check left pending for good. Quoted, or the colon makes them a mapping.
+  CTX_BUILD_RELEASE: "gha-ci: build (release)"
+  CTX_BUILD_DEBUG: "gha-ci: build (debug)"
   CI_ROOT: /home/gha-ci
   CI_BUILD_ROOT: /home/gha-ci/builds
   TIMINGS: /home/gha-ci/timings/shell.tsv
@@ -323,10 +328,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           SHA: ${{ needs.gate.outputs.sha }}
-          # Quoted: the colon would otherwise make these a YAML mapping.
-          C_RELEASE: "gha-ci: build (release)"
-          C_DEBUG: "gha-ci: build (debug)"
-          C_SHELL: "gha-ci: test_shell"
+          C_SHELL: "gha-ci: test_shell" # quoted: the colon would make it a mapping
         run: |
           set -eo pipefail
           if [[ ! "$SHA" =~ ^[0-9a-f]{40}$ ]]; then
@@ -349,8 +351,8 @@ jobs:
               exit 1
             fi
           }
-          pending "$C_RELEASE" "release build running"
-          pending "$C_DEBUG" "debug build running"
+          pending "$CTX_BUILD_RELEASE" "release build running"
+          pending "$CTX_BUILD_DEBUG" "debug build running"
           pending "$C_SHELL" "shell suite running"
           echo "pending posted on ${SHA}"
 
@@ -661,11 +663,9 @@ jobs:
   build_status:
     name: build status
     needs: [gate, build]
-    # Not success(), because a red build is what the required check exists to show.
-    # !cancelled() rather than always(), the way plan and collect read it: a run this
-    # run's group superseded has nothing to say about this build, and the run that
-    # replaced it posts its own pending and its own verdict. Under always() the dead
-    # run's failure can land after that verdict and leave a passing build red.
+    # !cancelled(), the way plan and collect read it: a superseded run has nothing to
+    # say about this build, and under always() its failure can land after the verdict
+    # of the run that replaced it and leave a passing build red.
     if: ${{ !cancelled() && needs.gate.outputs.run == 'true' && needs.gate.outputs.test == 'true' && needs.gate.outputs.pr != '' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 5
@@ -675,15 +675,9 @@ jobs:
     steps:
       - name: Post each build leg to the head commit
         env:
-          GITHUB_TOKEN: ${{ github.token }}
-          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }} # curl below, and gh reads it too
           REPO: ${{ github.repository }}
           SHA: ${{ needs.gate.outputs.sha }}
-          # Quoted: the colon would otherwise make these a YAML mapping. Neither is
-          # the check run `build (release)`; a different string is what keeps the two
-          # apart in the required list.
-          C_RELEASE: "gha-ci: build (release)"
-          C_DEBUG: "gha-ci: build (debug)"
         run: |
           set -eo pipefail
           if [[ ! "$SHA" =~ ^[0-9a-f]{40}$ ]]; then
@@ -693,18 +687,23 @@ jobs:
           # needs.build.result is the whole matrix: one leg failing would take the
           # other down with it. The legs are read back by job name instead -- the
           # jobs API returns the most recent execution of each one, so re-running a
-          # single leg still reports the other correctly.
-          leg() { # mode
-            gh api --paginate "repos/${REPO}/actions/runs/${GITHUB_RUN_ID}/jobs" \
-              --jq ".jobs[] | select(.name == \"build ($1)\") | .conclusion"
-          }
+          # single leg still reports the other correctly. Read once, and separately
+          # from the mapping below: a request that fails must not reach a check as a
+          # red build.
+          legs=$(gh api --paginate "repos/${REPO}/actions/runs/${GITHUB_RUN_ID}/jobs" \
+            --jq '.jobs[] | select(.name | startswith("build (")) | [.name, .conclusion] | @tsv') || {
+            echo "::error::could not read the jobs of this run; posting nothing"; exit 1; }
+          printf 'jobs API:\n%s\n' "$legs"
 
-          missing=0
-          post() { # context, mode, conclusion
-            case "$3" in
+          bad=0
+          post() { # context, mode
+            conc=$(printf '%s\n' "$legs" | awk -F'\t' -v n="build ($2)" '$1 == n {print $2}')
+            case "$conc" in
               success) state=success; desc="$2 build passed" ;;
-              '')      state=failure; desc="no $2 build job in this run"; missing=1 ;;
-              *)       state=failure; desc="$2 build $3 -- see the run" ;;
+              # Red rather than silent, and loud: a renamed build job would otherwise
+              # leave the check unanswered for good.
+              '')      state=failure; desc="no $2 build job in this run"; bad=1 ;;
+              *)       state=failure; desc="$2 build $conc -- see the run" ;;
             esac
             jq -n --arg s "$state" --arg c "$1" --arg d "$desc" \
               --arg u "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
@@ -715,20 +714,19 @@ jobs:
               -H "X-GitHub-Api-Version: 2022-11-28" \
               "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/statuses/${SHA}" \
               -d @/tmp/st.json)
-            echo "$1 -> $state (conclusion ${3:-none}, HTTP $code)"
+            echo "$1 -> $state (conclusion ${conc:-none}, HTTP $code)"
             if [ "$code" != "201" ]; then
               echo "::error::could not post the status: $1"
               jq -r '.message // .' /tmp/resp.json 2>/dev/null | head -3
-              exit 1
+              # No exit: the other context must still get its answer.
+              bad=1
             fi
           }
 
-          post "$C_RELEASE" release "$(leg release)"
-          post "$C_DEBUG" debug "$(leg debug)"
+          post "$CTX_BUILD_RELEASE" release
+          post "$CTX_BUILD_DEBUG" debug
+          [ "$bad" = 0 ] || exit 1
           echo "posted on ${SHA}"
-          # Red, not silent: a renamed build job would leave the checks unanswered.
-          [ "$missing" = 0 ] || {
-            echo "::error::the jobs API named no build leg -- this query is stale"; exit 1; }
 
   plan:
     name: plan

--- a/.github/workflows/gha-ci.yml
+++ b/.github/workflows/gha-ci.yml
@@ -2,18 +2,14 @@
 # Replaces the CircleCI jobs build + build_debug + download-build + test_shell.
 # Both stay live during the migration, so one /run comment can be compared.
 #
-# Trigger, and what each one runs. A pull request builds nothing on its own: asking
-# for the tests is what asks for the build, so the run that tests a commit is the one
-# that builds it. push still builds what it merges or pushes.
+# Trigger, and what each one runs. A pull request builds only what it asks to test.
 #
 #   issue_comment  /run shell | all    build, then the shell suite on the debug build
 #   push develop, feature/**           build only. develop also writes the ccache
 #   workflow_dispatch                  build; tests always run
 #
-# A pull request sees the build as the commit statuses `gha-ci: build (release)` and
-# `gha-ci: build (debug)`, which build_status posts. A comment run's check runs land
-# on the default branch head and not on the pull request head, so those statuses are
-# the only build result a pull request can carry.
+# A comment run's check runs land on the default branch head, so the pull request
+# gets its build as the commit statuses build_status posts.
 #
 # Any request that runs the suite takes an optional trailing testtools=<branch> --
 # `/run shell testtools=fix/x` or the dispatch input -- and then CTP comes from that
@@ -24,8 +20,7 @@
 # own and always reads the DEFAULT BRANCH, so /run does nothing until this is merged.
 # workflow_dispatch runs the copy in the ref it is given, and appears in the UI only
 # once the default branch carries the file. push runs the pushed commit's copy. No
-# trigger reads the copy a pull request proposes, so a change to this file is tried
-# out on a fork or by dispatch, never by opening the pull request.
+# trigger reads the copy a pull request proposes: change this file on a fork.
 #
 # Prerequisites in the runner, not here. circleci-k8s-ansible roles/arc owns
 # them; its README.md carries the full contract table for this file.
@@ -42,8 +37,6 @@ name: gha-ci
 
 on:
   # Which comments wake this is decided by the gate job; it cannot be narrowed here.
-  # No trigger here reaches a runner from a fork: the gate refuses every author
-  # association but OWNER, MEMBER and COLLABORATOR.
   issue_comment:
     types: [created, edited]
   # Post-merge build. Only develop refreshes the ccache.
@@ -125,9 +118,8 @@ concurrency:
   cancel-in-progress: ${{ github.event_name != 'push' }}
 
 env:
-  # The two checks build_status posts and status_pending marks pending. Defined here
-  # so the pair cannot drift apart: a context that differs between the two jobs is a
-  # required check left pending for good. Quoted, or the colon makes them a mapping.
+  # One definition for two jobs: a pending and a verdict spelling the context
+  # differently never resolve. Quoted, or the colon makes them a mapping.
   CTX_BUILD_RELEASE: "gha-ci: build (release)"
   CTX_BUILD_DEBUG: "gha-ci: build (debug)"
   CI_ROOT: /home/gha-ci
@@ -311,10 +303,9 @@ jobs:
           emit testtools "$tt"
           echo "resolved: event=$EV test=$test_run namespace=$ns ccache_write=$cache_write"
 
-  # The three checks a pull request carries, pending from the earliest point the
-  # answer is unknown. Posted from here and not from build or collect: those run in a
-  # pod that can be evicted, and statuses: write must not reach a runner that
-  # executes testcase code.
+  # The three checks a pull request carries. Posted from here and not from build or
+  # collect: those run in a pod that can be evicted, and statuses: write must not
+  # reach a runner that executes testcase code.
   status_pending:
     name: status (pending)
     needs: gate
@@ -328,7 +319,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           SHA: ${{ needs.gate.outputs.sha }}
-          C_SHELL: "gha-ci: test_shell" # quoted: the colon would make it a mapping
+          C_SHELL: "gha-ci: test_shell"
         run: |
           set -eo pipefail
           if [[ ! "$SHA" =~ ^[0-9a-f]{40}$ ]]; then
@@ -656,16 +647,13 @@ jobs:
             tail -60 "$f"
           fi
 
-  # The build result the pull request can see. A comment run posts its check runs on
-  # the default branch head, so `build (release)` never lands on the head commit;
-  # this job puts the same verdict there as a commit status instead. GitHub-hosted
-  # like the two status jobs: statuses: write stays off the build pod.
+  # The build verdict on the head commit, which a comment run's check runs never
+  # reach. GitHub-hosted: statuses: write stays off the build pod.
   build_status:
     name: build status
     needs: [gate, build]
-    # !cancelled(), the way plan and collect read it: a superseded run has nothing to
-    # say about this build, and under always() its failure can land after the verdict
-    # of the run that replaced it and leave a passing build red.
+    # !cancelled(), as plan and collect read it: under always() a superseded run's
+    # failure can land after the verdict of the run that replaced it.
     if: ${{ !cancelled() && needs.gate.outputs.run == 'true' && needs.gate.outputs.test == 'true' && needs.gate.outputs.pr != '' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 5
@@ -675,7 +663,7 @@ jobs:
     steps:
       - name: Post each build leg to the head commit
         env:
-          GITHUB_TOKEN: ${{ github.token }} # curl below, and gh reads it too
+          GITHUB_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           SHA: ${{ needs.gate.outputs.sha }}
         run: |
@@ -684,12 +672,9 @@ jobs:
             echo "::error::sha must be 40 lowercase hex characters, got: ${SHA}"; exit 1
           fi
 
-          # needs.build.result is the whole matrix: one leg failing would take the
-          # other down with it. The legs are read back by job name instead -- the
-          # jobs API returns the most recent execution of each one, so re-running a
-          # single leg still reports the other correctly. Read once, and separately
-          # from the mapping below: a request that fails must not reach a check as a
-          # red build.
+          # needs.build.result is the whole matrix, so the legs come by name; the jobs
+          # API answers with the latest execution of each. Read once and apart from
+          # the mapping: a failed request must not reach a check as a red build.
           legs=$(gh api --paginate "repos/${REPO}/actions/runs/${GITHUB_RUN_ID}/jobs" \
             --jq '.jobs[] | select(.name | startswith("build (")) | [.name, .conclusion] | @tsv') || {
             echo "::error::could not read the jobs of this run; posting nothing"; exit 1; }
@@ -700,8 +685,6 @@ jobs:
             conc=$(printf '%s\n' "$legs" | awk -F'\t' -v n="build ($2)" '$1 == n {print $2}')
             case "$conc" in
               success) state=success; desc="$2 build passed" ;;
-              # Red rather than silent, and loud: a renamed build job would otherwise
-              # leave the check unanswered for good.
               '')      state=failure; desc="no $2 build job in this run"; bad=1 ;;
               *)       state=failure; desc="$2 build $conc -- see the run" ;;
             esac
@@ -718,8 +701,7 @@ jobs:
             if [ "$code" != "201" ]; then
               echo "::error::could not post the status: $1"
               jq -r '.message // .' /tmp/resp.json 2>/dev/null | head -3
-              # No exit: the other context must still get its answer.
-              bad=1
+              bad=1 # no exit: the other context still needs its answer
             fi
           }
 
@@ -1271,9 +1253,8 @@ jobs:
   shard:
     name: "shard ${{ matrix.i }}"
     needs: plan
-    # The same override plan carries, and for the same reason: success() is false
-    # for a failed job anywhere behind this one, so a red release leg would skip
-    # every shard even though plan ran and published the split.
+    # success() is false for a failed job anywhere behind this one, so a red release
+    # leg would skip every shard even though plan published the split.
     if: ${{ !cancelled() && needs.plan.result == 'success' }}
     # 50 privileged pods running testcase code; testcases arrive via the App token.
     permissions: {}

--- a/.github/workflows/gha-ci.yml
+++ b/.github/workflows/gha-ci.yml
@@ -2,14 +2,11 @@
 # Replaces the CircleCI jobs build + build_debug + download-build + test_shell.
 # Both stay live during the migration, so one /run comment can be compared.
 #
-# Trigger, and what each one runs. A pull request builds only what it asks to test.
+# Trigger, and what each one runs.
 #
 #   issue_comment  /run shell | all    build, then the shell suite on the debug build
 #   push develop, feature/**           build only. develop also writes the ccache
 #   workflow_dispatch                  build; tests always run
-#
-# A comment run's check runs land on the default branch head, so the pull request
-# gets its build as the commit statuses build_status posts.
 #
 # Any request that runs the suite takes an optional trailing testtools=<branch> --
 # `/run shell testtools=fix/x` or the dispatch input -- and then CTP comes from that
@@ -19,8 +16,7 @@
 # Which copy of this file runs differs by trigger. issue_comment has no ref of its
 # own and always reads the DEFAULT BRANCH, so /run does nothing until this is merged.
 # workflow_dispatch runs the copy in the ref it is given, and appears in the UI only
-# once the default branch carries the file. push runs the pushed commit's copy. No
-# trigger reads the copy a pull request proposes: change this file on a fork.
+# once the default branch carries the file. push runs the pushed commit's copy.
 #
 # Prerequisites in the runner, not here. circleci-k8s-ansible roles/arc owns
 # them; its README.md carries the full contract table for this file.
@@ -118,8 +114,6 @@ concurrency:
   cancel-in-progress: ${{ github.event_name != 'push' }}
 
 env:
-  # One definition for two jobs: a pending and a verdict spelling the context
-  # differently never resolve. Quoted, or the colon makes them a mapping.
   CTX_BUILD_RELEASE: "gha-ci: build (release)"
   CTX_BUILD_DEBUG: "gha-ci: build (debug)"
   CI_ROOT: /home/gha-ci
@@ -647,13 +641,13 @@ jobs:
             tail -60 "$f"
           fi
 
-  # The build verdict on the head commit, which a comment run's check runs never
-  # reach. GitHub-hosted: statuses: write stays off the build pod.
+  # A comment run's check runs land on the default branch head, never on the
+  # pull request, so the build verdict reaches it as a commit status instead.
   build_status:
     name: build status
     needs: [gate, build]
-    # !cancelled(), as plan and collect read it: under always() a superseded run's
-    # failure can land after the verdict of the run that replaced it.
+    # !cancelled(), as plan and collect read it, and unlike status: under always() a
+    # superseded run's failure can land after the verdict that replaced it.
     if: ${{ !cancelled() && needs.gate.outputs.run == 'true' && needs.gate.outputs.test == 'true' && needs.gate.outputs.pr != '' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 5
@@ -672,9 +666,8 @@ jobs:
             echo "::error::sha must be 40 lowercase hex characters, got: ${SHA}"; exit 1
           fi
 
-          # needs.build.result is the whole matrix, so the legs come by name; the jobs
-          # API answers with the latest execution of each. Read once and apart from
-          # the mapping: a failed request must not reach a check as a red build.
+          # needs.build.result is the whole matrix, so the legs come by name. Read
+          # apart from the mapping: a failed query must not post as a red build.
           legs=$(gh api --paginate "repos/${REPO}/actions/runs/${GITHUB_RUN_ID}/jobs" \
             --jq '.jobs[] | select(.name | startswith("build (")) | [.name, .conclusion] | @tsv') || {
             echo "::error::could not read the jobs of this run; posting nothing"; exit 1; }
@@ -1253,8 +1246,8 @@ jobs:
   shard:
     name: "shard ${{ matrix.i }}"
     needs: plan
-    # success() is false for a failed job anywhere behind this one, so a red release
-    # leg would skip every shard even though plan published the split.
+    # success() is false for a failed job anywhere behind this one: without this a
+    # red release leg skips all 50 shards, though plan published the split.
     if: ${{ !cancelled() && needs.plan.result == 'success' }}
     # 50 privileged pods running testcase code; testcases arrive via the App token.
     permissions: {}

--- a/.github/workflows/gha-ci.yml
+++ b/.github/workflows/gha-ci.yml
@@ -661,8 +661,12 @@ jobs:
   build_status:
     name: build status
     needs: [gate, build]
-    # always(), not success(): a red build is what the required check exists to show.
-    if: ${{ always() && needs.gate.outputs.run == 'true' && needs.gate.outputs.test == 'true' && needs.gate.outputs.pr != '' }}
+    # Not success(), because a red build is what the required check exists to show.
+    # !cancelled() rather than always(), the way plan and collect read it: a run this
+    # run's group superseded has nothing to say about this build, and the run that
+    # replaced it posts its own pending and its own verdict. Under always() the dead
+    # run's failure can land after that verdict and leave a passing build red.
+    if: ${{ !cancelled() && needs.gate.outputs.run == 'true' && needs.gate.outputs.test == 'true' && needs.gate.outputs.pr != '' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
@@ -698,10 +702,9 @@ jobs:
           missing=0
           post() { # context, mode, conclusion
             case "$3" in
-              success)   state=success; desc="$2 build passed" ;;
-              cancelled) state=failure; desc="run was superseded or cancelled" ;;
-              '')        state=failure; desc="no $2 build job in this run"; missing=1 ;;
-              *)         state=failure; desc="$2 build $3 -- see the run" ;;
+              success) state=success; desc="$2 build passed" ;;
+              '')      state=failure; desc="no $2 build job in this run"; missing=1 ;;
+              *)       state=failure; desc="$2 build $3 -- see the run" ;;
             esac
             jq -n --arg s "$state" --arg c "$1" --arg d "$desc" \
               --arg u "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \

--- a/.github/workflows/gha-ci.yml
+++ b/.github/workflows/gha-ci.yml
@@ -1270,6 +1270,10 @@ jobs:
   shard:
     name: "shard ${{ matrix.i }}"
     needs: plan
+    # The same override plan carries, and for the same reason: success() is false
+    # for a failed job anywhere behind this one, so a red release leg would skip
+    # every shard even though plan ran and published the split.
+    if: ${{ !cancelled() && needs.plan.result == 'success' }}
     # 50 privileged pods running testcase code; testcases arrive via the App token.
     permissions: {}
     runs-on: cubrid-arc

--- a/.github/workflows/gha-ci.yml
+++ b/.github/workflows/gha-ci.yml
@@ -2,13 +2,18 @@
 # Replaces the CircleCI jobs build + build_debug + download-build + test_shell.
 # Both stay live during the migration, so one /run comment can be compared.
 #
-# Trigger, and what each one runs. Same shape as the CircleCI baseline, where the
-# test parameters default to false so the automatic path builds only.
+# Trigger, and what each one runs. A commit builds nothing by itself: asking for the
+# tests is what asks for the build, so the run that tests a commit is the one that
+# builds it.
 #
-#   pull_request opened, synchronize   build only
 #   issue_comment  /run shell | all    build, then the shell suite on the debug build
 #   push develop, feature/**           build only. develop also writes the ccache
 #   workflow_dispatch                  build; tests always run
+#
+# A pull request sees the build as the commit statuses `gha-ci: build (release)` and
+# `gha-ci: build (debug)`, which build_status posts. A comment run's check runs land
+# on the default branch head and not on the pull request head, so those statuses are
+# the only build result a pull request can carry.
 #
 # Any request that runs the suite takes an optional trailing testtools=<branch> --
 # `/run shell testtools=fix/x` or the dispatch input -- and then CTP comes from that
@@ -18,17 +23,17 @@
 # Which copy of this file runs differs by trigger. issue_comment has no ref of its
 # own and always reads the DEFAULT BRANCH, so /run does nothing until this is merged.
 # workflow_dispatch runs the copy in the ref it is given, and appears in the UI only
-# once the default branch carries the file. push runs the pushed commit's copy, and
-# pull_request the copy the pull request proposes -- which is why it may build and
-# never test.
+# once the default branch carries the file. push runs the pushed commit's copy. No
+# trigger reads the copy a pull request proposes, so a change to this file is tried
+# out on a fork or by dispatch, never by opening the pull request.
 #
 # Prerequisites in the runner, not here. circleci-k8s-ansible roles/arc owns
 # them; its README.md carries the full contract table for this file.
 #   pod template   shareProcessNamespace, or the shell tests hang instead of
 #                  failing; privileged, or the overlay mount fails;
 #                  imagePullPolicy Always, or nodes keep a stale image
-#   job hook       ALLOWED_EVENTS must list pull_request, issue_comment, push
-#                  and workflow_dispatch
+#   job hook       ALLOWED_EVENTS must list issue_comment, push and
+#                  workflow_dispatch
 #
 # Decisions, measurements and the ccache/path contract: CUBRIDQA-1526, and
 # roles/arc/README.md in circleci-k8s-ansible.
@@ -36,13 +41,9 @@
 name: gha-ci
 
 on:
-  # Builds only. A fork PR runs its own copy of this file, so nothing here may
-  # reach a test job -- the repository setting "Require approval for all external
-  # contributors" is what keeps an outsider's PR off these runners.
-  pull_request:
-    types: [opened, synchronize]
-    branches: [develop, 'feature/**']
   # Which comments wake this is decided by the gate job; it cannot be narrowed here.
+  # No trigger here reaches a runner from a fork: the gate refuses every author
+  # association but OWNER, MEMBER and COLLABORATOR.
   issue_comment:
     types: [created, edited]
   # Post-merge build. Only develop refreshes the ccache.
@@ -107,8 +108,6 @@ concurrency:
   group: >-
     gha-ci-${{ github.event_name == 'push'
     && format('push-{0}', github.sha)
-    || github.event_name == 'pull_request'
-    && format('pr-{0}-build', github.event.pull_request.number)
     || github.event_name == 'workflow_dispatch'
     && format('dispatch-{0}', inputs.sha)
     || github.event.issue.pull_request != null
@@ -136,7 +135,7 @@ env:
   ARTIFACT_URL_BASE: http://192.168.1.48:30080
 
 jobs:
-  # All four triggers become one shape: every job below reads needs.gate.outputs and
+  # All three triggers become one shape: every job below reads needs.gate.outputs and
   # never looks at the event, so adding a trigger means editing this job only.
   # GitHub-hosted, so the permission decision lands before a runner is claimed.
   gate:
@@ -147,8 +146,7 @@ jobs:
       pull-requests: read # the head SHA of the commented PR
     # Only the comment path needs an author check -- it is the one event anyone with
     # read access can raise. Same author set as comment_trigger.yml; CONTRIBUTOR is
-    # refused. push and workflow_dispatch already require write access, and
-    # pull_request is gated by the repository's fork-approval setting.
+    # refused. push and workflow_dispatch already require write access.
     if: >-
       ${{ github.event_name != 'issue_comment'
       || (github.event.issue.pull_request != null
@@ -175,10 +173,6 @@ jobs:
           EV: ${{ github.event_name }}
           BODY: ${{ github.event.comment.body }}
           ISSUE: ${{ github.event.issue.number }}
-          # pull_request: the head SHA, not the merge commit -- that is what the PR
-          # proposes, and it is the same value the comment path resolves to.
-          PR_NUM: ${{ github.event.pull_request.number }}
-          PR_HEAD: ${{ github.event.pull_request.head.sha }}
           PUSH_SHA: ${{ github.sha }}
           REF: ${{ github.ref }}
           IN_SHA: ${{ inputs.sha }}
@@ -203,12 +197,6 @@ jobs:
           test_run=false; pr=''; ns='pr'; cache_write=false
 
           case "$EV" in
-            pull_request)
-              sha="$PR_HEAD"
-              pr="$PR_NUM"
-              echo "pull_request: PR #${pr} / head ${sha} / build only"
-              ;;
-
             push)
               sha="$PUSH_SHA"
               # develop is the only ref that refreshes the shared ccache and lands in
@@ -275,7 +263,7 @@ jobs:
               sha=$(printf '%s' "$pull" | cut -f1)
               base=$(printf '%s' "$pull" | cut -f2)
               echo "comment: base branch ${base}"
-              # Same range as the pull_request trigger's branches: filter. release/11.x
+              # Same range as the push trigger's branches: filter. release/11.x
               # builds against a different toolchain, so this image cannot test it.
               case "$base" in
                 develop|feature/*) ;;
@@ -318,9 +306,10 @@ jobs:
           emit testtools "$tt"
           echo "resolved: event=$EV test=$test_run namespace=$ns ccache_write=$cache_write"
 
-  # The check ticket 28 makes required. Posted from here and not from collect: that
-  # job runs in a pod that can be evicted, and statuses: write must not reach a
-  # runner that executes testcase code.
+  # The three checks a pull request carries, pending from the earliest point the
+  # answer is unknown. Posted from here and not from build or collect: those run in a
+  # pod that can be evicted, and statuses: write must not reach a runner that
+  # executes testcase code.
   status_pending:
     name: status (pending)
     needs: gate
@@ -334,28 +323,35 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           SHA: ${{ needs.gate.outputs.sha }}
-          CONTEXT: "gha-ci: test_shell"
+          # Quoted: the colon would otherwise make these a YAML mapping.
+          C_RELEASE: "gha-ci: build (release)"
+          C_DEBUG: "gha-ci: build (debug)"
+          C_SHELL: "gha-ci: test_shell"
         run: |
           set -eo pipefail
           if [[ ! "$SHA" =~ ^[0-9a-f]{40}$ ]]; then
             echo "::error::sha must be 40 lowercase hex characters, got: ${SHA}"; exit 1
           fi
-          jq -n --arg c "$CONTEXT" \
-            --arg u "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
-            '{state:"pending", context:$c, target_url:$u, description:"shell suite running"}' \
-            > /tmp/st.json
-          code=$(curl -sS -o /tmp/resp.json -w '%{http_code}' -X POST \
-            -H "Authorization: Bearer $GITHUB_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/statuses/${SHA}" \
-            -d @/tmp/st.json)
-          echo "HTTP $code"
-          if [ "$code" != "201" ]; then
-            echo "::error::could not post the pending status"
-            jq -r '.message // .' /tmp/resp.json 2>/dev/null | head -3
-            exit 1
-          fi
+          pending() { # context, description
+            jq -n --arg c "$1" --arg d "$2" \
+              --arg u "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+              '{state:"pending", context:$c, target_url:$u, description:$d}' > /tmp/st.json
+            code=$(curl -sS -o /tmp/resp.json -w '%{http_code}' -X POST \
+              -H "Authorization: Bearer $GITHUB_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/statuses/${SHA}" \
+              -d @/tmp/st.json)
+            echo "$1 -> pending (HTTP $code)"
+            if [ "$code" != "201" ]; then
+              echo "::error::could not post the pending status: $1"
+              jq -r '.message // .' /tmp/resp.json 2>/dev/null | head -3
+              exit 1
+            fi
+          }
+          pending "$C_RELEASE" "release build running"
+          pending "$C_DEBUG" "debug build running"
+          pending "$C_SHELL" "shell suite running"
           echo "pending posted on ${SHA}"
 
   # Both modes of the CircleCI baseline, which differ only in the build argument and
@@ -551,8 +547,8 @@ jobs:
           dir="$CI_BUILD_ROOT/$BUILD_NS/$SHA/$MODE"
 
           # The reuse decision is 8 to 40 minutes old by now, and a duplicate run on
-          # the same SHA -- push feature/** and pull_request synchronize both fire on
-          # one commit -- publishes into this very path. Reading the sentinel again
+          # the same SHA -- a push to feature/** and a /run comment naming the same
+          # commit -- publishes into this very path. Reading the sentinel again
           # saves the 700MB staging copy when the other run is already done. It does
           # NOT decide the race: see the rename below.
           if [ "$REUSE" != 'reused' ] && [ "$INPUT_FORCE" != 'true' ] \
@@ -657,6 +653,79 @@ jobs:
             echo "=== last 60 lines of build.log ==="
             tail -60 "$f"
           fi
+
+  # The build result the pull request can see. A comment run posts its check runs on
+  # the default branch head, so `build (release)` never lands on the head commit;
+  # this job puts the same verdict there as a commit status instead. GitHub-hosted
+  # like the two status jobs: statuses: write stays off the build pod.
+  build_status:
+    name: build status
+    needs: [gate, build]
+    # always(), not success(): a red build is what the required check exists to show.
+    if: ${{ always() && needs.gate.outputs.run == 'true' && needs.gate.outputs.test == 'true' && needs.gate.outputs.pr != '' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      statuses: write
+      actions: read # the per-leg conclusion, below
+    steps:
+      - name: Post each build leg to the head commit
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ needs.gate.outputs.sha }}
+          # Quoted: the colon would otherwise make these a YAML mapping. Neither is
+          # the check run `build (release)`; a different string is what keeps the two
+          # apart in the required list.
+          C_RELEASE: "gha-ci: build (release)"
+          C_DEBUG: "gha-ci: build (debug)"
+        run: |
+          set -eo pipefail
+          if [[ ! "$SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::sha must be 40 lowercase hex characters, got: ${SHA}"; exit 1
+          fi
+
+          # needs.build.result is the whole matrix: one leg failing would take the
+          # other down with it. The legs are read back by job name instead -- the
+          # jobs API returns the most recent execution of each one, so re-running a
+          # single leg still reports the other correctly.
+          leg() { # mode
+            gh api --paginate "repos/${REPO}/actions/runs/${GITHUB_RUN_ID}/jobs" \
+              --jq ".jobs[] | select(.name == \"build ($1)\") | .conclusion"
+          }
+
+          missing=0
+          post() { # context, mode, conclusion
+            case "$3" in
+              success)   state=success; desc="$2 build passed" ;;
+              cancelled) state=failure; desc="run was superseded or cancelled" ;;
+              '')        state=failure; desc="no $2 build job in this run"; missing=1 ;;
+              *)         state=failure; desc="$2 build $3 -- see the run" ;;
+            esac
+            jq -n --arg s "$state" --arg c "$1" --arg d "$desc" \
+              --arg u "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+              '{state:$s, context:$c, target_url:$u, description:$d}' > /tmp/st.json
+            code=$(curl -sS -o /tmp/resp.json -w '%{http_code}' -X POST \
+              -H "Authorization: Bearer $GITHUB_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/statuses/${SHA}" \
+              -d @/tmp/st.json)
+            echo "$1 -> $state (conclusion ${3:-none}, HTTP $code)"
+            if [ "$code" != "201" ]; then
+              echo "::error::could not post the status: $1"
+              jq -r '.message // .' /tmp/resp.json 2>/dev/null | head -3
+              exit 1
+            fi
+          }
+
+          post "$C_RELEASE" release "$(leg release)"
+          post "$C_DEBUG" debug "$(leg debug)"
+          echo "posted on ${SHA}"
+          # Red, not silent: a renamed build job would leave the checks unanswered.
+          [ "$missing" = 0 ] || {
+            echo "::error::the jobs API named no build leg -- this query is stale"; exit 1; }
 
   plan:
     name: plan
@@ -923,7 +992,7 @@ jobs:
                 echo "  Pruned 7 days after the run, or never a gha-ci run at all."
               elif [ ! -d "$rd/results" ]; then
                 echo "::error::run $RERUN_FROM never ran the shell suite: no $rd/results"
-                echo "  A pull_request run builds only. Take the id from the 'current run' row"
+                echo "  A push run builds only. Take the id from the 'current run' row"
                 echo "  of a run that ran the suite, not from 'built by run'."
               else
                 echo "::error::run $RERUN_FROM ran the suite but published no failure list"


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBRIDQA-1583>

### Purpose

**PR 에 커밋을 올릴 때마다 돌던 빌드의 절반 이상이 테스트에 쓰이지 않았다.**

`pull_request` 트리거가 커밋마다 release·debug 둘을 빌드했다. 실측 2일(9/08~9/09)에 `pull_request` run 78건 = build job 156개 · pod 312개다. 그 중 shell suite 가 쓴 것은 절반이 안 된다. 나머지는 컴파일 검사로만 쓰였다.

**같은 커밋을 두 번 빌드하는 일이 일상이었다.**

push 뒤 빌드가 끝나기 전에 `/run` 을 치면, `/run` run 이 sentinel 을 못 보고 자기도 빌드한다. 발행 경합의 패자는 자기 트리를 버린다. 최근 표본 3건이 **3건 다** 두 번 빌드했다. 실물 하나 — PR #7788 커밋 `089eca75` 는 `pull_request` run 34198059273 이 5m17s/7m04s 로 발행했고, 2분 34초 뒤에 뜬 `/run` run 34198259227 이 13m54s/11m22s 를 더 쓰고 결과를 버렸다. 같은 노드에서 빌드 둘이 CPU 를 나눠 써서 둘 다 느려졌다.

**빨간 빌드를 `/run` 으로 고칠 수 없었다.**

9/10 에 `build (release)` 가 머지 필수 체크가 됐다. 그 체크는 `pull_request` run 만 PR head 에 붙인다. `issue_comment` run 의 check run 은 기본 브랜치 head 에 붙기 때문이다. 그래서 빨강을 지우는 길이 "그 run 화면의 Re-run failed jobs" 아니면 "새 커밋 push" 뿐이었다.

**release 빌드가 깨지면 shell suite 가 통째로 안 돌았다** (이 변경을 검증하다 찾았다).

`plan` 은 처음부터 `!cancelled()` 를 달고 "release 빨강이 suite 를 막지 않는다"고 주석에 적어 뒀다. CircleCI 가 `test_shell` 을 `build_debug` 에만 매단 것과 같은 뜻이다. 그런데 `shard` 에는 그 표시가 없었다. GitHub 의 기본 `success()` 는 자기 `needs` 만 보지 않고 **뒤에 있는 job 전부**를 본다. 그래서 release 다리가 빨강이면, plan 이 성공해 50개 몫을 발행하고도 shard 50개가 전부 skip 됐다. collect 만 돌아 `planned 50 / published 0` 으로 실패했다. 이 PR 전에도 같은 모양이었지만 — `/run` run 도 두 다리를 다 빌드했다 — 이 PR 뒤에는 빌드와 suite 가 **항상 한 run 에 있으므로** 이것이 release 전용 오류의 기본 모양이 된다.

### Implementation

**`pull_request` 트리거를 없앴다. 커밋을 테스트하는 run 이 그 커밋을 빌드한다.**

이제 빌드는 `/run shell`·`/run all`·`/run rerun`, `push`(develop·`feature/**`), `workflow_dispatch` 가 만든다. PR 에 push 만 하면 gha-ci 는 아무것도 돌지 않는다. 같은 SHA 를 두 run 이 동시에 빌드하는 구조가 사라졌다.

**빌드 결과를 PR head 에 commit status 로 쏜다.**

`/run` 이 붙이는 체크가 셋이 됐다.

| 체크 | 필수 | 뜻 |
|---|---|---|
| `gha-ci: build (release)` | 필수(전환 뒤) | release 빌드 결과 |
| `gha-ci: build (debug)` | 비필수 | debug 빌드 결과. shell suite 는 이 빌드로 돈다 |
| `gha-ci: test_shell` | 필수 | shell suite 결과 |

셋 다 gate 직후 pending 으로 먼저 붙고, 빌드가 끝나면 앞의 둘이 판정으로 바뀐다. 개발자가 보는 PR 화면은 전환 전(`build (release)` + `build (debug)`)과 같은 모양을 유지한다.

**판정은 새 job `build status` 가 쏜다.** GitHub-hosted 러너에서 돈다 — `statuses: write` 토큰을 빌드 pod 에 두지 않는다. 기존 `status (pending)`·`status` 와 같은 원칙이다.

**다리별 결과는 jobs API 로 읽는다.** `needs.build.result` 는 matrix 합산이라 한 다리가 빨강이면 다른 다리까지 빨강으로 끌고 간다. 그래서 `build (release)`·`build (debug)` job 의 결론을 이름으로 조회한다. 한 다리만 재실행해도 다른 다리의 판정이 유지된다.

**`shard` 에 plan 과 같은 `if:` 를 달았다.** `!cancelled() && needs.plan.result == 'success'` 다. plan 이 성공해 몫을 발행했으면 shard 가 돈다. plan 이 실패하거나 skip 이면 안 돈다. release 다리가 빨개도 suite 는 debug 빌드로 계속 돈다.

**안 바뀐 것**: `push`·`workflow_dispatch` 트리거, 빌드 재사용(SHA 별 발행·sentinel), plan·shard·collect, `/run` 문법, `/run rerun`.

**죽은 가지 정리**: gate 의 `pull_request)` 분기, concurrency 의 `pr-<N>-build` 그룹, 헤더 주석의 트리거 표.

### Remarks

**⚠ branch protection 변경이 이 PR 의 앞뒤로 나뉜다. 순서를 지켜야 한다.**

| 순서 | 무엇 | 왜 |
|---|---|---|
| 1 | `build (release)` 를 필수에서 뺀다 | 머지 뒤에는 어느 PR 에도 안 붙는다. 먼저 빼지 않으면 전 PR 이 막힌다 |
| 2 | 이 PR 을 머지한다 | 이 순간부터 push 는 빌드를 만들지 않는다 |
| 3 | 열린 PR 하나에 `/run shell` 을 친다 | 세 체크가 그 head 에 붙는 것을 눈으로 본다. 안 붙으면 4 를 하지 않는다 |
| 4 | `gha-ci: build (release)` 를 필수에 넣는다 | 3 에서 확인한 뒤에만. 먼저 넣으면 전 PR 이 막힌다 |

2~4 사이는 release 컴파일 오류가 머지를 막지 못하는 창이다. 15~30분 안에 끝내고, 그동안 머지를 하지 않는 것이 안전하다.

**⚠ 이 PR 자체에는 `build (release)` 가 안 붙는다.** 이 파일의 `pull_request` 트리거를 없애는 PR 이라서가 아니라, 어떤 트리거도 PR 이 제안한 워크플로 사본을 읽지 않기 때문이다. 그래서 검증을 포크에서 했다.

**필수 체크 수는 9건 그대로다.** `build (release)` 가 빠지고 `gha-ci: build (release)` 가 들어간다. 두 문자열이 다르므로 "같은 이름이면 둘 다 통과" 규칙에 걸리지 않는다.

**개발자 안내는 별도 공지로 나간다.** 요약하면 이렇다.

- 체크가 안 보이면 `/run shell` 을 친다. push 로는 gha-ci 체크가 붙지 않는다.
- 빌드가 빨갛고 코드 문제면 고쳐서 push 한 뒤 `/run shell`. 코드 문제가 아니면 `/run shell` 이나 Re-run failed jobs 로 다시 쓴다.
- CircleCI 는 그대로 커밋마다 빌드하고 비필수로 계속 돈다. 9/30 까지는 release 컴파일 검사가 그쪽에도 남아 있다.

**빌드 판정은 두 다리가 다 끝난 뒤에 붙는다.** `build status` 는 matrix 전체를 기다린다. 두 다리 소요가 비슷해서(실측 7.0/6.7 · 6.3/6.1 · 7.7/8.6) 평소에는 차이가 없다. 다만 한 다리가 일찍 죽으면 그 빨강이 다른 다리가 끝날 때까지 안 보인다 — 포크 검증에서 release 가 2분에 죽고 판정은 debug 가 끝난 뒤에 붙었다. 다리마다 따로 쏘려면 build job 을 matrix 에서 job 둘로 갈라야 하고, 그것은 이 PR 이 담는 롤백 단위를 넘는다.

**끊긴 run 은 빌드 체크를 안 건드린다.** 같은 PR 에 `/run` 을 다시 치면 앞 run 이 끊긴다. 그 run 은 `gha-ci: build (release)`·`(debug)` 를 쓰지 않는다 — `plan`·`collect` 와 같은 `!cancelled()` 다. 새 run 이 pending 을 다시 붙이고 판정을 쓴다. 사람이 손으로 취소하면 빌드 체크 둘이 pending 으로 남는다 — 머지는 막히고 `/run shell` 을 다시 치면 풀린다. ⚠ `gha-ci: test_shell` 은 종전 그대로 빨강이 된다.

**`roles/arc` 는 안 고쳐도 된다.** job hook 의 `ALLOWED_EVENTS` 는 이 워크플로가 쓰는 이벤트를 **포함**하기만 하면 된다. 안 쓰는 `pull_request` 가 목록에 남아 있어도 해롭지 않다.

### 검증

포크(`tw-kang/cubrid`)에서 확인했다. 포크 기본 브랜치에 이 변경을 얹고 — `issue_comment` 는 언제나 기본 브랜치 사본을 읽는다 — PR 하나에 `/run shell` 을 쳤다.

| 확인한 것 | 실물 |
|---|---|
| PR 을 열고 head 에 push 해도 gha-ci 가 안 뜬다 | 이 PR 이 만든 `pull_request` run 은 `github-checks` 하나뿐이다 |
| `push feature/**` 는 그대로 빌드하고, 체크는 안 붙인다 | run [34583918707](https://github.com/tw-kang/cubrid/actions/runs/34583918707) — build 두 다리 success · `status (pending)`·`build status` 둘 다 skipped · 그 SHA 에 commit status 0건 |
| `/run shell` 이 세 체크를 pending 으로 먼저 붙인다 | run [34583954873](https://github.com/tw-kang/cubrid/actions/runs/34583954873) — 코멘트 09:23:27Z → pending 09:23:43Z (16초) |
| 다리별로 판정이 갈린다 | 같은 run — `gha-ci: build (release)` failure · `gha-ci: build (debug)` success. release 에서만 깨지는 코드를 일부러 넣었다 |
| release 가 빨개도 suite 가 돈다 | run [34585215566](https://github.com/tw-kang/cubrid/actions/runs/34585215566) — plan success 뒤 shard 50개 생성, 10개 동시 실행. ⚠ `shard` 의 `if:` 를 고치기 전에는 50개가 전부 skip 됐다 (run 34583954873, collect 가 `planned 50 / published 0` 으로 실패) |
| 같은 SHA 를 다시 안 빌드한다 | run 34585215566 — `build (debug)` **18초**(09:38:47→09:39:05Z). 앞 run 이 발행한 것을 그대로 썼다 |
| 빨강이 `/run shell` 하나로 초록이 된다 | run [34585595602](https://github.com/tw-kang/cubrid/actions/runs/34585595602) — 고친 커밋을 push 하고 `/run shell` 한 번. `gha-ci: build (release)`·`(debug)` 둘 다 success(09:52:06Z). push 자체는 아무 run 도 만들지 않았다 |

| `Re-run failed jobs` 가 판정을 다시 쓴다 | run [34583954873](https://github.com/tw-kang/cubrid/actions/runs/34583954873) attempt 2 — attempt 1 에서 success 로 끝났던 `build status` 가 다시 돌아(12:15:03Z) 두 status 를 재게시했다. 다시 돌지 않은 `build (debug)` 의 결론도 jobs API 가 그대로 돌려줬다 |
| 끊긴 run 은 빌드 판정을 안 쓴다 | run [34598187246](https://github.com/tw-kang/cubrid/actions/runs/34598187246) — build 두 다리가 도는 중에 `/run shell` 을 다시 쳤다. 끊긴 run 의 `build status` 는 `steps=0` 으로 아예 실행되지 않았다 |

⚠ 포크 lane 은 러너 10개라 **기능만** 검증한다. 50-way 경합과 타이밍은 상류에서만 드러난다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cc8QCw59E5VuJcVmZiPrR
