### PR TITLE
[CBRD-27405] saving JVM memory consumption occurred by SP compilation (backport of #7911)

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/compiler/MemoryJavaCompiler.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/compiler/MemoryJavaCompiler.java
@@ -36,6 +36,7 @@ import com.cubrid.jsp.code.CompiledCodeSet;
 import com.cubrid.jsp.code.SourceCode;
 import com.cubrid.jsp.context.Context;
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -65,6 +66,14 @@ public class MemoryJavaCompiler {
 
         useOptions("-encoding", Context.getSessionCharset().toString());
         useOptions("-classpath", PL_SERVER_PATH);
+
+        // Use a per-compilation (unshared) javac name table so its name entries are
+        // reclaimed by GC after each compile, instead of accumulating in javac's
+        // process-wide SharedNameTable. Without this, every stored-procedure compile
+        // leaves behind a full name table (SharedNameTable$NameImpl[] + thousands of
+        // interned NameImpl), which exhausts the PL server heap over a long-running
+        // server (observed OOM: GC overhead limit exceeded).
+        useOptions("-XDuseUnsharedTable=true");
     }
 
     public synchronized void useOptions(String... options) {
@@ -75,35 +84,47 @@ public class MemoryJavaCompiler {
         DiagnosticCollector<JavaFileObject> collector = new DiagnosticCollector<>();
         MemoryFileManager fileManager =
                 new MemoryFileManager(compiler.getStandardFileManager(null, null, null));
-        JavaCompiler.CompilationTask task =
-                compiler.getTask(null, fileManager, collector, options, null, Arrays.asList(code));
+        try {
+            JavaCompiler.CompilationTask task =
+                    compiler.getTask(
+                            null, fileManager, collector, options, null, Arrays.asList(code));
 
-        boolean result = task.call();
-        if (!result || collector.getDiagnostics().size() > 0) {
-            String exceptionMsg = new String("Unable to compile the source");
-            boolean hasErrors = false;
+            boolean result = task.call();
+            if (!result || collector.getDiagnostics().size() > 0) {
+                String exceptionMsg = new String("Unable to compile the source");
+                boolean hasErrors = false;
 
-            for (Diagnostic<? extends JavaFileObject> d : collector.getDiagnostics()) {
-                switch (d.getKind()) {
-                    case NOTE:
-                    case MANDATORY_WARNING:
-                    case WARNING:
-                        break;
-                    case OTHER:
-                    case ERROR:
-                    default:
-                        hasErrors = true;
-                        break;
+                for (Diagnostic<? extends JavaFileObject> d : collector.getDiagnostics()) {
+                    switch (d.getKind()) {
+                        case NOTE:
+                        case MANDATORY_WARNING:
+                        case WARNING:
+                            break;
+                        case OTHER:
+                        case ERROR:
+                        default:
+                            hasErrors = true;
+                            break;
+                    }
+                }
+
+                if (hasErrors) {
+                    throw new RuntimeException(exceptionMsg.toString());
                 }
             }
 
-            if (hasErrors) {
-                throw new RuntimeException(exceptionMsg.toString());
+            assert (code.getClassName() != null);
+
+            return new CompiledCodeSet(code.getClassName(), fileManager.getCodeList());
+        } finally {
+
+            // Release the javac file manager and its compilation resources (name
+            // tables, ZipFileIndex caches) so they are not retained across compiles.
+            try {
+                fileManager.close();
+            } catch (IOException e) {
+                Server.log(e);
             }
         }
-
-        assert (code.getClassName() != null);
-
-        return new CompiledCodeSet(code.getClassName(), fileManager.getCodeList());
     }
 }


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27405>

### Purpose

(backport of #7911)

PL/CSQL SP 컴파일 건마다 누적되는 메모리 증가를 없애기 위해 -XDuseUnsharedTable=true 라는 javac 옵션을 사용.
OutOfMemoryError 을 일으켜 PL 서버를 crash 하게 만드는 주원인 제거.

추가로, MemoryJavaCompiler 에게 제공되는 file manager 의 사용 후 close() 문이 누락되어 추가한다.
