### PR TITLE
[CBRD-00000] Run the shell suite under the tuned volume and buffer sizes (CTP feature/ctp-perf)

### DIFF
--- a/conf/cubrid.conf
+++ b/conf/cubrid.conf
@@ -40,10 +40,10 @@ service=server,broker,manager
 # Manual > Performance Tuning > Database Server Configuration > Default Parameters
 
 # Size of data buffer are using K, M, G, T unit
-data_buffer_size=512M
+data_buffer_size=64M
 
 # Size of log buffer are using K, M, G, T unit
-log_buffer_size=256M
+log_buffer_size=4M
 
 # Size of sort buffer are using K, M, G, T unit
 # The sort buffer should be allocated per thread.
@@ -59,11 +59,11 @@ cubrid_port_id=1523
 
 # The createdb and addvoldb create a volume file of 'db_volume_size' size
 # if don't have any options about size.
-db_volume_size=512M
+db_volume_size=20M
 
 # The createdb creates a log volume file of 'log_volume_size' size
 # if don't have any options about size.
-log_volume_size=512M
+log_volume_size=20M
 
 # The log_max_archives parameter configures the maximum number of archive log files kept.
 # To completely recover the database from the media failures with a backup,


### PR DESCRIPTION
N/A — no JIRA issue. This is a CTP measurement run, not an engine change.

### Purpose

Give the parallel shell suite the environment it was measured under, so a
run of the CTP `feature/ctp-perf` branch can be compared against the
baseline on the same engine.

**Not for merge.** The diff is four values in the shipped `conf/cubrid.conf`.
It exists because `/run shell testtools=<branch>` passes no environment to
CTP: an experiment's environment has to arrive either in this file or in the
testtools branch, and the sizes belong to the engine install.

### Implementation

```
data_buffer_size  512M -> 64M
log_buffer_size   256M -> 4M
db_volume_size    512M -> 20M
log_volume_size   512M -> 20M
```

At the shipped 512 MB a volume, eight slots hold 8 GB of volumes before a
single case writes a row. These four lines are what make many slots fit on
one machine.

How to run it:

```
/run shell testtools=feature/ctp-perf
```

`feature/ctp-perf` is on CUBRID/cubrid-testtools and carries the CTP
createdb template cache, the `cubrid_createdb` exit-status fix, and the
`CTP_ERROR_BACKUP` / `CTP_ERROR_BACKUP_DIR` switches. The template cache
itself stays **opt-in** (`CTP_DB_TEMPLATE_CACHE=1`) and gha-ci sets no
environment, so this run exercises the status fix and the tuned environment,
not the cache.

### Remarks

**These four lines are not verdict-neutral.** A case that never names a size
still takes one — on `createdb`, or on the volumes a load auto-extends into —
and its answer file records what CUBRID ships. 38 cases in the corpus fail
for that reason alone, in two classes:

- **Findable** — the case prints the parameter, so the dump reads
  `db_volume_size=20M (512.0M)` where the answer wants `512.0M (512.0M)`.
- **Not findable** — the case never names a size but depends on the
  behaviour: counting temporary volumes, say, where the count changes when
  the volume size does. No search finds this class; only running the corpus
  at both values and diffing the verdicts does.

The linked **cubrid-testcases-private-ex** draft PR carries one patch per
case for exactly that class — each pinning the shipped value for that case
alone — so that a NOK in this run is the engine and not the conf. Cases
that fail for other environment reasons ($HOME layout, mawk, locale,
`expect` timing) are deliberately **not** patched there: they are a separate
question from these four parameters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
