### PR TITLE
[CBRD-27373] written column names in server-side JDBC (backport to release/11.3)

### DIFF
--- a/src/jsp/com/cubrid/jsp/data/ColumnInfo.java
+++ b/src/jsp/com/cubrid/jsp/data/ColumnInfo.java
@@ -11,6 +11,7 @@ public class ColumnInfo {
     public int prec;
     public byte charset;
     public String colName;
+    public String writtenColName;
     public byte isNotNull;
 
     public byte autoIncrement;
@@ -31,6 +32,7 @@ public class ColumnInfo {
         prec = unpacker.unpackInt();
 
         colName = unpacker.unpackCString();
+        writtenColName = unpacker.unpackCString();
         attrName = unpacker.unpackCString();
         className = unpacker.unpackCString();
         defaultValueString = unpacker.unpackCString();

--- a/src/jsp/com/cubrid/jsp/impl/SUStatement.java
+++ b/src/jsp/com/cubrid/jsp/impl/SUStatement.java
@@ -54,6 +54,7 @@ public class SUStatement {
 
     private List<ColumnInfo> columnInfos = null;
     private HashMap<String, Integer> colNameToIndex = null;
+    private HashMap<String, Integer> writtenColNameToIndex = null;
     private SUBindParameter bindParameter = null;
 
     private byte executeFlag;
@@ -273,14 +274,24 @@ public class SUStatement {
         return colNameToIndex;
     }
 
+    public Map<String, Integer> getWrittenColNameIndex() {
+        return writtenColNameToIndex;
+    }
+
     private void setColumnInfo(List<ColumnInfo> infos) {
         columnInfos = infos;
         columnNumber = columnInfos.size();
         colNameToIndex = new HashMap<String, Integer>(columnNumber);
+        writtenColNameToIndex = new HashMap<String, Integer>(columnNumber);
         for (int i = 0; i < columnInfos.size(); i++) {
             String name = columnInfos.get(i).colName.toLowerCase();
             if (colNameToIndex.containsKey(name) == false) {
                 colNameToIndex.put(name, i);
+            }
+
+            String writtenName = columnInfos.get(i).writtenColName.toLowerCase();
+            if (writtenColNameToIndex.containsKey(writtenName) == false) {
+                writtenColNameToIndex.put(writtenName, i);
             }
         }
     }

--- a/src/jsp/com/cubrid/jsp/jdbc/CUBRIDServerSideResultSet.java
+++ b/src/jsp/com/cubrid/jsp/jdbc/CUBRIDServerSideResultSet.java
@@ -446,35 +446,27 @@ public class CUBRIDServerSideResultSet implements ResultSet {
     @Override
     public int findColumn(String columnName) throws SQLException {
 
-        // NOTE: Suppose that a user wrote T.col as a column in a SELECT statement,
-        // In client-side JDBC, columnName argument must be "col" to find its index.
-        // In server-side JDBC, however, both "T.col" and "col" are allowed.
+        // NOTE: Suppose that a user wrote T.col as a column in a SELECT statement.
+        // The server sends down two names for the column:
+        //   - colName: the alias if an AS clause was given, otherwise the column name with the
+        //     table qualifier stripped off ("col"). This is the standard JDBC name.
+        //   - writtenColName: the name exactly as the user wrote it ("T.col"), which is to keep
+        //     the old behavior that deviates from JDBC standard about column names (CBRD-27242).
+        // We first try an exact match against colName ("col") to honor the JDBC convention, then
+        // fall back to an exact match against writtenColName ("T.col") for backward compatibility.
 
         String colName = columnName.toLowerCase();
-        Map<String, Integer> colNameToIdx = statementHandler.getColNameIndex();
 
-        // first, try exact match
-        Integer index = colNameToIdx.get(colName);
+        // first, try exact match against the (unqualified) column name
+        Integer index = statementHandler.getColNameIndex().get(colName);
         if (index == null) {
+            // second, try exact match against the name as written in the SELECT statement
+            index = statementHandler.getWrittenColNameIndex().get(colName);
+        }
 
-            // second, try postfix match with a dot
-            String dotColName = "." + colName;
-            for (String cn : colNameToIdx.keySet()) {
-                if (cn.endsWith(dotColName)) {
-                    if (index == null) {
-                        index = colNameToIdx.get(cn);
-                    } else {
-                        // we already found one. duplicate
-                        index = null;
-                        break;
-                    }
-                }
-            }
-
-            if (index == null) {
-                throw CUBRIDServerSideJDBCErrorManager.createCUBRIDException(
-                        CUBRIDServerSideJDBCErrorCode.ER_INVALID_COLUMN_NAME, null);
-            }
+        if (index == null) {
+            throw CUBRIDServerSideJDBCErrorManager.createCUBRIDException(
+                    CUBRIDServerSideJDBCErrorCode.ER_INVALID_COLUMN_NAME, null);
         }
 
         return index.intValue() + 1;

--- a/src/method/method_query_handler.cpp
+++ b/src/method/method_query_handler.cpp
@@ -453,7 +453,8 @@ namespace cubmethod
 		  }
 
 		/* first tuple, store attribute info */
-		column_info c_info = set_column_info (db_type, set_type, scale, precision, charset, attr_name, attr_name, class_name,
+		column_info c_info = set_column_info (db_type, set_type, scale, precision, charset, attr_name, attr_name,
+						      attr_name, class_name,
 						      false);
 
 		info.column_infos.push_back (c_info);
@@ -906,7 +907,7 @@ namespace cubmethod
 	  }
 
 	int num_cols = 0;
-	char *col_name = NULL, *class_name = NULL, *attr_name = NULL;
+	char *col_name = NULL, *written_col_name = NULL, *class_name = NULL, *attr_name = NULL;
 
 	char set_type;
 	int precision = 0;
@@ -916,20 +917,17 @@ namespace cubmethod
 	DB_QUERY_TYPE *col;
 	for (col = db_column_info; col != NULL; col = db_query_format_next (col))
 	  {
-#if 0
-	    // TODO: stripped_column_name
-	    if (stripped_column_name)
+	    // col_name is the name used to find a column index in a ResultSet (server-side JDBC findColumn).
+	    // It is the alias if the user wrote an AS clause, otherwise the column name with the table
+	    // qualifier stripped off (e.g. "col" for "T.col"). This matches the standard JDBC convention.
+	    col_name = (char *) db_query_format_name (col);
+
+	    // written_col_name keeps the name exactly as the user wrote it in the SELECT list
+	    // (e.g. "T.col"). It lets findColumn still accept the qualified name for backward compatibility (CBRD-27242).
+	    written_col_name = (char *) db_query_format_original_name (col);
+	    if (written_col_name == NULL || strchr (written_col_name, '*') != NULL)
 	      {
-		col_name = (char *) db_query_format_name (col);
-	      }
-	    else
-#endif
-	      {
-		col_name = (char *) db_query_format_original_name (col);
-		if (strchr (col_name, '*') != NULL)
-		  {
-		    col_name = (char *) db_query_format_name (col);
-		  }
+		written_col_name = col_name;
 	      }
 	    class_name = (char *) db_query_format_class_name (col);
 	    attr_name = (char *) db_query_format_attr_name (col);
@@ -961,7 +959,8 @@ namespace cubmethod
 		m_query_result.null_type_column.push_back (0);
 	      }
 
-	    column_info info = set_column_info ((int) db_type, set_type, scale, precision, charset, col_name, attr_name, class_name,
+	    column_info info = set_column_info ((int) db_type, set_type, scale, precision, charset, col_name, written_col_name,
+						attr_name, class_name,
 						(char) db_query_format_is_non_null (col));
 	    infos.push_back (info);
 	    num_cols++;
@@ -991,7 +990,7 @@ namespace cubmethod
 
   column_info
   query_handler::set_column_info (int dbType, int setType, short scale, int prec, char charset, const char *col_name,
-				  const char *attr_name,
+				  const char *written_col_name, const char *attr_name,
 				  const char *class_name, char is_non_null)
   {
     DB_OBJECT *class_obj = db_find_class (class_name);
@@ -1006,13 +1005,14 @@ namespace cubmethod
     char shared = db_attribute_is_shared (attr);
 
     std::string col_name_string (col_name ? col_name : "");
+    std::string written_col_name_string (written_col_name ? written_col_name : "");
     std::string attr_name_string (attr_name? attr_name : "");
     std::string class_name_string (class_name? class_name : "");
 
     std::string default_value_string = get_column_default_as_string (attr);
 
     column_info info (dbType, setType, scale, prec, charset,
-		      col_name_string, default_value_string,
+		      col_name_string, written_col_name_string, default_value_string,
 		      auto_increment, unique_key, primary_key, reverse_index, reverse_unique, foreign_key, shared,
 		      attr_name_string, class_name_string, is_non_null);
 

--- a/src/method/method_query_handler.hpp
+++ b/src/method/method_query_handler.hpp
@@ -133,7 +133,7 @@ namespace cubmethod
 
       /* column info */
       column_info set_column_info (int dbType, int setType, short scale, int prec, char charset, const char *col_name,
-				   const char *attr_name,
+				   const char *written_col_name, const char *attr_name,
 				   const char *class_name, char is_non_null);
 
       /* session */

--- a/src/method/method_struct_query.cpp
+++ b/src/method/method_struct_query.cpp
@@ -40,9 +40,10 @@ namespace cubmethod
     charset = lang_charset();
     is_non_null = 0;
 
-    /* col_name, attr_name, class_name, default_value leave as empty */
+    /* col_name, written_col_name, attr_name, class_name, default_value leave as empty */
     // FIXME: to remove warning
     col_name.clear ();
+    written_col_name.clear ();
     attr_name.clear ();
     class_name.clear ();
     default_value_string.clear();
@@ -69,6 +70,7 @@ namespace cubmethod
     this->col_name.assign (col_name);
     str_trim (this->col_name);
 
+    written_col_name.clear ();
     attr_name.clear ();
     class_name.clear ();
     default_value_string.clear();
@@ -83,7 +85,8 @@ namespace cubmethod
   }
 
   column_info::column_info (int db_type, int set_type, short scale, int prec, char charset,
-			    std::string col_name, std::string default_value, char auto_increment,
+			    std::string col_name, std::string written_col_name, std::string default_value,
+			    char auto_increment,
 			    char unique_key, char primary_key, char reverse_index, char reverse_unique,
 			    char foreign_key, char shared, std::string attr_name, std::string class_name,
 			    char is_non_null)
@@ -97,6 +100,9 @@ namespace cubmethod
 
     this->col_name.assign (col_name);
     str_trim (this->col_name);
+
+    this->written_col_name.assign (written_col_name);
+    str_trim (this->written_col_name);
 
     this->attr_name.assign (attr_name);
     this->class_name.assign (class_name);
@@ -130,6 +136,7 @@ namespace cubmethod
     serializator.pack_short (scale);
     serializator.pack_int (prec);
     serializator.pack_string (col_name);
+    serializator.pack_string (written_col_name);
     serializator.pack_string (attr_name);
     serializator.pack_string (class_name);
     serializator.pack_string (default_value_string);
@@ -156,6 +163,7 @@ namespace cubmethod
     deserializator.unpack_int (p);
 
     deserializator.unpack_string (col_name);
+    deserializator.unpack_string (written_col_name);
     deserializator.unpack_string (attr_name);
     deserializator.unpack_string (class_name);
     deserializator.unpack_string (default_value_string);
@@ -195,6 +203,7 @@ namespace cubmethod
     size += serializator.get_packed_int_size (size); // prec
 
     size += serializator.get_packed_string_size (col_name, size); // col_name
+    size += serializator.get_packed_string_size (written_col_name, size); // written_col_name
     size += serializator.get_packed_string_size (attr_name, size); // attr_name
     size += serializator.get_packed_string_size (class_name, size); // class_name
     size += serializator.get_packed_string_size (default_value_string, size); // default_value_string
@@ -216,6 +225,7 @@ namespace cubmethod
     fprintf (stdout, "class_name: %s\n", class_name.c_str());
     fprintf (stdout, "attr_name: %s\n", attr_name.c_str());
     fprintf (stdout, "col_name: %s\n", col_name.c_str());
+    fprintf (stdout, "written_col_name: %s\n", written_col_name.c_str());
     fprintf (stdout, "default_value_string: %s\n", default_value_string.c_str());
 
     fprintf (stdout, "scale: %d\n", scale);

--- a/src/method/method_struct_query.hpp
+++ b/src/method/method_struct_query.hpp
@@ -41,7 +41,7 @@ namespace cubmethod
     column_info (int db_type, int set_type, short scale, int prec, char charset,
 		 std::string col_name);
     column_info (int db_type, int set_type, short scale, int prec, char charset,
-		 std::string col_name, std::string default_value, char auto_increment,
+		 std::string col_name, std::string written_col_name, std::string default_value, char auto_increment,
 		 char unique_key, char primary_key, char reverse_index, char reverse_unique,
 		 char foreign_key, char shared, std::string attr_name, std::string class_name,
 		 char nullable);
@@ -56,6 +56,7 @@ namespace cubmethod
     int prec;
     char charset;
     std::string col_name;
+    std::string written_col_name; /* column name as written by the user in the SELECT list (e.g. "T.col") */
     char is_non_null;
 
     char auto_increment;


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27373>

### Purpose

backport of #7863

SP에서 실행하는 SELECT 문 결과의 메타데이터에서 컬럼 이름을 JDBC 규약에 맞춘다. (사용자가 t.col 형태로 썼어도 col 을 리턴한다)
예전 동작과의 compatibility 를 위해서 사용자가 써준 t.col 도 함께 리턴해서 findColumn() API 구현에서 참고한다.

